### PR TITLE
feat: Hide dashboards tab in table view when empty

### DIFF
--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -84,7 +84,7 @@ describe('TableDetail', () => {
 
     it('renders one tabs when dashboards are enabled but no dashboard exists', () => {
       mocked(indexDashboardsEnabled).mockImplementation(() => true);
-      mocked(props.numRelatedDashboards).mockImplementation(() => 0);
+      mocked(wrapper.props.numRelatedDashboards).mockImplementation(() => 0);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
       expect(

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -42,7 +42,7 @@ const setup = (
     tableLineage,
     isLoading: false,
     isLoadingDashboards: false,
-    numRelatedDashboards: 0,
+    numRelatedDashboards: 1,
     statusCode: 200,
     tableData: tableMetadata,
     getTableData: jest.fn(),
@@ -73,7 +73,7 @@ describe('TableDetail', () => {
       ).toBeFalsy();
     });
 
-    it('renders two tabs when dashboards are enabled', () => {
+    it('renders two tabs when dashboards are enabled and at least one dashboard exists', () => {
       mocked(indexDashboardsEnabled).mockImplementation(() => true);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
@@ -81,6 +81,17 @@ describe('TableDetail', () => {
         tabInfo.find((tab) => tab.key === TABLE_TAB.DASHBOARD)
       ).toBeTruthy();
     });
+
+   it('renders one tabs when dashboards are enabled but no dashboard exists', () => {
+      mocked(indexDashboardsEnabled).mockImplementation(() => true);
+      mocked(props.numRelatedDashboards).mockImplementation(() => 0)
+      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+      const tabInfo = content.find(TabsComponent).props().tabs;
+      expect(
+        tabInfo.find((tab) => tab.key === TABLE_TAB.DASHBOARD)
+      ).toBeFalsy();
+    });
+
     it('does not render upstream and downstream tabs when disabled', () => {
       mocked(isTableListLineageEnabled).mockImplementation(() => false);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -82,9 +82,9 @@ describe('TableDetail', () => {
       ).toBeTruthy();
     });
 
-   it('renders one tabs when dashboards are enabled but no dashboard exists', () => {
+    it('renders one tabs when dashboards are enabled but no dashboard exists', () => {
       mocked(indexDashboardsEnabled).mockImplementation(() => true);
-      mocked(props.numRelatedDashboards).mockImplementation(() => 0)
+      mocked(props.numRelatedDashboards).mockImplementation(() => 0);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
       expect(

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -264,19 +264,20 @@ export class TableDetail extends React.Component<
           Dashboards <LoadingSpinner />
         </div>
       );
-
-      tabInfo.push({
-        content: (
-          <TableDashboardResourceList
-            itemsPerPage={DASHBOARDS_PER_PAGE}
-            source={TABLE_SOURCE}
-          />
-        ),
-        key: Constants.TABLE_TAB.DASHBOARD,
-        title: isLoadingDashboards
-          ? loadingTitle
-          : `Dashboards (${numRelatedDashboards})`,
-      });
+      if (numRelatedDashboards > 0) {
+        tabInfo.push({
+          content: (
+            <TableDashboardResourceList
+              itemsPerPage={DASHBOARDS_PER_PAGE}
+              source={TABLE_SOURCE}
+            />
+          ),
+          key: Constants.TABLE_TAB.DASHBOARD,
+          title: isLoadingDashboards
+            ? loadingTitle
+            : `Dashboards (${numRelatedDashboards})`,
+        });
+      }
     }
 
     if (isTableListLineageEnabled()) {


### PR DESCRIPTION
### Summary of Changes

If table has no connected dashboards then we do not to display dashboard tab at all. This would align things with how it's handled for lineage tabs.

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
