### PR TITLE
fix: Update helm Neo4j deployment

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/configmap-neo4j.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/configmap-neo4j.yaml
@@ -12,13 +12,14 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   neo4j.conf: |-
+    apoc.export.file.enabled=true
     apoc.import.file.enabled=true
     cypher.forbid_shortestpath_common_nodes=false
     dbms.connector.bolt.enabled=true
+    dbms.connector.bolt.listen_address=:7687
+    dbms.connector.bolt.tls_level=OPTIONAL
     dbms.connector.http.enabled=true
     dbms.connector.https.enabled=true
-    dbms.shell.enabled=true
-    dbms.shell.host=0.0.0.0
     dbms.connectors.default_listen_address=0.0.0.0
     dbms.directories.import=/mnt
     dbms.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
@@ -33,8 +34,9 @@ data:
     dbms.memory.heap.max_size={{ .Values.neo4j.config.dbms.heap_max_size }}
     dbms.memory.pagecache.size={{ .Values.neo4j.config.dbms.pagecache_size }}
     dbms.security.allow_csv_import_from_file_urls=true
+    dbms.security.auth_enabled=false
     dbms.security.procedures.unrestricted=algo.*,apoc.*
+    dbms.shell.enabled=true
+    dbms.shell.host=0.0.0.0
     dbms.windows_service_name=neo4j
-    apoc.export.file.enabled=true
-    apoc.import.file.enabled=true
 {{ end }}

--- a/amundsen-kube-helm/templates/helm/templates/deployment-neo4j.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-neo4j.yaml
@@ -92,7 +92,5 @@ spec:
             claimName: neo4j-pvc
         {{- end}}
         - name: plugins
-          hostPath:
-            path: "/mnt/ephemeral/neo4j/plugins"
-            type: DirectoryOrCreate
+          emptyDir: {}
 {{ end }}


### PR DESCRIPTION
### Summary of Changes

Use [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) for Neo4j deployment plugin volumes instead of [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).
With this change we get rid of the dependency on hostPath and thus the dependency on the hosts filesystem and pods permissions to the hostPath.

The custom Neo4j deployment can now also run on GKE (and other k8s clusters).

I also sorted the config options for for Neo4j and disabled auth. The disabling of Neo4j auth seems to be a consistent setting through this repo (docker examples, and ECS examples).
