### PR TITLE
Docs: add information about default ES indexes to search Readme

### DIFF
--- a/search/README.md
+++ b/search/README.md
@@ -7,6 +7,11 @@
 
 Amundsen Search service serves a Restful API and is responsible for searching metadata. The service leverages [Elasticsearch](https://www.elastic.co/products/elasticsearch "Elasticsearch") for most of it's search capabilites.
 
+By default, it creates in total 3 indexes:
+* table_search_index
+* user_search_index
+* dashboard_search_index
+
 For information about Amundsen and our other services, refer to this [README.md](./../README.md). Please also see our instructions for a [quick start](./../docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](./../docs/architecture.md#architecture).
 
 ## Requirements


### PR DESCRIPTION
docs: add information about default ES indexes to search Readme 