### PR TITLE
feat: Configuration option to init custom routes

### DIFF
--- a/metadata/metadata_service/__init__.py
+++ b/metadata/metadata_service/__init__.py
@@ -95,6 +95,11 @@ def create_app(*, config_module_class: str) -> Flask:
     logging.info('Created app with config name {}'.format(config_module_class))
     logging.info('Using backend {}'.format(app.config.get('PROXY_CLIENT')))
 
+    # Initialize custom extensions and routes
+    init_custom_ext_routes = app.config.get('INIT_CUSTOM_EXT_AND_ROUTES')
+    if init_custom_ext_routes:
+        init_custom_ext_routes(app)
+
     api_bp = Blueprint('api', __name__)
     api_bp.add_url_rule('/healthcheck', 'healthcheck', healthcheck)
 

--- a/metadata/metadata_service/config.py
+++ b/metadata/metadata_service/config.py
@@ -3,11 +3,13 @@
 
 import distutils.util
 import os
+
 from typing import Dict, List, Optional, Set, Callable  # noqa: F401
 
 import boto3
 from amundsen_gremlin.config import LocalGremlinConfig
 from flask import Flask  # noqa: F401
+
 from metadata_service.entity.badge import Badge
 
 # PROXY configuration keys

--- a/metadata/metadata_service/config.py
+++ b/metadata/metadata_service/config.py
@@ -3,11 +3,11 @@
 
 import distutils.util
 import os
-from typing import Dict, List, Optional, Set  # noqa: F401
+from typing import Dict, List, Optional, Set, Callable  # noqa: F401
 
 import boto3
 from amundsen_gremlin.config import LocalGremlinConfig
-
+from flask import Flask  # noqa: F401
 from metadata_service.entity.badge import Badge
 
 # PROXY configuration keys
@@ -62,9 +62,9 @@ class Config:
 
     SWAGGER_ENABLED = os.environ.get('SWAGGER_ENABLED', False)
 
-    USER_DETAIL_METHOD = None   # type: Optional[function]
+    USER_DETAIL_METHOD = None  # type: Optional[function]
 
-    RESOURCE_REPORT_CLIENT = None   # type: Optional[function]
+    RESOURCE_REPORT_CLIENT = None  # type: Optional[function]
 
     # On User detail method, these keys will be added into amundsen_common.models.user.User.other_key_values
     USER_OTHER_KEYS = {'mode_user_id'}  # type: Set[str]
@@ -78,6 +78,9 @@ class Config:
     # Custom kwargs that will be passed to proxy client. Can be used to fine-tune parameters like timeout
     # or num of retries
     PROXY_CLIENT_KWARGS: Dict = dict()
+
+    # Initialize custom flask extensions and routes
+    INIT_CUSTOM_EXT_AND_ROUTES = None  # type: Callable[[Flask], None]
 
     SWAGGER_TEMPLATE_PATH = os.path.join('api', 'swagger_doc', 'template.yml')
     SWAGGER = {
@@ -124,7 +127,7 @@ class NeptuneConfig(LocalGremlinConfig, LocalConfig):
 
     # PROXY_HOST FORMAT: wss://<NEPTUNE_URL>:<NEPTUNE_PORT>/gremlin
     PROXY_HOST = os.environ.get('PROXY_HOST', 'localhost')
-    PROXY_PORT = None   # type: ignore
+    PROXY_PORT = None  # type: ignore
 
     PROXY_CLIENT = PROXY_CLIENTS['NEPTUNE']
     PROXY_PASSWORD = boto3.session.Session(region_name=os.environ.get('AWS_REGION', 'us-east-1'))

--- a/metadata/metadata_service/config.py
+++ b/metadata/metadata_service/config.py
@@ -3,8 +3,7 @@
 
 import distutils.util
 import os
-
-from typing import Dict, List, Optional, Set, Callable  # noqa: F401
+from typing import Callable, Dict, List, Optional, Set  # noqa: F401
 
 import boto3
 from amundsen_gremlin.config import LocalGremlinConfig


### PR DESCRIPTION
Signed-off-by: verdan <verdan.mahmood@gmail.com>


### Summary of Changes

Adds a new metadata configuration to initialize custom extensions and routes in the metadata package. This is same as this in frontend: https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/config.py#L65

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
