### PR TITLE
chore: Helm will keep persistent volume claims on delete

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/pvc-neo4j.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/pvc-neo4j.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: neo4j-pvc
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: "keep"
   labels:
     app: {{ template "amundsen.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
I suggest that helm delete should persist neo4j pvc's. Those should be deleted manually afterward to prevent dataloss.