### PR TITLE
feat: Query components metadata

### DIFF
--- a/common/amundsen_common/models/table.py
+++ b/common/amundsen_common/models/table.py
@@ -157,13 +157,13 @@ class SqlJoinSchema(AttrsSchema):
 
 
 @attr.s(auto_attribs=True, kw_only=True)
-class SqlWnere:
+class SqlWhere:
     where_clause: str
 
 
 class SqlWhereSchema(AttrsSchema):
     class Meta:
-        target = SqlWnere
+        target = SqlWhere
         register_as_scheme = True
 
 
@@ -188,7 +188,7 @@ class Table:
     is_view: Optional[bool] = attr.ib(default=None, converter=default_if_none)
     programmatic_descriptions: List[ProgrammaticDescription] = []
     common_joins: Optional[List[SqlJoin]] = None
-    common_filters: Optional[List[SqlWnere]] = None
+    common_filters: Optional[List[SqlWhere]] = None
 
 
 class TableSchema(AttrsSchema):

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -14,7 +14,8 @@ from amundsen_common.models.lineage import Lineage, LineageItem
 from amundsen_common.models.popular_table import PopularTable
 from amundsen_common.models.table import (Application, Badge, Column,
                                           ProgrammaticDescription, Source,
-                                          Stat, Table, Tag, User, Watermark)
+                                          SqlJoin, SqlWhere, Stat, Table,
+                                          TableSummary, Tag, User, Watermark)
 from amundsen_common.models.user import User as UserModel
 from neo4j import GraphDatabase
 
@@ -120,6 +121,36 @@ class TestNeo4jProxy(unittest.TestCase):
             ]
         }
 
+        table_common_usage = MagicMock()
+        table_common_usage.single.return_value = {
+            'joins': [
+                {
+                    'join_exec_cnt': 2,
+                    'join': {
+                        'join_sql': (
+                            'statewide_cases cases '
+                            'join statewide_testing tests on cases.newcountconfirmed <= tests.tested'
+                        ),
+                        'join_type': 'inner join',
+                        'joined_on_column': 'newcountconfirmed',
+                        'joined_on_table': {
+                            'schema': 'open_data',
+                            'cluster': 'ca_covid',
+                            'database': 'snowflake',
+                            'name': 'statewide_testing'
+                        },
+                        'column': 'newcountconfirmed'
+                    }
+                }
+            ],
+            'filters': [
+                {
+                    'where_clause': 'b.countnewestcases <= 15',
+                    'where_exec_cnt': 2
+                }
+            ]
+        }
+
         table_writer = {
             'application_url': 'airflow_host/admin/airflow/tree?dag_id=test_table',
             'description': 'DAG generating a table',
@@ -139,12 +170,20 @@ class TestNeo4jProxy(unittest.TestCase):
 
         self.last_updated_timestamp = last_updated_timestamp
 
+        self.table_common_usage = table_common_usage
+
     def tearDown(self) -> None:
         pass
 
     def test_get_table(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
-            mock_execute.side_effect = [self.col_usage_return_value, [], self.table_level_return_value]
+            mock_execute.side_effect = [
+                self.col_usage_return_value,
+                [],
+                self.table_level_return_value,
+                self.table_common_usage,
+                []
+            ]
 
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
             table = neo4j_proxy.get_table(table_uri='dummy_uri')
@@ -186,6 +225,26 @@ class TestNeo4jProxy(unittest.TestCase):
                                                          text='Test Test'),
                                  ProgrammaticDescription(source='s3_crawler',
                                                          text='Test Test Test')
+                             ],
+                             common_joins=[
+                                 SqlJoin(
+                                     join_sql=(
+                                         'statewide_cases cases '
+                                         'join statewide_testing tests on cases.newcountconfirmed <= tests.tested'
+                                     ),
+                                     join_type='inner join',
+                                     joined_on_column='newcountconfirmed',
+                                     joined_on_table=TableSummary(
+                                         schema='open_data',
+                                         cluster='ca_covid',
+                                         database='snowflake',
+                                         name='statewide_testing'
+                                     ),
+                                     column='newcountconfirmed'
+                                 )
+                             ],
+                             common_filters=[
+                                 SqlWhere(where_clause='b.countnewestcases <= 15')
                              ])
 
             self.assertEqual(str(expected), str(table))
@@ -196,7 +255,13 @@ class TestNeo4jProxy(unittest.TestCase):
             col['tbl']['is_view'] = True
 
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
-            mock_execute.side_effect = [col_usage_return_value, [], self.table_level_return_value]
+            mock_execute.side_effect = [
+                col_usage_return_value,
+                [],
+                self.table_level_return_value,
+                self.table_common_usage,
+                []
+            ]
 
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
             table = neo4j_proxy.get_table(table_uri='dummy_uri')
@@ -238,6 +303,26 @@ class TestNeo4jProxy(unittest.TestCase):
                                                          text='Test Test'),
                                  ProgrammaticDescription(source='s3_crawler',
                                                          text='Test Test Test')
+                             ],
+                             common_joins=[
+                                 SqlJoin(
+                                     join_sql=(
+                                         'statewide_cases cases '
+                                         'join statewide_testing tests on cases.newcountconfirmed <= tests.tested'
+                                     ),
+                                     join_type='inner join',
+                                     joined_on_column='newcountconfirmed',
+                                     joined_on_table=TableSummary(
+                                         schema='open_data',
+                                         cluster='ca_covid',
+                                         database='snowflake',
+                                         name='statewide_testing'
+                                     ),
+                                     column='newcountconfirmed'
+                                 )
+                             ],
+                             common_filters=[
+                                 SqlWhere(where_clause='b.countnewestcases <= 15')
                              ])
 
             self.assertEqual(str(expected), str(table))


### PR DESCRIPTION
### Summary of Changes

Adds query components that are associated to a table to the metadata table details API for neo4j as part of [RFC 37](https://github.com/amundsen-io/rfcs/blob/master/rfcs/037-index-query-composition.md). This does not need to be added to the other proxies because `common_join` and `common_filter` attributes on the common `Table` model are optional.

Also fixed spelling in `QueryWhere`

### Tests

Existing tests updated to include new response attributes.

### Documentation

n/a
