### PR TITLE
fix: Update proxy settings for atlas in docker-compose

### DIFF
--- a/docker-amundsen-atlas.yml
+++ b/docker-amundsen-atlas.yml
@@ -37,8 +37,9 @@ services:
     environment:
       - CREDENTIALS_PROXY_USER=admin
       - CREDENTIALS_PROXY_PASSWORD=admin
-      - PROXY_HOST=http://atlas
+      - PROXY_HOST=atlas
       - PROXY_PORT=21000
+      - PROXY_ENCRYPTED=False
       - PROXY_CLIENT=ATLAS
   amundsenfrontend:
     build:


### PR DESCRIPTION
### Summary of Changes

Update proxy settings for atlas in docker-compose, I removed http:// from the host and added an environment variable that disables encrypted traffic ([as suggested](https://github.com/amundsen-io/amundsen/issues/590#issuecomment-667322796) by @verdan).

### Documentation

Current settings are contacting non-existent URL, fix will ensure that the docker-compose for Atlas works again.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
