### PR TITLE
fix: Helm service versions moved up to latest ones

### DIFF
--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -54,7 +54,7 @@ search:
   # - name: "image-pull-secret"
 
   # search.imageTag -- The image tag of the search container.
-  imageTag: 2.4.0
+  imageTag: 2.5.1
 
   # search.replicas -- How many replicas of the search service to run.
   replicas: 1
@@ -102,7 +102,7 @@ metadata:
   # - name: "image-pull-secret"
 
   # metadata.imageTag -- The image tag of the metadata container.
-  imageTag: 2.5.5
+  imageTag: 3.5.0
 
   # metadata.replicas -- How many replicas of the metadata service to run.
   replicas: 1
@@ -147,7 +147,7 @@ frontEnd:
   # - name: "image-pull-secret"
 
   # frontEnd.imageTag -- The image tag of the frontend container.
-  imageTag: 2.3.0
+  imageTag: 3.7.0
 
   # frontEnd.servicePort -- The port the frontend service will be exposed on via the loadbalancer.
   servicePort: 80


### PR DESCRIPTION
### Summary of Changes

It addresses the issue #1069, that with current versions of search and frontend service, the tag search update doesn't work correctly. On our current setup I run this set of versions together and it works fine between with each other, including that the issue #1069 is fixed.

### Tests
1. Add tag manually in frontend
2. Search for this tag using advanced search

### Documentation
N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
