### PR TITLE
fix: Fix db key constraints

### DIFF
--- a/databuilder/databuilder/models/schema/schema_constant.py
+++ b/databuilder/databuilder/models/schema/schema_constant.py
@@ -11,4 +11,4 @@ SCHEMA_REVERSE_RELATION_TYPE = 'SCHEMA_OF'
 DATABASE_SCHEMA_KEY_FORMAT = '{db}://{cluster}.{schema}'
 
 # pattern used to match a schema key, e.g., hive://gold.test_schema
-SCHEMA_KEY_PATTERN_REGEX = '([a-z]+://[a-zA-Z0-9_-]+).[a-zA-Z0-9_.-]+'
+SCHEMA_KEY_PATTERN_REGEX = '([a-zA-Z0-9_]+://[a-zA-Z0-9_-]+).[a-zA-Z0-9_.-]+'

--- a/databuilder/tests/unit/models/schema/test_schema.py
+++ b/databuilder/tests/unit/models/schema/test_schema.py
@@ -208,3 +208,15 @@ class TestSchemaDescription(unittest.TestCase):
                                                                   'description_source': 'bar',
                                                                   'description': 'foo',
                                                                   'schema_rk': 'db://cluster.schema'})
+
+    def test_get_cluster_key(self) -> None:
+        schema_key = 'a123b_staging://cluster.schema'
+        schema_name = 'schema_name'
+        schema = SchemaModel(schema_key=schema_key, schema=schema_name)
+        assert schema._get_cluster_key(schema_key) == 'a123b_staging://cluster'
+
+        failed_schema_key_1 = 'a123b.staging://cluster.schema'
+        self.assertRaises(Exception, SchemaModel, schema_key=failed_schema_key_1, schema_name=schema_name)
+
+        failed_schema_key_2 = 'a123b-staging://cluster.schema'
+        self.assertRaises(Exception, SchemaModel, schema_key=failed_schema_key_2, schema_name=schema_name)


### PR DESCRIPTION
### Summary of Changes

We at Brex have databases named with numbers and underscores in it. There were exceptions when we tried to use Badges, as Badges checked key format https://github.com/amundsen-io/amundsen/blob/54f5ed6bb4dbcb0ed59182e485bd109374d549a9/databuilder/databuilder/models/badge.py#L52-#L67

Gladly, those checks haven been removed recently https://github.com/amundsen-io/amundsen/commit/aa67a0c14d191501b23ea488f1a4b9d4bbe20230#diff-1eb09b5d29f66bcea3cd4a4a23befe3c93d8e577a33de1e9d903f3fb9c1faffdL52

This PR is to change another place that checks a key should match a pattern.

### Tests

Added unit tests

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
