### PR TITLE
ci: fix metadata ci config

### DIFF
--- a/.github/workflows/metadata_pull_request.yml
+++ b/.github/workflows/metadata_pull_request.yml
@@ -24,4 +24,5 @@ jobs:
         working-directory: ./metadata
       - name: Codecov
         uses: codecov/codecov-action@v1
-        working-directory: ./metadata
+        with:
+          directory: ./metadata


### PR DESCRIPTION
### Summary of Changes

`working-directory` isn't valid for non-shell actions, so this was a copy-paste error