### PR TITLE
fix: change badge name and category to lower case

### DIFF
--- a/databuilder/databuilder/models/badge.py
+++ b/databuilder/databuilder/models/badge.py
@@ -16,8 +16,12 @@ from databuilder.models.table_serializable import TableSerializable
 
 class Badge:
     def __init__(self, name: str, category: str):
-        self.name = name
-        self.category = category
+        # Amundsen UI always formats badge display with first letter capitalized while other letters are lowercase.
+        # Clicking table badges in UI always results in searching lower cases badges
+        # https://github.com/amundsen-io/amundsen/blob/6ec9b398634264e52089bb9e1b7d76a6fb6a35a4/frontend/amundsen_application/static/js/components/BadgeList/index.tsx#L56
+        # If badges stored in neo4j are not lowercase, they won't be searchable in UI.
+        self.name = name.lower()
+        self.category = category.lower()
 
     def __repr__(self) -> str:
         return f'Badge({self.name!r}, {self.category!r})'

--- a/databuilder/tests/unit/models/test_badge.py
+++ b/databuilder/tests/unit/models/test_badge.py
@@ -35,6 +35,11 @@ class TestBadge(unittest.TestCase):
                                           start_key='hive://default.base/test/ds',
                                           badges=[badge1, badge2])
 
+    def test_badge_name_category_are_lower_cases(self):
+        uppercase_badge = Badge('BadGe3', 'COLUMN_3')
+        self.assertEqual(uppercase_badge.name, 'badge3')
+        self.assertEqual(uppercase_badge.category, 'column_3')
+
     def test_get_badge_key(self) -> None:
         badge_key = self.badge_metada.get_badge_key(badge1.name)
         self.assertEqual(badge_key, badge1.name)

--- a/databuilder/tests/unit/models/test_badge.py
+++ b/databuilder/tests/unit/models/test_badge.py
@@ -35,7 +35,7 @@ class TestBadge(unittest.TestCase):
                                           start_key='hive://default.base/test/ds',
                                           badges=[badge1, badge2])
 
-    def test_badge_name_category_are_lower_cases(self):
+    def test_badge_name_category_are_lower_cases(self) -> None:
         uppercase_badge = Badge('BadGe3', 'COLUMN_3')
         self.assertEqual(uppercase_badge.name, 'badge3')
         self.assertEqual(uppercase_badge.category, 'column_3')


### PR DESCRIPTION
### Summary of Changes

Change badge name and category to lower case so badges are searchable.

Amundsen UI by default formats badge display with first letter capitalized while other letters are lowercase.
https://github.com/amundsen-io/amundsen/blob/6ec9b398634264e52089bb9e1b7d76a6fb6a35a4/frontend/amundsen_application/static/js/config/config-utils.ts#L128

Clicking table badges in UI always results in searching lower cases badges.
https://github.com/amundsen-io/amundsen/blob/6ec9b398634264e52089bb9e1b7d76a6fb6a35a4/frontend/amundsen_application/static/js/components/BadgeList/index.tsx#L56

If badges stored in neo4j are not lowercase, they won't be searchable in UI.

### Tests

Add a unit test 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
