### PR TITLE
feat: Add customization point for footer logo title

### DIFF
--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -32,6 +32,7 @@ const configDefault: AppConfig = {
   },
   logoPath: null,
   logoTitle: 'AMUNDSEN',
+  footerLogoTitle: 'Amundsen',
   documentTitle: 'Amundsen - Data Discovery Portal',
   numberFormat: null,
   mailClientFeatures: {

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -18,6 +18,7 @@ export interface AppConfig {
   issueTracking: IssueTrackingConfig;
   logoPath: string | null;
   logoTitle: string;
+  footerLogoTitle: string;
   documentTitle: string;
   numberFormat: NumberFormatConfig | null;
   mailClientFeatures: MailClientFeaturesConfig;
@@ -41,6 +42,7 @@ export interface AppConfigCustom {
   issueTracking?: IssueTrackingConfig;
   logoPath?: string;
   logoTitle?: string;
+  footerLogoTitle?: string;
   documentTitle?: string;
   numberFormat?: NumberFormatConfig | null;
   mailClientFeatures?: MailClientFeaturesConfig;

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -318,6 +318,13 @@ export function getLogoTitle(): string {
 }
 
 /**
+ * Returns footerLogoTitle.
+ */
+export function getFooterLogoTitle(): string {
+  return AppConfig.footerLogoTitle;
+}
+
+/**
  * Returns whether the in-app table lineage list is enabled.
  */
 export function isTableListLineageEnabled() {

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -407,6 +407,14 @@ describe('getLogoTitle', () => {
   });
 });
 
+describe('getFooterLogoTitle', () => {
+  it('returns footerLogoTitle defined in config', () => {
+    const actual = ConfigUtils.getFooterLogoTitle();
+    const expected = AppConfig.footerLogoTitle;
+    expect(actual).toBe(expected);
+  });
+});
+
 describe('isTableListLineageEnabled', () => {
   it('returns isTableListLineageEnabled defined in config', () => {
     const actual = ConfigUtils.isTableListLineageEnabled();

--- a/frontend/amundsen_application/static/js/features/Footer/index.tsx
+++ b/frontend/amundsen_application/static/js/features/Footer/index.tsx
@@ -9,6 +9,7 @@ import { GlobalState } from 'ducks/rootReducer';
 import { getLastIndexed } from 'ducks/lastIndexed/reducer';
 import { GetLastIndexedRequest } from 'ducks/lastIndexed/types';
 
+import { getFooterLogoTitle } from 'config/config-utils';
 import { formatDateTimeLong } from 'utils/dateUtils';
 
 import './styles.scss';
@@ -46,7 +47,7 @@ export class Footer extends React.Component<FooterProps> {
     if (this.props.lastIndexed) {
       content = (
         <div>
-          {`Amundsen was last indexed on ${this.generateDateTimeString(
+          {`${getFooterLogoTitle()} was last indexed on ${this.generateDateTimeString(
             this.props.lastIndexed
           )}`}
         </div>


### PR DESCRIPTION
### Summary of Changes

In addition to a customization point for the header logo title (58472343), the footer's logo title should also be customizable.

Requested by: https://github.com/amundsen-io/amundsenfrontendlibrary/pull/953#issuecomment-831803247

### Tests

Tests for the getter method are added.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
