### PR TITLE
docs: Fix doc links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Use the button in our [header](https://github.com/amundsen-io/amundsen#readme) t
 
 ## Getting Started
 
-Please visit the Amundsen installation documentation for a [quick start](./installation/) to bootstrap a default version of Amundsen with dummy data.
+Please visit the Amundsen installation documentation for a [quick start](./amundsen/docs/installation.md) to bootstrap a default version of Amundsen with dummy data.
 
 ## Architecture Overview
 
-Please visit [Architecture](./architecture/) for Amundsen architecture overview.
+Please visit [Architecture](./amundsen/docs/architecture.md) for Amundsen architecture overview.
 
 ## Supported Entities
 
@@ -149,11 +149,11 @@ Amundsen can also connect to any database that provides `dbapi` or `sql_alchemy`
 
 ## Installation
 
-Please visit [Installation guideline](./installation) on how to install Amundsen.
+Please visit [Installation guideline](./amundsen/docs/installation.md) on how to install Amundsen.
 
 ## Roadmap
 
-Please visit [Roadmap](./roadmap/) if you are interested in Amundsen upcoming roadmap items.
+Please visit [Roadmap](./amundsen/docs/roadmap.md) if you are interested in Amundsen upcoming roadmap items.
 
 ## Blog Posts and Interviews
 


### PR DESCRIPTION

### Summary of Changes

Just a quick driveby to fix a few doc links that still point to old locations.

### Tests

None needed - docs only.

### Documentation

README.MD

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
