### PR TITLE
Fix: Make BigQuery extractors support Relational Metadata store

### DIFF
--- a/databuilder/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/databuilder/extractor/base_bigquery_extractor.py
@@ -4,6 +4,7 @@
 import json
 import logging
 from collections import namedtuple
+from datetime import datetime, timezone
 from typing import (
     Any, Dict, Iterator, List,
 )
@@ -29,10 +30,13 @@ class BaseBigQueryExtractor(Extractor):
     CRED_KEY = 'project_cred'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
+    # metadata for tables created after the cutoff time would not be extracted from bigquery.
+    CUTOFF_TIME_KEY = 'cutoff_time'
     _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly']
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8
+    DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
     def init(self, conf: ConfigTree) -> None:
         # should use key_path, or cred_key if the former doesn't exist
@@ -43,6 +47,8 @@ class BaseBigQueryExtractor(Extractor):
             BaseBigQueryExtractor.PAGE_SIZE_KEY,
             BaseBigQueryExtractor.DEFAULT_PAGE_SIZE)
         self.filter = conf.get_string(BaseBigQueryExtractor.FILTER_KEY, '')
+        self.cutoff_time = conf.get_string(BaseBigQueryExtractor.CUTOFF_TIME_KEY,
+                                           datetime.now(timezone.utc).strftime(BaseBigQueryExtractor.DATE_TIME_FORMAT))
 
         if self.key_path:
             credentials = (

--- a/databuilder/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_usage_extractor.py
@@ -4,7 +4,9 @@
 import logging
 import re
 from collections import namedtuple
-from datetime import date, timedelta
+from datetime import (
+    datetime, timedelta, timezone,
+)
 from time import sleep
 from typing import (
     Any, Dict, Iterator, List, Optional, Tuple,
@@ -30,15 +32,23 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
     _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/cloud-platform']
     EMAIL_PATTERN = 'email_pattern'
     DELAY_TIME = 'delay_time'
+    # GCP console allows running queries using tables from a project different from the one the extractor is used for;
+    # if 'count_tables_only_from_project_id_key' is enabled only usage metadata of referenced tables
+    # in the given project_id_key for the extractor is taken into account and usage metadata of referenced tables
+    # from other projects is ignored.
+    COUNT_TABLES_ONLY_FROM_PROJECT_ID_KEY = 'count_tables_only_from_project_id_key'
+    TABLE_DECORATORS = ['$', '@']
 
     def init(self, conf: ConfigTree) -> None:
         BaseBigQueryExtractor.init(self, conf)
         self.timestamp = conf.get_string(
             BigQueryTableUsageExtractor.TIMESTAMP_KEY,
-            (date.today() - timedelta(days=1)).strftime('%Y-%m-%dT00:00:00Z'))
+            (datetime.now(timezone.utc) - timedelta(days=1)).strftime(BigQueryTableUsageExtractor.DATE_TIME_FORMAT))
 
         self.email_pattern = conf.get_string(BigQueryTableUsageExtractor.EMAIL_PATTERN, None)
         self.delay_time = conf.get_int(BigQueryTableUsageExtractor.DELAY_TIME, 100)
+        self.count_tables_only_from_project_id = conf.get_bool(
+            BigQueryTableUsageExtractor.COUNT_TABLES_ONLY_FROM_PROJECT_ID_KEY, False)
 
         self.table_usage_counts: Dict[TableColumnUsageTuple, int] = {}
         self._count_usage()
@@ -49,7 +59,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
         for entry in self._retrieve_records():
             count += 1
             if count % self.pagesize == 0:
-                LOGGER.info(f'Aggregated %i records', count)
+                LOGGER.info(f'Aggregated {count} records')
 
             if entry is None:
                 continue
@@ -99,29 +109,54 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
             return
 
         for refResource in refResources:
-            key = TableColumnUsageTuple(database='bigquery',
-                                        cluster=refResource['projectId'],
-                                        schema=refResource['datasetId'],
-                                        table=refResource['tableId'],
-                                        column='*',
-                                        email=email)
+            tableId = refResource['tableId']
+            datasetId = refResource['datasetId']
+
+            if self._is_anonymous_dataset(datasetId) or self._is_wildcard_table(tableId):
+                continue
+
+            tableId = self._remove_table_decorators(tableId)
+
+            if self._is_sharded_table(tableId):
+                tableId = tableId[:-BigQueryTableUsageExtractor.DATE_LENGTH]
+
+            if self.count_tables_only_from_project_id:
+                if refResource['projectId'] == self.project_id:
+                    key = TableColumnUsageTuple(database='bigquery',
+                                                cluster=refResource['projectId'],
+                                                schema=datasetId,
+                                                table=tableId,
+                                                column='*',
+                                                email=email)
+                else:
+                    LOGGER.debug(f'Not counting usage for {refResource} since '
+                                 f'{BigQueryTableUsageExtractor.COUNT_TABLES_ONLY_FROM_PROJECT_ID_KEY} is True')
+                    continue
+            else:
+                key = TableColumnUsageTuple(database='bigquery',
+                                            cluster=refResource['projectId'],
+                                            schema=datasetId,
+                                            table=tableId,
+                                            column='*',
+                                            email=email)
 
             new_count = self.table_usage_counts.get(key, 0) + 1
             self.table_usage_counts[key] = new_count
 
     def _retrieve_records(self) -> Iterator[Optional[Dict]]:
         """
-        Extracts bigquery log data by looking at the principalEmail in the
-        authenticationInfo block and referencedTables in the jobStatistics.
-
+        Extracts bigquery log data by looking at the principalEmail in the authenticationInfo block and
+        referencedTables in the jobStatistics and filters out log entries of metadata queries.
         :return: Provides a record or None if no more to extract
         """
         body = {
             'resourceNames': [f'projects/{self.project_id}'],
             'pageSize': self.pagesize,
-            'filter': 'resource.type="bigquery_resource" AND '
-                      'protoPayload.methodName="jobservice.jobcompleted" AND '
-                      f'timestamp >= "{self.timestamp}"'
+            'filter': 'protoPayload.methodName="jobservice.jobcompleted" AND '
+                      'resource.type="bigquery_resource" AND '
+                      'NOT protoPayload.serviceData.jobCompletedEvent.job.jobConfiguration.query.query:('
+                      'INFORMATION_SCHEMA OR __TABLES__) AND '
+                      f'timestamp >= "{self.timestamp}" AND timestamp < "{self.cutoff_time}"'
         }
         for page in self._page_over_results(body):
             for entry in page['entries']:
@@ -151,6 +186,18 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
             except Exception:
                 # Add a delay when BQ quota exceeds limitation
                 sleep(self.delay_time)
+
+    def _remove_table_decorators(self, tableId: str) -> Optional[str]:
+        for decorator in BigQueryTableUsageExtractor.TABLE_DECORATORS:
+            tableId = tableId.split(decorator)[0]
+        return tableId
+
+    def _is_anonymous_dataset(self, datasetId: str) -> bool:
+        # temporary/cached results tables are stored in anonymous datasets that have names starting with '_'
+        return datasetId.startswith('_')
+
+    def _is_wildcard_table(self, tableId: str) -> bool:
+        return '*' in tableId
 
     def get_scope(self) -> str:
         return 'extractor.bigquery_table_usage'

--- a/databuilder/tests/unit/extractor/test_bigquery_usage_extractor.py
+++ b/databuilder/tests/unit/extractor/test_bigquery_usage_extractor.py
@@ -199,7 +199,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         Test Extraction using mock class
         """
         config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -225,7 +225,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_no_entries(self, mock_build: Any) -> None:
         config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -249,7 +249,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
             keyfile.write(base64.b64decode(KEYFILE_DATA))
             keyfile.flush()
             config_dict = {
-                f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+                f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
                 f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.KEY_PATH_KEY}': keyfile.name,
             }
             conf = ConfigFactory.from_dict(config_dict)
@@ -273,7 +273,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         PAGESIZE = 215
 
         config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
             f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.TIMESTAMP_KEY}': TIMESTAMP,
             f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PAGE_SIZE_KEY}': PAGESIZE,
         }
@@ -294,7 +294,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_failed_jobs_should_not_be_counted(self, mock_build: Any) -> None:
         config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -310,7 +310,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_email_filter_not_counted(self, mock_build: Any) -> None:
         config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
             f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.EMAIL_PATTERN}': 'emailFilter',
         }
         conf = ConfigFactory.from_dict(config_dict)
@@ -325,7 +325,7 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
     @patch('databuilder.extractor.base_bigquery_extractor.build')
     def test_email_filter_counted(self, mock_build: Any) -> None:
         config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
+            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
             f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.EMAIL_PATTERN}': '.*@test.com.*',
         }
         conf = ConfigFactory.from_dict(config_dict)
@@ -350,14 +350,12 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
         self.assertEqual(value, 1)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_count_tables_only_from_project_id_key_when_different_project(self, mock_build: Any) -> None:
+    def test_referenced_table_belonging_to_different_project(self, mock_build: Any) -> None:
         """
-        Test result when COUNT_TABLES_ONLY_FROM_PROJECT_ID is enabled and referenced table's project is different
-        from the PROJECT_ID_KEY of the extractor
+        Test result when referenced table belongs to a project different from the PROJECT_ID_KEY of the extractor
         """
         config_dict = {
             f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'your-project-here',
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.COUNT_TABLES_ONLY_FROM_PROJECT_ID_KEY}': True,
         }
         conf = ConfigFactory.from_dict(config_dict)
 
@@ -368,35 +366,3 @@ class TestBigqueryUsageExtractor(unittest.TestCase):
 
         result = extractor.extract()
         assert result is None
-
-    @patch('databuilder.extractor.base_bigquery_extractor.build')
-    def test_count_tables_only_from_project_id_when_same_project(self, mock_build: Any) -> None:
-        """
-        Test result when COUNT_TABLES_ONLY_FROM_PROJECT_ID is enabled and referenced table's project is same as the
-        PROJECT_ID_KEY of the extractor
-        """
-        config_dict = {
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.PROJECT_ID_KEY}': 'bigquery-public-data',
-            f'extractor.bigquery_table_usage.{BigQueryTableUsageExtractor.COUNT_TABLES_ONLY_FROM_PROJECT_ID_KEY}': True,
-        }
-        conf = ConfigFactory.from_dict(config_dict)
-
-        mock_build.return_value = MockLoggingClient(CORRECT_DATA)
-        extractor = BigQueryTableUsageExtractor()
-        extractor.init(Scoped.get_scoped_conf(conf=conf,
-                                              scope=extractor.get_scope()))
-
-        result = extractor.extract()
-        assert result is not None
-        self.assertIsInstance(result, tuple)
-
-        (key, value) = result
-        self.assertIsInstance(key, TableColumnUsageTuple)
-        self.assertIsInstance(value, int)
-
-        self.assertEqual(key.database, 'bigquery')
-        self.assertEqual(key.cluster, 'bigquery-public-data')
-        self.assertEqual(key.schema, 'austin_incidents')
-        self.assertEqual(key.table, 'incidents_2008')
-        self.assertEqual(key.email, 'your-user-here@test.com')
-        self.assertEqual(value, 1)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->
Changes made according to the issues: #1070 & #1071
Additional changes made not mentioned in the issue: 
- Skip usage counts for wildcard tables: When there is a query like `select * from project:dataset:tableprefix*`, the `'referenced tables'` in the logging response contains the tableId as tableprefix* resulting in a FK constraint violation between table_usage and table_metadata tables.

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->
Added unit tests for the new configs in bigquery_usage_extractor and bigquery_watermark_extractor. 
### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->
N/A
### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
