### PR TITLE
Automatic PR labeling

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -1,0 +1,71 @@
+labelPRBasedOnFilePath:
+  area:common:
+    - common/**/*
+
+  area:databuilder:
+    - databuilder/**/*
+
+  area:docs:
+    - docs/**/*
+    - docs_overrides/**/*
+
+  area:frontend:
+    - frontend/**/*
+
+  area:helm:
+    - amundsen-kube-helm/**/*
+
+  area:metadata:
+    - metadata/**/*
+
+  area:search:
+    - search/**/*
+
+  area:dev-tools:
+    - .dependabot/**/*
+    - .github/**/*
+    - .editorconfig
+    - .gitignore
+    - .mailmap
+    - CODE_OF_CONDUCT.md
+    - CONTRIBUTING.md
+    - docker*yml
+    - deploy_website.sh
+    - GOVERNANCE.md
+    - LICENSE
+    - MAINTAINING.md
+    - mkdocs.yml
+    - NOTICE
+    - OWNERS.md
+    - README.md
+    - SECURITY.md
+
+  category:ui:
+    - frontend/amundsen_application/static/**/*
+
+  category:api:
+    - frontend/amundsen_application/api/**/*
+    - metadata/metadata_service/api/**/*
+    - search/search_service/api/**/*
+
+  category:models:
+    - common/amundsen_common/models/**/*
+    - databuilder/databuilder/models/**/*
+    - frontend/amundsen_application/models/**/*
+    - metadata/metadata_service/models/**/*
+    - search/search_service/models/**/*
+
+  category:proxy:
+    - metadata/metadata_serivce/proxy/**/*
+    - search/search_service/proxy/**/*
+
+firstPRWelcomeComment: >
+  Congratulations on your first Pull Request and welcome to Amundsen community!
+  If you have any issues or are unsure about any anything please check our
+  Contribution Guide (https://github.com/amundsen-io/amundsen/blob/main/CONTRIBUTING.md)
+
+firstPRMergeComment: >
+  Awesome work, congrats on your first merged pull request!
+
+firstIssueWelcomeComment: >
+  Thanks for opening your first issue here! Be sure to follow the issue template!


### PR DESCRIPTION
### Summary of Changes

Proposes to use https://probot.github.io/apps/boring-cyborg/ as an automatic PR labeler.

After migrating to monorepo we could benefit from this to have better traceability of PRs that are filed.

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
