### PR TITLE
docs:neo4j.serviceType is not documented

### DIFF
--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -232,6 +232,9 @@ neo4j:
       # neo4j.config.dbms.pagecache_size -- the page cache size for neo4j
       pagecache_size: 2G
 
+  # neo4j.serviceType -- The neo4j service type. See service types [ref](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+  serviceType: ClusterIP
+
   # neo4j.persistence -- Neo4j persistence. Turn this on to keep your data between pod crashes, etc. This is also needed for backups.
   persistence: {}
   #  storageClass: gp2


### PR DESCRIPTION
Signed-off-by: benrifkind <ben.rifkind@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->
The neo4j.serviceType is not documented in values.yaml so I added it. Here's where it is used: https://github.com/amundsen-io/amundsen/blob/master/amundsen-kube-helm/templates/helm/templates/service-neo4j.yaml#L18. I think it defaults to ClusterIP if not set but nice to have it documented.

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links -->


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
