### PR TITLE
[WIP] Configurable .Values.frontEnd.OIDC_PROVIDER

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Amundsen charts and
 | frontEnd.OIDC_CLIENT_ID | string | `nil` | The client id for OIDC. |
 | frontEnd.OIDC_CLIENT_SECRET | string | `""` | The client secret for OIDC. |
 | frontEnd.OIDC_ORG_URL | string | `nil` | The organization URL for OIDC. |
+| frontEnd.OIDC_OVERWRITE_REDIRECT_URI | string | `nil` | The redirect URI/reply URL for OIDC. |
 | frontEnd.affinity | object | `{}` | Frontend pod specific affinity. |
 | frontEnd.createOidcSecret | bool | `false` | OIDC needs some configuration. If you want the chart to make your secrets, set this to true and set the next four values. If you don't want to configure your secrets via helm, you can still use the amundsen-oidc-config.yaml as a template |
 | frontEnd.imageVersion | string | `"2.0.0"` | The frontend version of the metadata container. |

--- a/amundsen-kube-helm/templates/helm/templates/amundsen-deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/amundsen-deployment.yaml
@@ -149,6 +149,10 @@ spec:
           - name: FRONTEND_BASE
             value: http://{{ .Values.frontEnd.FRONTEND_BASE }}
           {{ end }}
+          {{- if .Values.frontEnd.OIDC_OVERWRITE_REDIRECT_URI }}
+          - name: FLASK_OIDC_REDIRECT_OVERRIDE
+            value: {{ .Values.frontEnd.OIDC_OVERWRITE_REDIRECT_URI }}
+          {{- end }}
           - name: SEARCHSERVICE_BASE
             value: http://{{ .Chart.Name }}-{{ .Values.search.serviceName }}:5001
           - name: METADATASERVICE_BASE

--- a/amundsen-kube-helm/templates/helm/templates/amundsen-oidc-config.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/amundsen-oidc-config.yaml
@@ -31,7 +31,7 @@ stringData:
         "userinfo_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}/v1/userinfo",
         {{- end }}
         "redirect_uris": [
-          "http://localhost/oidc_callback"
+          "{{ .Values.frontEnd.OIDC_OVERWRITE_REDIRECT_URI }}"
         ],
         {{- if (eq .Values.frontEnd.OIDC_PROVIDER "azure") or (eq .Values.frontEnd.OIDC_PROVIDER "google") }}
         "token_introspection_uri": ""

--- a/amundsen-kube-helm/templates/helm/templates/amundsen-oidc-config.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/amundsen-oidc-config.yaml
@@ -11,14 +11,33 @@ stringData:
       "web": {
         "client_id": "{{ .Values.frontEnd.OIDC_CLIENT_ID }}",
         "client_secret": "{{ .Values.frontEnd.OIDC_CLIENT_SECRET }}",
+
+        {{- if eq .Values.frontEnd.OIDC_PROVIDER "azure" }}
+        "auth_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/v2.0/authorize",
+        "token_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/v2.0/token",
+        "issuer": "{{ .Values.frontEnd.OIDC_ORG_URL }}/v2.0",
+        "userinfo_uri": "https://graph.microsoft.com/oidc/userinfo",
+
+        {{- else if eq .Values.frontEnd.OIDC_PROVIDER "google" }}
+        "auth_uri": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "issuer": "https://accounts.google.com",
+        "userinfo_uri": "https://openidconnect.googleapis.com/v1/userinfo",
+
+        {{- else }}
         "auth_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}/v1/authorize",
         "token_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}/v1/token",
         "issuer": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}",
         "userinfo_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}/v1/userinfo",
+        {{- end }}
         "redirect_uris": [
           "http://localhost/oidc_callback"
         ],
+        {{- if (eq .Values.frontEnd.OIDC_PROVIDER "azure") or (eq .Values.frontEnd.OIDC_PROVIDER "google") }}
+        "token_introspection_uri": ""
+        {{- else }}        
         "token_introspection_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}/v1/introspect"
+        {{- end }}
       }
     }
 {{- end }}

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -175,6 +175,10 @@ frontEnd:
   ## frontEnd.OIDC_AUTH_SERVER_ID -- The authorization server id for OIDC.
   ##
   OIDC_AUTH_SERVER_ID:
+  ##
+  ## frontEnd.OIDC_OVERWRITE_REDIRECT_URI -- The redirect URI/reply URL for OIDC.
+  ##
+  OIDC_OVERWRITE_REDIRECT_URI:
 
   ##
   ## frontEnd.resources -- See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)


### PR DESCRIPTION
### Summary of Changes

Adds use of a new `.Values.frontEnd.OIDC_PROVIDER`.

If the value is not set or set to something different than "azure" or "google" it should behave as before. (I could need help with testing that)

Note setting to either "azure" or "google" essentially skips token validation by setting `"token_introspection_uri": ""` (to a blank string).

⚠️ of course it shouldn't be taken lightheartedly to skip id token validation (through a _remote_ endpoint, which neither Google, nor Azure AD appears to offer), which is _exactly_ why for those providers we _NEED_ to pair with `offline` validation instead - as can be added through the other WIP PR lyft/amundsenfrontendlibrary#421 (hope that made sense?)

### Documentation

**TODO** - needs addition in the values file and in README.md

In addition https://github.com/lyft/amundsen/blob/master/docs/authentication/oidc.md#using-okta-with-amundsen-on-k8s should be adjusted/generalized a bit

<!-- _What documentation did you add or modify and why? Add any relevant links then optionally, remove this line_ -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely.
- [ ] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
