### PR TITLE
docs: fixes the "Edit this page" for symbolic links

### DIFF
--- a/docs_overrides/main.html
+++ b/docs_overrides/main.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% if page.edit_url %}
+  <a href="{{ page.edit_url
+    | replace('/amundsen/edit/master/docs/metadata/docs/','/amundsenmetadatalibrary/edit/master/docs/')
+    | replace('/amundsen/edit/master/docs/common/docs/','/amundsencommon/edit/master/docs/')
+    | replace('/amundsen/edit/master/docs/databuilder/docs/','/amundsendatabuilder/edit/master/docs/')
+    | replace('/amundsen/edit/master/docs/frontend/docs/','/amundsenfrontendlibrary/edit/master/docs/')
+    | replace('/amundsen/edit/master/docs/search/docs/','/amundsensearchlibrary/edit/master/docs/')
+    | replace('/amundsen/edit/master/docs/metadata/docs/','/amundsenmetadatalibrary/edit/master/docs/')
+    | replace('/amundsen/edit/master/docs/CONTRIBUTING.md','/amundsen/edit/master/CONTRIBUTING.md')
+    | replace('/amundsen/edit/master/docs/LICENSE','/amundsen/edit/master/LICENSE')
+    | replace('/amundsen/edit/master/docs/index.md','/amundsen/edit/master/README.md')
+    | replace('/amundsen/edit/master/docs/k8s_install.md','/amundsen/edit/master/amundsen-kube-helm/README.md')
+     }}" title="{{ lang.t('edit.link.title') }}" class="md-content__button md-icon">
+    {% include ".icons/material/pencil.svg" %}
+  </a>
+{% endif %}
+{% if not "\x3ch1" in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+{{ page.content }}
+{% if page and page.meta %}
+  {% if page.meta.git_revision_date_localized or
+        page.meta.revision_date
+  %}
+    {% include "partials/source-date.html" %}
+  {% endif %}
+{% endif %}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
     accent: '#2B1B81'
   feature:
     tabs: true
+  custom_dir: docs_overrides/
 
 -extra_css:
   - 'css/app.css'


### PR DESCRIPTION
### Summary of Changes

This PR fixes the "Edit this page" for symbolic links (submodules and linked readme files) by overriding part of the template. The solution is slightly ad-hoc (hardcoded replacements), however resolves the issue. This could be improved by writing a [custom filter](https://jinja.palletsprojects.com/en/2.11.x/api/#writing-filters) that dynamically finds symbolic links.

### Example

https://www.amundsen.io/amundsen/metadata/docs/proxy/atlas_proxy/
<img width="400" src="https://user-images.githubusercontent.com/9756388/114410803-f1994a00-9bab-11eb-80c8-171720ef96f8.png">

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely, including a title prefix.
- [X] PR includes a summary of changes.
- [X] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
