### PR TITLE
test: Add Python 3.8 and 3.9 databuilder CI

### DIFF
--- a/.github/workflows/databuilder_pull_request.yml
+++ b/.github/workflows/databuilder_pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ['3.6.x', '3.7.x']
+        python-version: ['3.6.x', '3.7.x', '3.8.x', '3.9.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/noop_pull_request.yml
+++ b/.github/workflows/noop_pull_request.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6.x", "3.7.x", "3.8.x"]
+        python-version: ["3.6.x", "3.7.x", "3.8.x", "3.9.x"]
     steps:
       - name: Do nothing
         run: exit 0

--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -59,6 +59,7 @@ httplib2>=0.18.0
 unidecode
 Jinja2>=2.10.0,<2.12
 pandas>=0.21.0,<1.2.0
+numpy>=1.15.4
 
 requests==2.23.0,<3.0
 responses==0.10.6

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -120,5 +120,7 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )


### PR DESCRIPTION
### Summary of Changes

Ran the databuilder locally using 3.9 and it works fine, would be a pity to not add this as a supported version

### Tests

Added the versions to the `setup.py` and the CI itself.

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
