### PR TITLE
style: Adding back focus on table detail button

### DIFF
--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -123,11 +123,6 @@ $row-bottom-border-color: $gray10;
   &:hover svg use {
     fill: $gray60;
   }
-
-  // TODO: Fix this so it is accessible
-  &:focus {
-    outline: none;
-  }
 }
 
 // Loading State


### PR DESCRIPTION
making it accessible so focus does appear on the expand and collapse buttons

### Summary of Changes

Removed explicit rule that hide the focus indicator

addresses issue: https://github.com/amundsen-io/amundsen/issues/1231

### Tests

no test necessary as just a style change