### PR TITLE
fix: pytest setup.cfg section fix

### DIFF
--- a/search/setup.cfg
+++ b/search/setup.cfg
@@ -9,7 +9,7 @@ ignore = I201
 max-line-length = 120
 
 # modify --cov-fail-under parameter after adding unit tests
-[pytest]
+[tool:pytest]
 addopts = --cov=search_service --cov-fail-under=0 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
 
 [coverage:run]


### PR DESCRIPTION
### Summary of Changes

In Search service `setup.cfg` section changed from `[pytest]` to `[tool:pytest]`. Linked to issue #1143 

### Tests

No tests modified. Install latest `pytest` and run.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
