### PR TITLE
fix: bw-incompatible update to user elasticsearch index

### DIFF
--- a/common/amundsen_common/models/index_map.py
+++ b/common/amundsen_common/models/index_map.py
@@ -101,6 +101,10 @@ TABLE_INDEX_MAP = textwrap.dedent(
             },
             "unique_usage": {
               "type": "long"
+            },
+            "programmatic_descriptions": {
+              "type": "text",
+              "analyzer": "simple"
             }
           }
         }
@@ -195,57 +199,60 @@ DASHBOARD_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
     """
 )
 
-USER_INDEX_MAP = textwrap.dedent("""
-{
-"mappings":{
-    "user":{
-      "properties": {
-        "email": {
-          "type":"text",
-          "analyzer": "simple",
-          "fields": {
-            "raw": {
-              "type": "keyword"
+USER_INDEX_MAP = textwrap.dedent(
+    """
+    {
+    "mappings":{
+        "user":{
+          "properties": {
+            "email": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "first_name": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "last_name": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "full_name": {
+              "type":"text",
+              "analyzer": "simple",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "total_read":{
+              "type": "long"
+            },
+            "total_own": {
+              "type": "long"
+            },
+            "total_follow": {
+              "type": "long"
             }
           }
-        },
-        "first_name": {
-          "type":"text",
-          "analyzer": "simple",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "last_name": {
-          "type":"text",
-          "analyzer": "simple",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "name": {
-          "type":"text",
-          "analyzer": "simple",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "total_read":{
-          "type": "long"
-        },
-        "total_own": {
-          "type": "long"
-        },
-        "total_follow": {
-          "type": "long"
         }
       }
     }
-  }
-}""")
+    """
+)

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-common.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
Signed-off-by: Dmitriy Kunitskiy <dkunitskiy@lyft.com>

### Summary of Changes

This change fixes the discrepancy between the user ES index located in [common](https://github.com/amundsen-io/amundsen/blob/main/common/amundsen_common/models/index_map.py#L230) vs [databuilder](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/publisher/elasticsearch_constants.py#L224). The discrepancy is in one field: `full_name` vs `name`.

This is being done in preparation for deleting the `elasticsearch_constants.py` databuilder file and importing these mappings from common instead. 

The same cleanup was performed [here](https://github.com/amundsen-io/amundsendatabuilder/pull/385) but had to be [reverted](https://github.com/amundsen-io/amundsendatabuilder/pull/389) because of some marshmallow thing that's no longer relevant. 

Why this change is safe-ish:
1. the [ES document](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/models/user_elasticsearch_document.py#L31) for user has `full_name`.
2. search service uses `full_name`: [model](https://github.com/amundsen-io/amundsen/blob/main/search/search_service/models/user.py#L31), [proxy](https://github.com/amundsen-io/amundsen/blob/main/search/search_service/proxy/elasticsearch.py#L461)
3. only usage I could find of the old `amundsen-common`'s index is [here](https://github.com/amundsen-io/amundsen/blob/main/search/search_service/proxy/elasticsearch.py#L655) in the ES proxy. This function is only used to create an index when an index is not found. But the ES publisher does create an index as its first step so in theory this function should be mostly unused.

In other words, data should be loaded using `full_name` and searched using `full_name`. The fact that an index exists in another place with `name` instead of `full_name` just means people who've been using it were probably having semi-broken user search.

### Notice to community

Backwards incompatible change alert!
We're deleting databuilder's [elasticsearch_constants.py](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/publisher/elasticsearch_constants.py) file in favor of amundsen-common's [index_map.py](https://github.com/amundsen-io/amundsen/blob/main/common/amundsen_common/models/index_map.py). If you were using databuilder's constants, please switch to common. 
