### PR TITLE
fix: update chart location

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -23,7 +23,7 @@ This is setup templates for deploying [amundsen](https://github.com/amundsen-io/
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://kubernetes-charts.storage.googleapis.com/ | elasticsearch | 1.32.0 |
+| https://charts.helm.sh/stable | elasticsearch | 1.32.0 |
 
 ## Chart Values
 

--- a/amundsen-kube-helm/templates/helm/requirements.yaml
+++ b/amundsen-kube-helm/templates/helm/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
 #  - name: neo4j
 #    version: 1.2.2
-#    repository: https://kubernetes-charts.storage.googleapis.com/
+#    repository: https://charts.helm.sh/stable/
   - name: elasticsearch
     version: 1.32.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: elasticsearch.enabled


### PR DESCRIPTION
### Summary of Changes

Update chart location, the old one stopped working, every time I do something like `helm dep update` it returns `failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden`

The old location was moved to https://charts.helm.sh/stable as explained here https://helm.sh/blog/new-location-stable-incubator-charts/


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
