### PR TITLE
feat: Add merge query results functionality to rest_api_query

### DIFF
--- a/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
+++ b/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_utils.py
@@ -26,7 +26,6 @@ class ModeDashboardUtils(object):
         seed_query = RestApiQuerySeed(seed_record=seed_record)
         return seed_query
 
-    # TODO: Delete this get_spaces_query_api once everything is moved to use discovery api
     @staticmethod
     def get_spaces_query_api(conf: ConfigTree) -> BaseRestApiQuery:
         """
@@ -40,8 +39,7 @@ class ModeDashboardUtils(object):
         spaces_url_template = 'https://app.mode.com/batch/{organization}/spaces'
 
         # Seed query record for next query api to join with
-        seed_record = [{'organization': conf.get_string(ORGANIZATION)}]
-        seed_query = RestApiQuerySeed(seed_record=seed_record)
+        seed_query = ModeDashboardUtils.get_seed_query(conf=conf)
 
         # mode_bearer_token must be provided in the conf
         # the token is required to access discovery endpoint

--- a/databuilder/databuilder/rest_api/query_merger.py
+++ b/databuilder/databuilder/rest_api/query_merger.py
@@ -1,6 +1,10 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import (
+    Any, Dict
+)
+
 from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery
 
 
@@ -35,7 +39,7 @@ class QueryMerger:
                  ) -> None:
         self._query_to_merge = query_to_merge
         self._merge_key = merge_key
-        self._computed_query_result = dict()
+        self._computed_query_result: Dict[Any, Any] = dict()
 
     def merge_into(self, record_dict: dict) -> None:
         """
@@ -54,7 +58,7 @@ class QueryMerger:
             raise Exception(f'{self._merge_key} {value_of_merge_key} not found in query_to_merge results')
         record_dict.update(record_dict_to_merge)
 
-    def _compute_query_result(self) -> dict:
+    def _compute_query_result(self) -> Dict[Any, Any]:
         """
         Transform the query result to a dictionary.
 
@@ -68,7 +72,7 @@ class QueryMerger:
 
         :return: a dictionary
         """
-        computed_query_results = dict()
+        computed_query_results: Dict[Any, Any] = dict()
         iterator = self._query_to_merge.execute()
 
         while True:

--- a/databuilder/databuilder/rest_api/query_merger.py
+++ b/databuilder/databuilder/rest_api/query_merger.py
@@ -1,0 +1,86 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery
+
+
+class QueryMerger:
+    """
+    To be used in rest_api_query
+
+    e.g. Assuming
+            query_merger = QueryMerger(query_to_merge=spaces_query, merge_key='dashboard_group_id'),
+         where spaces_query yields a record like
+            {
+             'dashboard_group_id': 'ggg',
+             'dashboard_group': 'dashboard group'
+            },
+         and RestApiQuery's inner_rest_api_query.execute() returns a record of
+            {
+             'dashboard_id': 'ddd',
+             'dashboard_name': 'dashboard_name',
+             'dashboard_group_id': 'ggg'
+             },
+         the final yield record_dict from RestApiQuery(query_merger=query_merger).execute() will be
+            {
+             'dashboard_id': 'ddd',
+             'dashboard_name': 'dashboard_name',
+             'dashboard_group_id': 'ggg',
+             'dashboard_group': 'dashboard group'
+            }
+    """
+    def __init__(self,
+                 query_to_merge: BaseRestApiQuery,
+                 merge_key: str,
+                 ) -> None:
+        self._query_to_merge = query_to_merge
+        self._merge_key = merge_key
+        self._computed_query_result = dict()
+
+    def merge_into(self, record_dict: dict) -> None:
+        """
+        Merge results of query_to_merge into record_dict. Update record_dict in place.
+
+        :param record_dict: the record_dict to be updated in place
+        :return:
+        """
+        # compute query results for easy lookup later to find the exact record to merge
+        if not self._computed_query_result:
+            self._computed_query_result = self._compute_query_result()
+
+        value_of_merge_key = record_dict.get(self._merge_key)
+        record_dict_to_merge = self._computed_query_result.get(value_of_merge_key)
+        if not record_dict_to_merge:
+            raise Exception(f'{self._merge_key} {value_of_merge_key} not found in query_to_merge results')
+        record_dict.update(record_dict_to_merge)
+
+    def _compute_query_result(self) -> dict:
+        """
+        Transform the query result to a dictionary.
+
+        Assuming merge_key is 'dashboard_id' and self._query_to_merge.execute() returns
+            iter([{'dashboard_id': 'd1', 'dashboard_name': 'n1'}, {'dashboard_id': 'd2', 'dashboard_name': 'n2'}]),
+        the returned dict of this method will look like
+            {
+             'd1': {'dashboard_id': 'd1', 'dashboard_name': 'n1'},
+             'd2': {'dashboard_id': 'd2', 'dashboard_name': 'n2'},
+            }
+
+        :return: a dictionary
+        """
+        computed_query_results = dict()
+        iterator = self._query_to_merge.execute()
+
+        while True:
+            try:
+                record = next(iterator)
+            except StopIteration:
+                return computed_query_results
+
+            value_of_merge_key = record[self._merge_key]
+            if value_of_merge_key in computed_query_results:
+                raise Exception(
+                    f'merge_key {self._merge_key} value {value_of_merge_key} is not unique across the query results'
+                )
+
+            computed_query_results[value_of_merge_key] = record

