### PR TITLE
feat: support skipping configured Mode spaces

### DIFF
--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -618,7 +618,7 @@ relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_f
 job_config = ConfigFactory.from_dict({
     'extractor.mode_dashboard.{}'.format(ORGANIZATION): organization,
     'extractor.mode_dashboard.{}'.format(MODE_BEARER_TOKEN): mode_bearer_token,
-    'extractor.mode_dashboard.{}'.format(DASHBOARD_GROUP_ID_TO_SKIP): [space_token_1, space_token_2, ...],
+    'extractor.mode_dashboard.{}'.format(DASHBOARD_GROUP_IDS_TO_SKIP): [space_token_1, space_token_2, ...],
     'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH): node_files_folder,
     'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH): relationship_files_folder,
     'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR): True,

--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -618,6 +618,7 @@ relationship_files_folder = '{tmp_folder}/relationships'.format(tmp_folder=tmp_f
 job_config = ConfigFactory.from_dict({
     'extractor.mode_dashboard.{}'.format(ORGANIZATION): organization,
     'extractor.mode_dashboard.{}'.format(MODE_BEARER_TOKEN): mode_bearer_token,
+    'extractor.mode_dashboard.{}'.format(DASHBOARD_GROUP_ID_TO_SKIP): [space_token_1, space_token_2, ...],
     'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH): node_files_folder,
     'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH): relationship_files_folder,
     'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.SHOULD_DELETE_CREATED_DIR): True,

--- a/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -20,6 +20,8 @@ from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, Timest
 
 LOGGER = logging.getLogger(__name__)
 
+DASHBOARD_GROUP_ID_TO_SKIP = 'dashboard_group_id_to_skip'
+
 
 class ModeDashboardExtractor(Extractor):
     """
@@ -37,6 +39,8 @@ class ModeDashboardExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         self._conf = conf
+
+        self.dashboard_group_id_to_skip = self._conf.get_list(DASHBOARD_GROUP_ID_TO_SKIP, [])
 
         restapi_query = self._build_restapi_query()
         self._extractor = ModeDashboardUtils.create_mode_rest_api_extractor(restapi_query=restapi_query,
@@ -78,6 +82,11 @@ class ModeDashboardExtractor(Extractor):
 
     def extract(self) -> Any:
         record = self._extractor.extract()
+
+        # determine whether we want to skip these records
+        while record and record.get('dashboard_group_id') in self.dashboard_group_id_to_skip:
+            record = self._extractor.extract()
+
         if not record:
             return None
 

--- a/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -20,6 +20,7 @@ from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, Timest
 
 LOGGER = logging.getLogger(__name__)
 
+# a list of space tokens that we want to skip indexing
 DASHBOARD_GROUP_ID_TO_SKIP = 'dashboard_group_id_to_skip'
 
 

--- a/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -21,7 +21,7 @@ from databuilder.transformer.timestamp_string_to_epoch import FIELD_NAME, Timest
 LOGGER = logging.getLogger(__name__)
 
 # a list of space tokens that we want to skip indexing
-DASHBOARD_GROUP_ID_TO_SKIP = 'dashboard_group_id_to_skip'
+DASHBOARD_GROUP_IDS_TO_SKIP = 'dashboard_group_ids_to_skip'
 
 
 class ModeDashboardExtractor(Extractor):
@@ -41,7 +41,7 @@ class ModeDashboardExtractor(Extractor):
     def init(self, conf: ConfigTree) -> None:
         self._conf = conf
 
-        self.dashboard_group_id_to_skip = self._conf.get_list(DASHBOARD_GROUP_ID_TO_SKIP, [])
+        self.dashboard_group_ids_to_skip = self._conf.get_list(DASHBOARD_GROUP_IDS_TO_SKIP, [])
 
         restapi_query = self._build_restapi_query()
         self._extractor = ModeDashboardUtils.create_mode_rest_api_extractor(restapi_query=restapi_query,
@@ -85,7 +85,7 @@ class ModeDashboardExtractor(Extractor):
         record = self._extractor.extract()
 
         # determine whether we want to skip these records
-        while record and record.get('dashboard_group_id') in self.dashboard_group_id_to_skip:
+        while record and record.get('dashboard_group_id') in self.dashboard_group_ids_to_skip:
             record = self._extractor.extract()
 
         if not record:

--- a/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_extractor.py
+++ b/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_extractor.py
@@ -16,6 +16,7 @@ class TestModeDashboardExtractor(unittest.TestCase):
         config = ConfigFactory.from_dict({
             'extractor.mode_dashboard.organization': 'amundsen',
             'extractor.mode_dashboard.mode_bearer_token': 'amundsen_bearer_token',
+            'extractor.mode_dashboard.dashboard_group_id_to_skip': ['ggg_to_skip'],
         })
         self.config = config
 
@@ -57,6 +58,67 @@ class TestModeDashboardExtractor(unittest.TestCase):
             self.assertEqual(record.created_timestamp, 1612560009)
             self.assertEqual(record.dashboard_group_url, 'https://app.mode.com/amundsen/spaces/ggg')
             self.assertEqual(record.dashboard_url, 'https://app.mode.com/amundsen/reports/ddd')
+
+    def test_extractor_skip_record(self) -> None:
+        extractor = ModeDashboardExtractor()
+        extractor.init(Scoped.get_scoped_conf(conf=self.config, scope=extractor.get_scope()))
+
+        with patch('databuilder.rest_api.rest_api_query.RestApiQuery._send_request') as mock_request, \
+                patch('databuilder.rest_api.query_merger.QueryMerger._compute_query_result') as mock_query_result:
+            mock_request.return_value.json.return_value = {
+                'reports': [
+                    {
+                        'token': 'ddd',
+                        'name': 'dashboard name',
+                        'description': 'dashboard description',
+                        'created_at': '2021-02-05T21:20:09.019Z',
+                        'space_token': 'ggg',
+                    },
+                    {
+                        'token': 'ddd_2',
+                        'name': 'dashboard name 2',
+                        'description': 'dashboard description 2',
+                        'created_at': '2021-02-05T21:20:09.019Z',
+                        'space_token': 'ggg_to_skip',
+                    },
+                    {
+                        'token': 'ddd_3',
+                        'name': 'dashboard name 3',
+                        'description': 'dashboard description 3',
+                        'created_at': '2021-02-05T21:20:09.019Z',
+                        'space_token': 'ggg_not_skip',
+                    },
+                ]
+            }
+            mock_query_result.return_value = {
+                'ggg': {
+                    'dashboard_group_id': 'ggg',
+                    'dashboard_group': 'dashboard group name',
+                    'dashboard_group_description': 'dashboard group description',
+                },
+                'ggg_to_skip': {
+                    'dashboard_group_id': 'ggg_to_skip',
+                    'dashboard_group': 'dashboard group name to skip',
+                    'dashboard_group_description': 'dashboard group description to skip',
+                },
+                'ggg_not_skip': {
+                    'dashboard_group_id': 'ggg_not_skip',
+                    'dashboard_group': 'dashboard group name not skip',
+                    'dashboard_group_description': 'dashboard group description not skip',
+                }
+            }
+
+            record = next(extractor.extract())
+            self.assertIsInstance(record, DashboardMetadata)
+            self.assertEqual(record.dashboard_group_id, 'ggg')
+            self.assertEqual(record.dashboard_id, 'ddd')
+
+            record = next(extractor.extract())
+            self.assertIsInstance(record, DashboardMetadata)
+            self.assertEqual(record.dashboard_group_id, 'ggg_not_skip')
+            self.assertEqual(record.dashboard_id, 'ddd_3')
+
+            self.assertIsNone(extractor.extract())
 
 
 if __name__ == '__main__':

--- a/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_extractor.py
+++ b/databuilder/tests/unit/extractor/dashboard/mode_analytics/test_mode_dashboard_extractor.py
@@ -16,7 +16,7 @@ class TestModeDashboardExtractor(unittest.TestCase):
         config = ConfigFactory.from_dict({
             'extractor.mode_dashboard.organization': 'amundsen',
             'extractor.mode_dashboard.mode_bearer_token': 'amundsen_bearer_token',
-            'extractor.mode_dashboard.dashboard_group_id_to_skip': ['ggg_to_skip'],
+            'extractor.mode_dashboard.dashboard_group_ids_to_skip': ['ggg_to_skip'],
         })
         self.config = config
 


### PR DESCRIPTION
### Summary of Changes

Provide a config in ModeDashboardExtractor that we can skip some spaces we don't want to index.

### Tests

Added test for this functionality

### Documentation

Described it in the comment and also updated the README

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
