### PR TITLE
fix: fix bug in rest_api_query

### DIFF
--- a/databuilder/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/databuilder/rest_api/rest_api_query.py
@@ -177,10 +177,10 @@ class RestApiQuery(BaseRestApiQuery):
                     if not sub_record or len(sub_record) != len(self._field_names):
                         # skip the record
                         continue
-                    record_dict = copy.deepcopy(record_dict)
+                    new_record_dict = copy.deepcopy(record_dict)
                     for field_name in self._field_names:
-                        record_dict[field_name] = sub_record.pop(0)
-                    yield record_dict
+                        new_record_dict[field_name] = sub_record.pop(0)
+                    yield new_record_dict
 
                 self._post_process(response)
 


### PR DESCRIPTION
### Summary of Changes

Potential bugs in rest api query:
The yield `record_dict` for example `{'product': 'mode'}` may be transformed in an extractor to a dict like `{'product': 'mode', 'new_field': 'new_field'}`. When the next yield record is extracted, it still should be `{'product': 'mode'}` instead of `{'product': 'mode', 'new_field': 'new_field'}` since two records should be unrelevant.

See this extractor as an example that changes record_dict https://github.com/amundsen-io/amundsen/blob/1cece5b4461c8623414ccfb635e495e794a55988/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_queries_extractor.py#L74

This is not causing a problem on our end right now. It is a proactive change to avoid possible problems. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
