### PR TITLE
fix: Temporarily fix potential 404 in mode dashboard executions extractor

### DIFF
--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -583,6 +583,7 @@ job_config = ConfigFactory.from_dict({
     '{}.{}'.format(extractor.get_scope(), ORGANIZATION): organization,
     '{}.{}'.format(extractor.get_scope(), MODE_ACCESS_TOKEN): mode_token,
     '{}.{}'.format(extractor.get_scope(), MODE_PASSWORD_TOKEN): mode_password,
+    '{}.{}'.format(extractor.get_scope(), MODE_BEARER_TOKEN): mode_bearer_token,
 })
 
 job = DefaultJob(conf=job_config,

--- a/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_executions_extractor.py
@@ -72,6 +72,8 @@ class ModeDashboardExecutionsExtractor(Extractor):
 
         # TODO: revise this extractor once Mode team provides last execution timestamp in reports discovery api
         # https://mode.com/developer/discovery-api/analytics/reports/
+        # Once we can fully switch to Mode discovery api,
+        # the performance of this extractor will be dramatically increased.
 
         spaces_query = ModeDashboardUtils.get_spaces_query_api(conf=self._conf)
         params = ModeDashboardUtils.get_auth_params(conf=self._conf)


### PR DESCRIPTION
### Summary of Changes

Temporarily fix potential 404 in mode dashboard executions extractor. Reached an agreement with Mode team that they will include last_execution_timestamp in reports discovery api. Once Mode team finishes it, we can switch to reports discovery api in this extractor

### Documentation

update mode dashboard executions extractor config in README

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
