### PR TITLE
other: Add persistent volumes for docker-compose images

### DIFF
--- a/docker-amundsen.yml
+++ b/docker-amundsen.yml
@@ -16,6 +16,7 @@ services:
           - ./example/docker/neo4j/conf:/conf
           - ./example/docker/neo4j/plugins:/plugins
           - ./example/backup:/backup
+          - neo4j_data:/neo4j/data
       networks:
         - amundsennet
   elasticsearch:
@@ -23,10 +24,8 @@ services:
       container_name: es_amundsen
       ports:
           - 9200:9200
-# TODO - tried mounting ES data outside the volume.
-# Not confident I did it right, I saw it acting up on restarts, plz halp!
-#      volumes:
-#          - ./example/docker/es_data:/usr/share/elasticsearch/data
+      volumes:
+        - es_data:/usr/share/elasticsearch/data
       networks:
         - amundsennet
       ulimits:
@@ -79,3 +78,7 @@ services:
 
 networks:
   amundsennet:
+
+volumes:
+  es_data:
+  neo4j_data:


### PR DESCRIPTION
### Summary of Changes

This PR includes two changes:
1. Adds persistent Docker volumes for Neo4J and Elasticsearch so data in both services is preserved across restarts.
1. Renames the default compose file from `docker-amundsen.yml` to `docker-compose.yml`. This simplifies the commands used to run the default docker compose setup, since compose will automatically use an available `docker-compose.yml` file.

I sequestered both changes into separate commits, so if it's preferred to keep `docker-amundsen.yml` over `docker-compose.yml` I can jettison the second commit and we can retain the mounted volume changes in this PR.

I've also tested this locally to make sure that changes persist 😄 

### Documentation

Updated all references to `docker-amundsen.yml` to `docker-compose.yml` and simplified commands where possible.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely, including a title prefix.
- [X] PR includes a summary of changes.
- [X] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
