### PR TITLE
chore: Add compat with flask-oidc v0.1.x in amundsenfrontendlibrary

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/deployment-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-frontend.yaml
@@ -64,26 +64,41 @@ spec:
           - name: FRONTEND_SVC_CONFIG_MODULE_CLASS
             value: amundsen_application.oidc_config.OidcConfig
           - name: FLASK_OIDC_WHITELISTED_ENDPOINTS
-            value: status,healthcheck,health
-          - name: FLASK_OIDC_SQLALCHEMY_DATABASE_URI
+            value: status,healthcheck,health,logout
+          - name: SQLALCHEMY_DATABASE_URI
             value: sqlite:///sessions.db
           - name: APP_WRAPPER
             value: flaskoidc
           - name: APP_WRAPPER_CLASS
             value: FlaskOIDC
-          - name: FLASK_OIDC_CLIENT_SECRETS
+          - name: OIDC_CLIENT_SECRETS
             value: /etc/client_secrets.json
-          - name: FLASK_OIDC_SECRET_KEY
+          {{- if .Values.frontEnd.OVERWRITE_REDIRECT_URI }}
+          - name: OVERWRITE_REDIRECT_URI
+            value: {{ .Values.frontEnd.OVERWRITE_REDIRECT_URI }}
+          {{- end }}
+          - name: OIDC_SECRET_KEY
             valueFrom:
               secretKeyRef:
                 name: oidc-config
                 key: OIDC_CLIENT_SECRET
         {{- end }}
+        command: ["gunicorn"]
+        args: ['-w', '4', '--bind', ':5000', 'amundsen_application.wsgi']
+        readinessProbe:
+          httpGet:
+            path: "/healthcheck"
+            port: 5000
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             path: "/healthcheck"
             port: 5000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 10
           periodSeconds: 60
           timeoutSeconds: 1
           successThreshold: 1

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -68,7 +68,7 @@ search:
   ##
   ## search.imageTag -- The image tag of the search container.
   ##
-  imageTag: 2.0.0
+  imageTag: 2.4.0
   ##
   ## search.replicas -- How many replicas of the search service to run.
   ##
@@ -128,7 +128,7 @@ metadata:
   ##
   ## metadata.imageTag -- The image tag of the metadata container.
   ##
-  imageTag: 2.0.0
+  imageTag: 2.5.5
   ##
   ## metadata.replicas -- How many replicas of the metadata service to run.
   ##
@@ -184,7 +184,7 @@ frontEnd:
   ##
   ## frontEnd.imageTag -- The image tag of the frontend container.
   ##
-  imageTag: 2.0.0
+  imageTag: 2.3.0
   ##
   ## frontEnd.servicePort -- The port the frontend service will be exposed on via the loadbalancer.
   ##
@@ -222,6 +222,10 @@ frontEnd:
   ## frontEnd.OIDC_AUTH_SERVER_ID -- The authorization server id for OIDC.
   ##
   OIDC_AUTH_SERVER_ID:
+  ##
+  ## frontEnd.OVERWRITE_REDIRECT_URI -- The redirect uri for OIDC.
+  ##
+  OVERWRITE_REDIRECT_URI:
 
   ##
   ## frontEnd.resources -- See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)

--- a/docs/authentication/oidc.md
+++ b/docs/authentication/oidc.md
@@ -154,7 +154,7 @@ ENV FRONTEND_SVC_CONFIG_MODULE_CLASS amundsen_application.oidc_config.OidcConfig
 ENV APP_WRAPPER flaskoidc
 ENV APP_WRAPPER_CLASS FlaskOIDC
 ENV FLASK_OIDC_WHITELISTED_ENDPOINTS status,healthcheck,health
-ENV FLASK_OIDC_SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
+ENV SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
 ```
 
 


### PR DESCRIPTION
Updated helm chart to be compatible with @verdan's recent updates to flask-oidc.

Also bumped dockerimage tags to latest versions.