### PR TITLE
fix: bump databuilder version

### DIFF
--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '4.5.3'
+__version__ = '5.0.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
Forgot to bump version here: https://github.com/amundsen-io/amundsen/pull/1235

Proposing a major bump given the bw-incompatibility in above PR. 