### PR TITLE
feat: Adds dynamic table notices from Atlas

### DIFF
--- a/common/amundsen_common/models/table.py
+++ b/common/amundsen_common/models/table.py
@@ -107,6 +107,18 @@ class ResourceReportSchema(AttrsSchema):
         register_as_scheme = True
 
 
+@attr.s(auto_attribs=True, kw_only=True)
+class Notice:
+    severity: str
+    message_html: str
+
+
+class NoticeSchema(AttrsSchema):
+    class Meta:
+        target = Notice
+        register_as_scheme = True
+
+
 # this is a temporary hack to satisfy mypy. Once https://github.com/python/mypy/issues/6136 is resolved, use
 # `attr.converters.default_if_none(default=False)`
 def default_if_none(arg: Optional[bool]) -> bool:
@@ -183,6 +195,7 @@ class Table:
     watermarks: List[Watermark] = []
     table_writer: Optional[Application] = None
     resource_reports: Optional[List[ResourceReport]] = None
+    notices: Optional[List[Notice]] = None
     last_updated_timestamp: Optional[int] = None
     source: Optional[Source] = None
     is_view: Optional[bool] = attr.ib(default=None, converter=default_if_none)

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -151,7 +151,7 @@ exports[`eslint`] = {
     "js/components/Inputs/CheckBoxItem/index.tsx:360935175": [
       [26, 6, 163, "A control must be associated with a text label.", "3374264857"]
     ],
-    "js/components/OwnerEditor/index.spec.tsx:871220739": [
+    "js/components/OwnerEditor/index.spec.tsx:3522945449": [
       [11, 0, 41, "\`./constants\` import should occur before import of \`.\`", "1965203596"]
     ],
     "js/components/OwnerEditor/index.tsx:2188228583": [
@@ -231,7 +231,7 @@ exports[`eslint`] = {
     "js/components/ResourceListItem/DashboardListItem/index.tsx:2194588229": [
       [17, 0, 41, "\`../types\` import should occur before import of \`./constants\`", "2620565544"]
     ],
-    "js/components/ResourceListItem/FeatureListItem/index.spec.tsx:2508428579": [
+    "js/components/ResourceListItem/FeatureListItem/index.spec.tsx:1582455272": [
       [45, 6, 25, "Use object destructuring.", "354229464"],
       [46, 6, 29, "Use object destructuring.", "2645724888"]
     ],
@@ -1046,11 +1046,11 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:2009672874": [
-      [135, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [145, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [158, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
-      [238, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
+    "js/pages/TableDetailPage/index.tsx:955127622": [
+      [155, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [165, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [178, 22, 12, "\'getTableData\' is already declared in the upper scope.", "3938384029"],
+      [258, 6, 28, "\'openRequestDescriptionDialog\' is already declared in the upper scope.", "4102713454"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/FeatureListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/FeatureListItem/index.tsx
@@ -18,9 +18,8 @@ export interface FeatureListItemProps {
   logging: LoggingParams;
 }
 
-const getLink = (feature: FeatureResource, logging: LoggingParams) => {
-  return `/feature/${feature.key}?index=${logging.index}&source=${logging.source}`;
-};
+const getLink = (feature: FeatureResource, logging: LoggingParams) =>
+  `/feature/${feature.key}?index=${logging.index}&source=${logging.source}`;
 
 const generateResourceIconClass = (
   featureId: string,

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -8,6 +8,7 @@ import {
   FilterConfig,
   LinkConfig,
   NoticeType,
+  NoticeSeverity,
 } from './config-types';
 import { ResourceType } from '../interfaces';
 
@@ -83,6 +84,21 @@ export function getResourceNotices(
   return false;
 }
 
+/**
+ * Sorts notices: descending severity, ascending messageHtml
+ */
+export function sortNotices(notices: NoticeType[]): NoticeType[] {
+  const severityOrd = {
+    [NoticeSeverity.ALERT]: 0,
+    [NoticeSeverity.WARNING]: 1,
+    [NoticeSeverity.INFO]: 2,
+  };
+
+  return notices.sort((n1, n2) => {
+    const sevCmp = severityOrd[n1.severity] - severityOrd[n2.severity];
+    return sevCmp === 0 ? n1.messageHtml.localeCompare(n2.messageHtml) : sevCmp;
+  });
+}
 /**
  * Returns the displayName for the given resourceType
  */

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -341,6 +341,7 @@ describe('generateExploreUrl', () => {
     table_readers: [],
     source: { source: '', source_type: '' },
     resource_reports: [],
+    notices: [],
     watermarks: [],
     programmatic_descriptions: {},
   };
@@ -463,6 +464,7 @@ describe('getColumnLineageLink', () => {
       table_readers: [],
       source: { source: '', source_type: '' },
       resource_reports: [],
+      notices: [],
       watermarks: [],
       programmatic_descriptions: {},
     };

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -56,6 +56,7 @@ export const initialTableDataState: TableMetadata = {
   table_readers: [],
   source: { source: '', source_type: '' },
   resource_reports: [],
+  notices: [],
   watermarks: [],
   programmatic_descriptions: {},
 };

--- a/frontend/amundsen_application/static/js/fixtures/globalState.ts
+++ b/frontend/amundsen_application/static/js/fixtures/globalState.ts
@@ -209,6 +209,7 @@ const globalState: GlobalState = {
       table_readers: [],
       source: { source: '', source_type: '' },
       resource_reports: [],
+      notices: [],
       watermarks: [],
       programmatic_descriptions: {},
     },

--- a/frontend/amundsen_application/static/js/fixtures/metadata/table.ts
+++ b/frontend/amundsen_application/static/js/fixtures/metadata/table.ts
@@ -120,6 +120,7 @@ export const tableMetadata: TableMetadata = {
     source_type: 'github',
   },
   resource_reports: [{ name: 'Test report', url: 'http://localhost' }],
+  notices: [{ severity: 'info', message_html: 'Test' }],
   table_readers: [
     {
       read_count: 1735,

--- a/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -92,6 +92,11 @@ export interface ResourceReport {
   url: string;
 }
 
+export interface Notice {
+  severity: string;
+  message_html: string;
+}
+
 export interface TableMetadata {
   badges: Badge[];
   cluster: string;
@@ -109,6 +114,7 @@ export interface TableMetadata {
   table_readers: TableReader[];
   source: TableSource;
   resource_reports: ResourceReport[];
+  notices: Notice[];
   watermarks: Watermark[];
   programmatic_descriptions: TableProgrammaticDescriptions;
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ExploreButton/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ExploreButton/index.spec.tsx
@@ -53,6 +53,7 @@ describe('ExploreButton', () => {
           source_type: '',
         },
         resource_reports: [],
+        notices: [],
         watermarks: [],
         programmatic_descriptions: {},
         ...tableDataOverrides,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -18,6 +18,7 @@ import { GetTableLineageRequest } from 'ducks/lineage/types';
 import { OpenRequestAction } from 'ducks/notification/types';
 import { UpdateSearchStateRequest } from 'ducks/search/types';
 
+import { NoticeSeverity } from 'config/config-types';
 import {
   getDescriptionSourceDisplayName,
   getMaxLength,
@@ -28,6 +29,7 @@ import {
   issueTrackingEnabled,
   isTableListLineageEnabled,
   notificationsEnabled,
+  sortNotices,
 } from 'config/config-utils';
 
 import BadgeList from 'features/BadgeList';
@@ -351,6 +353,13 @@ export class TableDetail extends React.Component<
         ResourceType.table,
         `${data.cluster}.${data.database}.${data.schema}.${data.name}`
       );
+      const dataNotices = data.notices.map((n) => ({
+        severity: n.severity as NoticeSeverity,
+        messageHtml: n.message_html,
+      }));
+      const notices = sortNotices(
+        tableNotice ? dataNotices.concat([tableNotice]) : dataNotices
+      );
 
       innerContent = (
         <div className="resource-detail-layout table-detail">
@@ -401,12 +410,12 @@ export class TableDetail extends React.Component<
           </header>
           <div className="column-layout-1">
             <aside className="left-panel">
-              {!!tableNotice && (
+              {notices.map((notice) => (
                 <Alert
-                  message={tableNotice.messageHtml}
-                  severity={tableNotice.severity}
+                  message={notice.messageHtml}
+                  severity={notice.severity}
                 />
-              )}
+              ))}
               <EditableSection
                 title={Constants.DESCRIPTION_TITLE}
                 readOnly={!data.is_editable}

--- a/metadata/tests/unit/proxy/test_atlas_proxy.py
+++ b/metadata/tests/unit/proxy/test_atlas_proxy.py
@@ -151,6 +151,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
                          description=ent_attrs['description'],
                          owners=[User(email=ent_attrs['owner'])],
                          resource_reports=[],
+                         notices=[],
                          last_updated_timestamp=int(str(self.entity1['updateTime'])[:10]),
                          columns=[exp_col] * self.active_columns,
                          watermarks=[],


### PR DESCRIPTION
### Summary of Changes

In follow up to [#957](https://github.com/amundsen-io/amundsenfrontendlibrary/pull/957) functionality of table notices is extended to allow for defining multiple dynamic notices for each table in Apache Atlas. Notices coming from Atlas are displayed together with config notices in the same fashion.

### Tests

Tests were adjusted to accommodate new data model.

### Documentation

--
