### PR TITLE
fix: Allow support for Jira cloud (preserves backward compatibility)

### DIFF
--- a/frontend/amundsen_application/config.py
+++ b/frontend/amundsen_application/config.py
@@ -90,6 +90,8 @@ class Config:
     ISSUE_TRACKER_CLIENT_ENABLED = False  # type: bool
     # Max issues to display at a time
     ISSUE_TRACKER_MAX_RESULTS = None  # type: int
+    # Override issue type ID for cloud Jira deployments
+    ISSUE_TRACKER_ISSUE_TYPE_ID = None
 
     # Programmatic Description configuration. Please see docs/flask_config.md
     PROGRAMMATIC_DISPLAY = None  # type: Optional[Dict]

--- a/frontend/docs/flask_config.md
+++ b/frontend/docs/flask_config.md
@@ -65,7 +65,7 @@ Here are the settings and what they should be set to
     ISSUE_TRACKER_CLIENT = None  # type: str (Fully qualified class name and path)
     ISSUE_TRACKER_CLIENT_ENABLED = False  # type: bool (Enabling the feature, must be set to True)
     ISSUE_TRACKER_MAX_RESULTS = None  # type: int (Max issues to display at a time)
-
+    ISSUE_TRACKER_ISSUE_TYPE_ID = None # type: int (Jira only: Override default issue tracker ID whenever needed for cloud/hosted deployments)
 ```
 ## Programmatic Descriptions
 Amundsen supports configuring other mark down supported non-editable description boxes on the table page.
@@ -84,7 +84,7 @@ Programmatic descriptions are referred to by a "description source" which is a u
 In the UI, they will appear on the table page under structured metadata.
 
 In config.py you can then configure the descriptions to have a custom order, as well as whether or not they should exist in the left column or right column.
-```    
+```
 PROGRAMMATIC_DISPLAY = {
     'RIGHT': {
       "test3" : {},

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -75,7 +75,7 @@ amundsen-common==0.11.0
 flask-restful==0.3.8
 
 # SDK for JIRA
-jira==2.0.0
+jira==3.0.1
 
 # SDK for Asana
 asana==0.10.3
@@ -87,4 +87,3 @@ retrying>=1.3.3,<2.0
 # License: Apache 2.0
 # Upstream url: https://pypi.org/project/dataclasses/
 dataclasses==0.8; python_version < '3.7'
-


### PR DESCRIPTION
Re:  #1206 

Implements issue creation on Jira cloud instances addressing two problems:

- issue type id on Jira cloud is not fixed to 1, allow customization (invalid issue type causes rejection by the api)
- reporter needs to be adjusted from `{'name': 'name of user'}` to `{'accountId': 'atlassian account id'}`


### Summary of Changes

Introduced a new setting allowing to override issue type ID.
Used the jira client library deployment type detection to branch out on reporter payload.
Bumped jira library version to 3.x tree. (only breaking change was 2.7 support removal)

### Tests

N/A - internal to jira_client

### Documentation

Listed the ability to override Jira cloud issue type id's in the relevant documentation section. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