--- a/databuilder/databuilder/rest_api/query_merger.py
+++ b/databuilder/databuilder/rest_api/query_merger.py
@@ -1,9 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import (
-    Any, Dict
-)
+from typing import Any, Dict
 
 from databuilder.rest_api.base_rest_api_query import BaseRestApiQuery
 

--- a/databuilder/tests/unit/rest_api/test_query_merger.py
+++ b/databuilder/tests/unit/rest_api/test_query_merger.py
@@ -1,0 +1,99 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from mock import patch
+
+from databuilder.rest_api.base_rest_api_query import RestApiQuerySeed
+from databuilder.rest_api.query_merger import QueryMerger
+from databuilder.rest_api.rest_api_query import RestApiQuery
+
+
+class TestQueryMerger(unittest.TestCase):
+    def setUp(self):
+        query_to_join_seed_record = [
+            {'foo1': 'bar1', 'dashboard_id': 'd1'},
+            {'foo2': 'bar2', 'dashboard_id': 'd3'}
+        ]
+        self.query_to_join = RestApiQuerySeed(seed_record=query_to_join_seed_record)
+        self.json_path = 'foo.name'
+        self.field_names = ['name_field']
+        self.url = 'foobar'
+
+    def test_ensure_record_get_updated(self):
+        query_to_merge_seed_record = [
+            {'organization': 'amundsen', 'dashboard_id': 'd1'},
+            {'organization': 'amundsen-databuilder', 'dashboard_id': 'd2'},
+            {'organization': 'amundsen-dashboard', 'dashboard_id': 'd3'},
+        ]
+        query_to_merge = RestApiQuerySeed(seed_record=query_to_merge_seed_record)
+        query_merger = QueryMerger(query_to_merge=query_to_merge, merge_key='dashboard_id')
+
+        with patch('databuilder.rest_api.rest_api_query.requests.get') as mock_get:
+            mock_get.return_value.json.side_effect = [
+                {'foo': {'name': 'john'}},
+                {'foo': {'name': 'doe'}},
+            ]
+            query = RestApiQuery(query_to_join=self.query_to_join, url=self.url, params={},
+                                 json_path=self.json_path, field_names=self.field_names,
+                                 query_merger=query_merger)
+            results = list(query.execute())
+            self.assertEqual(len(results), 2)
+            self.assertDictEqual(
+                {'dashboard_id': 'd1', 'foo1': 'bar1', 'name_field': 'john', 'organization': 'amundsen'},
+                results[0],
+            )
+            self.assertDictEqual(
+                {'dashboard_id': 'd3', 'foo2': 'bar2', 'name_field': 'doe', 'organization': 'amundsen-dashboard'},
+                results[1],
+            )
+
+    def test_exception_rasied_with_duplicate_merge_key(self):
+        """
+         Two records in query_to_merge results have {'dashboard_id': 'd2'},
+         exception should be raised
+        """
+        query_to_merge_seed_record = [
+            {'organization': 'amundsen', 'dashboard_id': 'd1'},
+            {'organization': 'amundsen-databuilder', 'dashboard_id': 'd2'},
+            {'organization': 'amundsen-dashboard', 'dashboard_id': 'd2'},
+        ]
+        query_to_merge = RestApiQuerySeed(seed_record=query_to_merge_seed_record)
+        query_merger = QueryMerger(query_to_merge=query_to_merge, merge_key='dashboard_id')
+
+        with patch('databuilder.rest_api.rest_api_query.requests.get') as mock_get:
+            mock_get.return_value.json.side_effect = [
+                {'foo': {'name': 'john'}},
+                {'foo': {'name': 'doe'}},
+            ]
+            query = RestApiQuery(query_to_join=self.query_to_join, url=self.url, params={},
+                                 json_path=self.json_path, field_names=self.field_names,
+                                 query_merger=query_merger)
+            self.assertRaises(Exception, query.execute())
+
+    def test_exception_raised_with_missing_merge_key(self):
+        """
+         No record in query_to_merge results contains {'dashboard_id': 'd3'},
+         exception should be raised
+        """
+        query_to_merge_seed_record = [
+            {'organization': 'amundsen', 'dashboard_id': 'd1'},
+            {'organization': 'amundsen-databuilder', 'dashboard_id': 'd2'},
+        ]
+        query_to_merge = RestApiQuerySeed(seed_record=query_to_merge_seed_record)
+        query_merger = QueryMerger(query_to_merge=query_to_merge, merge_key='dashboard_id')
+
+        with patch('databuilder.rest_api.rest_api_query.requests.get') as mock_get:
+            mock_get.return_value.json.side_effect = [
+                {'foo': {'name': 'john'}},
+                {'foo': {'name': 'doe'}},
+            ]
+            query = RestApiQuery(query_to_join=self.query_to_join, url=self.url, params={},
+                                 json_path=self.json_path, field_names=self.field_names,
+                                 query_merger=query_merger)
+            self.assertRaises(Exception, query.execute())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/databuilder/tests/unit/rest_api/test_query_merger.py
+++ b/databuilder/tests/unit/rest_api/test_query_merger.py
@@ -11,7 +11,7 @@ from databuilder.rest_api.rest_api_query import RestApiQuery
 
 
 class TestQueryMerger(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         query_to_join_seed_record = [
             {'foo1': 'bar1', 'dashboard_id': 'd1'},
             {'foo2': 'bar2', 'dashboard_id': 'd3'}
@@ -21,7 +21,7 @@ class TestQueryMerger(unittest.TestCase):
         self.field_names = ['name_field']
         self.url = 'foobar'
 
-    def test_ensure_record_get_updated(self):
+    def test_ensure_record_get_updated(self) -> None:
         query_to_merge_seed_record = [
             {'organization': 'amundsen', 'dashboard_id': 'd1'},
             {'organization': 'amundsen-databuilder', 'dashboard_id': 'd2'},
@@ -49,7 +49,7 @@ class TestQueryMerger(unittest.TestCase):
                 results[1],
             )
 
-    def test_exception_rasied_with_duplicate_merge_key(self):
+    def test_exception_rasied_with_duplicate_merge_key(self) -> None:
         """
          Two records in query_to_merge results have {'dashboard_id': 'd2'},
          exception should be raised
@@ -72,7 +72,7 @@ class TestQueryMerger(unittest.TestCase):
                                  query_merger=query_merger)
             self.assertRaises(Exception, query.execute())
 
-    def test_exception_raised_with_missing_merge_key(self):
+    def test_exception_raised_with_missing_merge_key(self) -> None:
         """
          No record in query_to_merge results contains {'dashboard_id': 'd3'},
          exception should be raised


### PR DESCRIPTION
### Summary of Changes

Adding this functionality in support of moving Move Dashboard Extractors to discovery API.

Based on discovery api documents, [space discovery api ](https://mode.com/developer/discovery-api/analytics/spaces/)has dashboard_group_id, dashboard_group_name, and dashboard_group_description, while [report discovery api](https://mode.com/developer/discovery-api/analytics/reports/) has dashboard_id, dashboard_name, dashboard_group_id, and dashboard_description etc.  If we want to extract DashboardMetadata that has all these information in one record, we have to join them based on dashboard_group_id. The purpose of this PR is to address this.

There are some other use cases that we need to merge results as well, for example, total_views_count that lives in [report stats discovery api](https://mode.com/developer/discovery-api/analytics/report-stats/), which we have to merge into the response of [report discovery api](https://mode.com/developer/discovery-api/analytics/reports/)

### Tests

Unit test for QueryMerger

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
