### PR TITLE
import multiprocessing's TimeoutError explicitly

### DIFF
--- a/databuilder/databuilder/extractor/hive_table_last_updated_extractor.py
+++ b/databuilder/databuilder/extractor/hive_table_last_updated_extractor.py
@@ -5,6 +5,7 @@ import logging
 import time
 from datetime import datetime
 from functools import wraps
+from multiprocessing.context import TimeoutError
 from multiprocessing.pool import ThreadPool
 from typing import (
     Any, Iterator, List, Union,


### PR DESCRIPTION
The catch on L277 is actually looking for Python's builtin `TimeoutError`, but `multiprocessing.context.TimeoutError`s are still thrown from L274.