### PR TITLE
fix: Docker Compose Elastic Search volume configuration, resolve permission denied issue

### DIFF
--- a/docker-amundsen.yml
+++ b/docker-amundsen.yml
@@ -25,8 +25,8 @@ services:
           - 9200:9200
 # TODO - tried mounting ES data outside the volume.
 # Not confident I did it right, I saw it acting up on restarts, plz halp!
-#      volumes:
-#          - ./example/docker/es_data:/usr/share/elasticsearch/data
+      volumes:
+          - ./example/docker/es_data:/usr/share/elasticsearch/data
       networks:
         - amundsennet
       ulimits:

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -40,6 +40,7 @@ $ git submodule update --remote
 
 2. Launch the containers needed for local development (the `-d` option launches in background) :
     ```bash
+    $ mkdir -p .local/elasticsearch/data # create the necessary folder for Elastic Search to avoid permission issue
     $ docker-compose -f docker-amundsen-local.yml up -d
     ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,7 @@ The following instructions are for setting up a version of Amundsen using Docker
 3. Enter the cloned directory and run:
     ```bash
     # For Neo4j Backend
+    $ mkdir -p  example/docker/es_data  # this is to create the necessary volume folder with permission for Elastic Search
     $ docker-compose -f docker-amundsen.yml up
 
     # For Atlas


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes
Currently `.local` and `example` folders are ignored by `.gitignore`. When `docker-compose` starts, it create these folders with root permission. Elastic Search will throw a `Caused by: java.nio.file.AccessDeniedException: /usr/share/elasticsearch/data/nodes` issue. 
<!-- Include a summary of changes -->

### Documentation
[Installation Doc](docs/installation.md) and [Developer Docs](docs/developer.md)
<!-- What documentation did you add or modify and why? Add any relevant links -->

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
