### PR TITLE
chore: update ModePaginatedRestApiQuery default parameters

### DIFF
--- a/databuilder/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
+++ b/databuilder/databuilder/rest_api/mode_analytics/mode_paginated_rest_api_query.py
@@ -9,10 +9,10 @@ from jsonpath_rw import parse
 
 from databuilder.rest_api.rest_api_query import RestApiQuery
 
-#  How many records considers as full and indicating there might be next page? In list reports on space API, it's 30.
-DEFAULT_MAX_RECORD_SIZE = 30
+#  How many records considers as full and indicating there might be next page?
+DEFAULT_MAX_RECORD_SIZE = 1000
 PAGE_SUFFIX_TEMPLATE = '?page={}'
-LIST_REPORTS_PAGINATION_JSON_PATH = '_embedded.reports[*]'  # So far this is the only paginated API that we need.
+LIST_REPORTS_PAGINATION_JSON_PATH = 'reports[*]'
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Summary of Changes

For the Mode main API, it is 30 per page. For the discovery, by default, it is 1000 records per page.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
