### PR TITLE
fix:Expose elastic search credentials in helm deploy

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
@@ -47,6 +47,10 @@ spec:
         env:
         - name: PROXY_ENDPOINT
           value: {{ if .Values.search.elasticsearchEndpoint }}{{ .Values.search.elasticsearchEndpoint }}{{ else }}{{ .Release.Name }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
+        - name: CREDENTIALS_PROXY_USER
+          value: {{ .Values.search.elasticSearchUser }}
+        - name: CREDENTIALS_PROXY_PASSWORD
+          value: {{ .Values.search.elasticSearchPassword }}
         livenessProbe:
           httpGet:
             path: "/healthcheck"

--- a/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-search.yaml
@@ -47,10 +47,12 @@ spec:
         env:
         - name: PROXY_ENDPOINT
           value: {{ if .Values.search.elasticsearchEndpoint }}{{ .Values.search.elasticsearchEndpoint }}{{ else }}{{ .Release.Name }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
+        {{- if and .Values.search.elasticSearchCredentials (not .Values.elasticsearch.enabled) }}
         - name: CREDENTIALS_PROXY_USER
-          value: {{ .Values.search.elasticSearchUser }}
+          value: {{ .Values.search.elasticSearchCredentials.user }}
         - name: CREDENTIALS_PROXY_PASSWORD
-          value: {{ .Values.search.elasticSearchPassword }}
+          value: {{ .Values.search.elasticSearchCredentials.password }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: "/healthcheck"

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -62,13 +62,12 @@ search:
   ##
   elasticsearchEndpoint:
   ##
-  ## search.elasticSearchUser -- The elasticsearch user
+  ## search.elasticSearchCredentials -- The elasticsearch user and password. This should only be set if you bring your own elasticsearch cluster in which case you must also set elasticsearch.enabled to false
   ##
-  credentialsProxyUser:
+  elasticSearchCredentials: {}
+  #  user:
+  #  password:
   ##
-  ## search.elasticSearchPassword -- The elasticsearch password
-  ##
-  elasticSearchPassword:
   ##
   ## search.image -- The image of the search container.
   ##

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -62,6 +62,16 @@ search:
   ##
   elasticsearchEndpoint:
   ##
+  ## search.elasticSearchUser -- The elasticsearch user
+  ##
+  credentialsProxyUser:
+  ##
+  ## search.elasticSearchPassword -- The elasticsearch password
+  ##
+  elasticSearchPassword:
+  ##
+  ## search.image -- The image of the search container.
+  ##
   ## search.image -- The image of the search container.
   ##
   image: amundsendev/amundsen-search


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->
Adds the ability to specify a user and password for elasticsearch when you bring your own cluster. I added this because I am using a hosted elasticsearch on AWS and I need to set my user and password to the empty string (`''`).

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links -->
Added some description in the values.yaml file.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
