### PR TITLE
fix: Database filter to return string, not object

### DIFF
--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -68,7 +68,7 @@ export const mapDispatchToProps = (dispatch: any) =>
       searchDatabase: (databaseText: string) =>
         updateSearchState({
           filters: {
-            [ResourceType.table]: { database: databaseText }
+            [ResourceType.table]: { database: databaseText },
           },
           submitSearch: true,
         }),

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.tsx
@@ -68,7 +68,7 @@ export const mapDispatchToProps = (dispatch: any) =>
       searchDatabase: (databaseText: string) =>
         updateSearchState({
           filters: {
-            [ResourceType.table]: { database: { [databaseText]: true } },
+            [ResourceType.table]: { database: databaseText }
           },
           submitSearch: true,
         }),


### PR DESCRIPTION
Signed-off-by: Grant Seward <grant@stemma.ai>

### Summary of Changes

Previously, when selecting the database from the table details page the value placed into the `source` field was an object, not a string. This PR updates the value being passed to be the actual value of the database.

Previous:

![Screen Shot 2021-04-23 at 10 30 32 AM](https://user-images.githubusercontent.com/10226663/117057557-95799f80-aceb-11eb-81dc-55b22175a871.png)

Current:

![Screen Shot 2021-04-23 at 10 30 39 AM](https://user-images.githubusercontent.com/10226663/117057582-9c081700-aceb-11eb-932e-4980a32bd761.png)

This is inline with how other filters are being passed, for example, dashboard and table tags: https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/components/Tags/TagInfo/index.tsx#L63

### Documentation

N/A

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely, including a title prefix.
- [ ] PR includes a summary of changes.
- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
