### PR TITLE
perf: Update ModeDashboardOwner extractor to use Mode discovery api

### DIFF
--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -541,8 +541,7 @@ task = DefaultTask(extractor=extractor,
 
 job_config = ConfigFactory.from_dict({
     '{}.{}'.format(extractor.get_scope(), ORGANIZATION): organization,
-    '{}.{}'.format(extractor.get_scope(), MODE_ACCESS_TOKEN): mode_token,
-    '{}.{}'.format(extractor.get_scope(), MODE_PASSWORD_TOKEN): mode_password,
+    '{}.{}'.format(extractor.get_scope(), MODE_BEARER_TOKEN): mode_bearer_token,
 })
 
 job = DefaultJob(conf=job_config,

--- a/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_owner_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_owner_extractor.py
@@ -10,8 +10,6 @@ from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_utils import ModeDashboardUtils
 from databuilder.extractor.restapi.rest_api_extractor import MODEL_CLASS
 from databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query import ModePaginatedRestApiQuery
-from databuilder.rest_api.rest_api_failure_handlers import HttpFailureSkipOnStatus
-from databuilder.rest_api.rest_api_query import RestApiQuery
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,37 +39,25 @@ class ModeDashboardOwnerExtractor(Extractor):
     def get_scope(self) -> str:
         return 'extractor.mode_dashboard_owner'
 
-    def _build_restapi_query(self) -> RestApiQuery:
+    def _build_restapi_query(self) -> ModePaginatedRestApiQuery:
         """
-        Build REST API Query. To get Mode Dashboard owner, it needs to call three APIs (spaces API, reports
-        API, and user API) joining together.
+        Build REST API Query to get Mode Dashboard owner
         :return: A RestApiQuery that provides Mode Dashboard owner
         """
 
-        # https://mode.com/developer/api-reference/analytics/reports/#listReportsInSpace
-        report_url_template = 'https://app.mode.com/api/{organization}/spaces/{dashboard_group_id}/reports'
-
-        # https://mode.com/developer/api-reference/management/users/
-        creator_url_template = 'https://app.mode.com{creator_resource_path}'
-
-        spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
-        params = ModeDashboardUtils.get_auth_params(conf=self._conf)
+        seed_query = ModeDashboardUtils.get_seed_query(conf=self._conf)
+        params = ModeDashboardUtils.get_auth_params(conf=self._conf, discover_auth=True)
 
         # Reports
-        json_path = '(_embedded.reports[*].token) | (_embedded.reports[*]._links.creator.href)'
-        field_names = ['dashboard_id', 'creator_resource_path']
-        creator_resource_path_query = ModePaginatedRestApiQuery(query_to_join=spaces_query, url=report_url_template,
-                                                                params=params,
-                                                                json_path=json_path, field_names=field_names,
-                                                                skip_no_result=True,
-                                                                json_path_contains_or=True)
+        # https://mode.com/developer/discovery-api/analytics/reports/
+        url = 'https://app.mode.com/batch/{organization}/reports'
+        json_path = 'reports[*].[token, space_token, creator_email]'
+        field_names = ['dashboard_id', 'dashboard_group_id', 'email']
+        max_record_size = 1000
+        pagination_json_path = 'reports[*]'
+        creator_query = ModePaginatedRestApiQuery(query_to_join=seed_query, url=url, params=params,
+                                                  json_path=json_path, field_names=field_names,
+                                                  skip_no_result=True, max_record_size=max_record_size,
+                                                  pagination_json_path=pagination_json_path)
 
-        json_path = 'email'
-        field_names = ['email']
-        failure_handler = HttpFailureSkipOnStatus(status_codes_to_skip={404})
-        owner_email_query = RestApiQuery(query_to_join=creator_resource_path_query, url=creator_url_template,
-                                         params=params,
-                                         json_path=json_path, field_names=field_names, skip_no_result=True,
-                                         can_skip_failure=failure_handler.can_skip_failure)
-
-        return owner_email_query
+        return creator_query

--- a/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_owner_extractor.py
+++ b/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_owner_extractor.py
@@ -1,0 +1,49 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from mock import patch
+from pyhocon import ConfigFactory
+
+from databuilder import Scoped
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_owner_extractor import (
+    ModeDashboardOwnerExtractor,
+)
+from databuilder.models.dashboard.dashboard_owner import DashboardOwner
+
+
+class TestModeDashboardLastModifiedTimestampExtractor(unittest.TestCase):
+    def setUp(self) -> None:
+        config = ConfigFactory.from_dict({
+            'extractor.mode_dashboard_owner.organization': 'amundsen',
+            'extractor.mode_dashboard_owner.mode_bearer_token': 'amundsen_bearer_token',
+        })
+        self.config = config
+
+    def test_extractor_extract_record(self) -> None:
+        extractor = ModeDashboardOwnerExtractor()
+        extractor.init(Scoped.get_scoped_conf(conf=self.config, scope=extractor.get_scope()))
+
+        with patch(
+                'databuilder.rest_api.mode_analytics.mode_paginated_rest_api_query.ModePaginatedRestApiQuery.execute'
+        ) as mock_execute:
+            mock_execute.return_value = iter([
+                {
+                    'dashboard_group_id': 'ggg',
+                    'dashboard_id': 'ddd',
+                    'email': 'amundsen@abc.com',
+                }
+            ])
+
+            record = extractor.extract()
+            self.assertIsInstance(record, DashboardOwner)
+            self.assertEqual(record._dashboard_group_id, 'ggg')
+            self.assertEqual(record._dashboard_id, 'ddd')
+            self.assertEqual(record._email, 'amundsen@abc.com')
+            self.assertEqual(record._product, 'mode')
+            self.assertEqual(record._cluster, 'gold')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_owner_extractor.py
+++ b/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_owner_extractor.py
@@ -7,9 +7,7 @@ from mock import patch
 from pyhocon import ConfigFactory
 
 from databuilder import Scoped
-from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_owner_extractor import (
-    ModeDashboardOwnerExtractor,
-)
+from databuilder.extractor.dashboard.mode_analytics.mode_dashboard_owner_extractor import ModeDashboardOwnerExtractor
 from databuilder.models.dashboard.dashboard_owner import DashboardOwner
 
 


### PR DESCRIPTION
### Summary of Changes

Update ModeDashboardOwnerExtractor to use Mode discovery api. Metadata can be extracted in one api endpoint call instead of using 3 endpoints (it used to be one for spaces, one for reports, and one for creator email)

Test added.

### Documentation

ModeDashboardOwnerExtractor config example in README

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely, including a title prefix.
- [x] PR includes a summary of changes.
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
