### PR TITLE
fix: Specify storageClassName for neo4j persistent volume

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/pv-neo4j.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/pv-neo4j.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: "{{ default "" .Values.neo4j.persistence.storageClass }}"
   capacity:
     storage: {{ default "3Gi" .Values.neo4j.persistence.size }}
   nfs:

--- a/amundsen-kube-helm/templates/helm/templates/pvc-neo4j.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/pvc-neo4j.yaml
@@ -15,6 +15,7 @@ spec:
   accessModes:
     - {{ default "ReadWriteOnce" .Values.neo4j.persistence.accessMode }}
   storageClassName: "{{ default "" .Values.neo4j.persistence.storageClass }}"
+  volumeName: neo4j-pv
   resources:
     requests:
       storage: {{ default "3Gi" .Values.neo4j.persistence.size }}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->
I am using an EFS from AWS on EKS for the neo4j deployment and the volume claim fails to bind to the volume because the storage-class is not specified in the pv-neo4j.yaml template. Adding it in fixed the issue for me.

I also added a reference to the volumeName in pvc-neo4j.yaml. I believe this will make sure that the volume claim uses the neo4j volume that is being created with this helm deployment. 

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links -->
No documentation
### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
