### PR TITLE
fix: override content block in docs for `mkdocs-material==4.6.3`

### DIFF
--- a/docs_overrides/main.html
+++ b/docs_overrides/main.html
@@ -13,19 +13,58 @@
     | replace('/amundsen/edit/master/docs/LICENSE','/amundsen/edit/master/LICENSE')
     | replace('/amundsen/edit/master/docs/index.md','/amundsen/edit/master/README.md')
     | replace('/amundsen/edit/master/docs/k8s_install.md','/amundsen/edit/master/amundsen-kube-helm/README.md')
-     }}" title="{{ lang.t('edit.link.title') }}" class="md-content__button md-icon">
-    {% include ".icons/material/pencil.svg" %}
+     }}" title="{{ lang.t('edit.link.title') }}" class="md-icon md-content__icon">
+    &#xE3C9;<!-- edit -->
   </a>
 {% endif %}
+<!--
+  Hack: check whether the content contains a h1 headline. If it
+  doesn't, the page title (or respectively site name) is used
+  as the main headline.
+-->
 {% if not "\x3ch1" in page.content %}
-  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+  <h1>{{ page.title | default(config.site_name, true)}}</h1>
 {% endif %}
+
+<!-- Content -->
 {{ page.content }}
-{% if page and page.meta %}
-  {% if page.meta.git_revision_date_localized or
-        page.meta.revision_date
-  %}
-    {% include "partials/source-date.html" %}
+
+<!-- Source files -->
+{% block source %}
+  {% if page and page.meta and page.meta.source %}
+    <h2 id="__source">{{ lang.t("meta.source") }}</h2>
+    {% set repo = config.repo_url %}
+    {% if repo | last == "/" %}
+      {% set repo = repo[:-1] %}
+    {% endif %}
+    {% set path = page.meta.path | default([""]) %}
+    {% set file = page.meta.source %}
+    <a href="{{ [repo, path, file] | join('/') }}"
+        title="{{ file }}" class="md-source-file">
+      {{ file }}
+    </a>
   {% endif %}
+{% endblock %}
+
+<!-- Support for mkdocs-git-revision-date-localized-plugin -->
+{% if page and page.meta and (
+      page.meta.git_revision_date_localized or
+      page.meta.revision_date
+) %}
+  {% set label = lang.t("source.revision.date") %}
+  <hr />
+  <div class="md-source-date">
+    <small>
+
+      <!-- mkdocs-git-revision-date-localized-plugin -->
+      {% if page.meta.git_revision_date_localized %}
+        {{ label }}: {{ page.meta.git_revision_date_localized }}
+
+      <!-- mkdocs-git-revision-date-plugin -->
+      {% elif page.meta.revision_date %}
+        {{ label }}: {{ page.meta.revision_date }}
+      {% endif %}
+    </small>
+  </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Summary of Changes

Fixes CI in https://github.com/amundsen-io/amundsen/runs/2366741094. 
Docs update in #989 was designed for the latest version of mkdocs-material (7.1.1), while amundsen uses 4.6.3.
This PR uses the code specific to the 4.6.3 version.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely, including a title prefix.
- [X] PR includes a summary of changes.
- [X] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
