### PR TITLE
docs: Add Troubleshooting Information for Docker error 137

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,3 +76,6 @@ Atlas would be ready once you'll have the following output in the docker output 
      hard: 65535
  ```
    Then check if all 5 Amundsen related containers are running with `docker ps`? Can you connect to the Neo4j UI at http://localhost:7474/browser/ and similarly the raw ES API at http://localhost:9200? Does Docker logs reveal any serious issues?
+
+5. If ES container crashed with Docker error 137 on the first call from the website (http://localhost:5000/), this is because you are using the default Docker engine memory allocation of 2GB. The minimum needed for all the containers to run with the loaded sample data is 3GB. To do this go to your `Docker -> Preferences -> Resources -> Advanced` and increase the `Memory`, then restart the Docker engine.
+


### PR DESCRIPTION
### Summary of Changes

After Docker-compose run, when ES was called the first time, the container crashed with Docker error 137 Out Of Memory. Add a troubleshooting guide on how to add memory to the Docker engine.

### Documentation

This PR is for documentation.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
