### PR TITLE
feat: Common query models

### DIFF
--- a/common/amundsen_common/models/table.py
+++ b/common/amundsen_common/models/table.py
@@ -8,7 +8,6 @@ import attr
 from amundsen_common.models.user import User
 from amundsen_common.models.badge import Badge
 from amundsen_common.models.tag import Tag
-
 from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 

--- a/common/amundsen_common/models/table.py
+++ b/common/amundsen_common/models/table.py
@@ -8,6 +8,7 @@ import attr
 from amundsen_common.models.user import User
 from amundsen_common.models.badge import Badge
 from amundsen_common.models.tag import Tag
+
 from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 
@@ -126,6 +127,48 @@ class ProgrammaticDescriptionSchema(AttrsSchema):
 
 
 @attr.s(auto_attribs=True, kw_only=True)
+class TableSummary:
+    database: str = attr.ib()
+    cluster: str = attr.ib()
+    schema: str = attr.ib()
+    name: str = attr.ib()
+    description: Optional[str] = attr.ib(default=None)
+    schema_description: Optional[str] = attr.ib(default=None)
+
+
+class TableSummarySchema(AttrsSchema):
+    class Meta:
+        target = TableSummary
+        register_as_scheme = True
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class SqlJoin:
+    column: str
+    joined_on_table: TableSummary
+    joined_on_column: str
+    join_type: str
+    join_sql: str
+
+
+class SqlJoinSchema(AttrsSchema):
+    class Meta:
+        target = SqlJoin
+        register_as_scheme = True
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class SqlWnere:
+    where_clause: str
+
+
+class SqlWhereSchema(AttrsSchema):
+    class Meta:
+        target = SqlWnere
+        register_as_scheme = True
+
+
+@attr.s(auto_attribs=True, kw_only=True)
 class Table:
     database: str
     cluster: str
@@ -145,25 +188,11 @@ class Table:
     source: Optional[Source] = None
     is_view: Optional[bool] = attr.ib(default=None, converter=default_if_none)
     programmatic_descriptions: List[ProgrammaticDescription] = []
+    common_joins: Optional[List[SqlJoin]] = None
+    common_filters: Optional[List[SqlWnere]] = None
 
 
 class TableSchema(AttrsSchema):
     class Meta:
         target = Table
-        register_as_scheme = True
-
-
-@attr.s(auto_attribs=True, kw_only=True)
-class TableSummary:
-    database: str = attr.ib()
-    cluster: str = attr.ib()
-    schema: str = attr.ib()
-    name: str = attr.ib()
-    description: Optional[str] = attr.ib(default=None)
-    schema_description: Optional[str] = attr.ib(default=None)
-
-
-class TableSummarySchema(AttrsSchema):
-    class Meta:
-        target = TableSummary
         register_as_scheme = True

--- a/common/setup.py
+++ b/common/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '0.11.0'
+__version__ = '0.12.0'
 
 setup(
     name='amundsen-common',


### PR DESCRIPTION

### Summary of Changes

This change introduces the common models that will be used by the frontend and metadata services per the [rfc](https://github.com/amundsen-io/rfcs/pull/37) to index query compositions.

Two new models are introduced:
- SqlJoin
- SqlWhere

In addition, the `TableSummary` was moved higher up in the file to enable it to be reused. 

### Tests

N/A - changes are limited to making schema models

### Documentation
