### PR TITLE
feat: Making notices more general (real)

### DIFF
--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -151,7 +151,7 @@ export enum NoticeSeverity {
 }
 export interface NoticeType {
   severity: NoticeSeverity;
-  messageHtml: string;
+  messageHtml: string | ((resourceName: string) => string);
 }
 /**
  * Stats configuration options

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -114,7 +114,8 @@ export function getResourceNotices(
       }
     });
     if (hasNotice) {
-      const noticeFromWildcard: NoticeType = wildcardNoticesArray[0];
+      // const noticeFromWildcard: NoticeType = wildcardNoticesArray[0];
+      const [noticeFromWildcard] = wildcardNoticesArray;
       return withComputedMessage(noticeFromWildcard, resourceName);
     }
   }

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -13,7 +13,16 @@ import { ResourceType } from '../interfaces';
 
 export const DEFAULT_DATABASE_ICON_CLASS = 'icon-database icon-color';
 export const DEFAULT_DASHBOARD_ICON_CLASS = 'icon-dashboard icon-color';
+const WILDCARD_SIGN = '*';
+const RESOURCE_SEPARATOR = '.';
 const ANNOUNCEMENTS_LINK_LABEL = 'Announcements';
+const hasWildcard = (n) => n.indexOf(WILDCARD_SIGN) > -1;
+const withComputedMessage = (notice: NoticeType, resourceName) => {
+  if (typeof notice.messageHtml === 'function') {
+    notice.messageHtml = notice.messageHtml(resourceName);
+  }
+  return notice;
+};
 
 /**
  * Returns the display name for a given source id for a given resource type.
@@ -77,7 +86,37 @@ export function getResourceNotices(
   const { notices } = AppConfig.resourceConfig[resourceType];
 
   if (notices && notices[resourceName]) {
-    return notices[resourceName];
+    const thisNotice = notices[resourceName];
+    return withComputedMessage(thisNotice, resourceName);
+  }
+
+  const wildcardNoticesKeys = Object.keys(notices).filter(hasWildcard);
+  if (wildcardNoticesKeys.length) {
+    const wildcardNoticesArray = new Array(1);
+    let hasNotice: boolean = false;
+
+    wildcardNoticesKeys.forEach((key) => {
+      const decomposedKey = key.split(RESOURCE_SEPARATOR);
+      const decomposedResource = resourceName.split(RESOURCE_SEPARATOR);
+
+      for (let i = 0; i < decomposedKey.length; i++) {
+        if (
+          decomposedKey[i] === decomposedResource[i] ||
+          decomposedKey[i] === WILDCARD_SIGN
+        ) {
+          if (i === decomposedKey.length - 1) {
+            wildcardNoticesArray[0] = notices[key];
+            hasNotice = true;
+          }
+          continue;
+        }
+        break;
+      }
+    });
+    if (hasNotice) {
+      const noticeFromWildcard: NoticeType = wildcardNoticesArray[0];
+      return withComputedMessage(noticeFromWildcard, resourceName);
+    }
   }
 
   return false;

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -68,59 +68,629 @@ describe('getDisplayNameByResource', () => {
 });
 
 describe('getResourceNotices', () => {
-  describe('when there is a notice', () => {
-    AppConfig.resourceConfig[ResourceType.table].notices = {
-      testName: {
-        severity: NoticeSeverity.WARNING,
-        messageHtml: 'testMessage',
-      },
-    };
+  describe('when resource is a table', () => {
+    describe('when there is a notice', () => {
+      it('returns the notice', () => {
+        AppConfig.resourceConfig[ResourceType.table].notices = {
+          testName: {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
+        };
+        const expected = 'testMessage';
+        const notice = ConfigUtils.getResourceNotices(
+          ResourceType.table,
+          'testName'
+        );
+        const actual = notice && notice.messageHtml;
 
-    it('returns the notice', () => {
-      const expected = 'testMessage';
-      const notice = ConfigUtils.getResourceNotices(
-        ResourceType.table,
-        'testName'
-      );
-      const actual = notice && notice.messageHtml;
-
-      expect(actual).toEqual(expected);
+        expect(actual).toEqual(expected);
+      });
     });
-  });
 
-  describe('when there is no notice', () => {
-    AppConfig.resourceConfig[ResourceType.table].notices = {
-      testName: {
-        severity: NoticeSeverity.WARNING,
-        messageHtml: 'testMessage',
-      },
-    };
+    describe('when there are wildcards ', () => {
+      describe('when there is a wildcard in cluster position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            '*.hive.core.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
 
-    it('returns false', () => {
-      const expected = false;
-      const actual = ConfigUtils.getResourceNotices(
-        ResourceType.table,
-        'testNameNoThere'
-      );
+          expect(actual).toEqual(expected);
+        });
+      });
 
-      expect(actual).toEqual(expected);
+      describe("when there is a wildcard in cluster position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            '*.hive.coco.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there is a wildcard in datasource position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.*.core.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in datasource position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.*.coco.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there is a wildcard in schema position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.*.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in schema position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.*.dimension_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there is a wildcard in table position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.core.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in table position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.coco.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 2 wildcards in schema/table positions', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.*.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 2 notices that match', () => {
+        it('returns the last matched notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.*.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+            'gold.hive.core.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage2',
+            },
+          };
+          const expected = 'testMessage2';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 2 notices, but only one matches', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            'gold.hive.core.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage2',
+            },
+            'gold.hive.shadow.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage2';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 4 wildcards', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.table].notices = {
+            '*.*.*.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.table,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+    });
+
+    describe('when there is a notice with a dynamic message', () => {
+      it('returns notice with dynamic message', () => {
+        AppConfig.resourceConfig[ResourceType.table].notices = {
+          'gold.hive.core.fact_rides': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: (resourceName) => {
+              const [cluster, datasource, schema, table] = resourceName.split(
+                '.'
+              );
+              return `${cluster}, ${datasource}, ${schema}, ${table}`;
+            },
+          },
+        };
+        const expected = 'gold, hive, core, fact_rides';
+        const notice = ConfigUtils.getResourceNotices(
+          ResourceType.table,
+          'gold.hive.core.fact_rides'
+        );
+        const actual = notice && notice.messageHtml;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when there is a notice with a wildcard and dynamic message', () => {
+      it('returns notice with dynamic message', () => {
+        AppConfig.resourceConfig[ResourceType.table].notices = {
+          'gold.hive.core.*': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: (resourceName) => {
+              const [cluster, datasource, schema, table] = resourceName.split(
+                '.'
+              );
+              return `${cluster}, ${datasource}, ${schema}, ${table}`;
+            },
+          },
+        };
+        const expected = 'gold, hive, core, fact_rides';
+        const notice = ConfigUtils.getResourceNotices(
+          ResourceType.table,
+          'gold.hive.core.fact_rides'
+        );
+        const actual = notice && notice.messageHtml;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when there is no notice', () => {
+      it('returns false', () => {
+        AppConfig.resourceConfig[ResourceType.table].notices = {
+          testName: {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
+        };
+        const expected = false;
+        const actual = ConfigUtils.getResourceNotices(
+          ResourceType.table,
+          'testNameNoThere'
+        );
+        expect(actual).toEqual(expected);
+      });
     });
   });
 
   describe('when resource is a dashboard', () => {
     describe('when there is a notice', () => {
-      AppConfig.resourceConfig[ResourceType.dashboard].notices = {
-        testName: {
-          severity: NoticeSeverity.WARNING,
-          messageHtml: 'testMessage',
-        },
-      };
-
       it('returns the notice', () => {
+        AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+          testName: {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
+        };
         const expected = 'testMessage';
         const notice = ConfigUtils.getResourceNotices(
           ResourceType.dashboard,
           'testName'
+        );
+        const actual = notice && notice.messageHtml;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when there are wildcards ', () => {
+      describe('when there is a wildcard in cluster position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            '*.hive.core.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in cluster position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            '*.hive.coco.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there is a wildcard in datasource position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.*.core.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in datasource position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.*.coco.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there is a wildcard in schema position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.*.fact_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in schema position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.*.dimension_rides': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there is a wildcard in table position', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.core.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe("when there is a wildcard in table position that doesn't match", () => {
+        it('returns false', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.coco.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = false;
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 2 wildcards in schema/table positions', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.*.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 2 notices that match', () => {
+        it('returns the last matched notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.*.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+            'gold.hive.core.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage2',
+            },
+          };
+          const expected = 'testMessage2';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 2 notices, but only one matches', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            'gold.hive.core.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage2',
+            },
+            'gold.hive.shadow.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage2';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+
+      describe('when there are 4 wildcards', () => {
+        it('returns notice', () => {
+          AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+            '*.*.*.*': {
+              severity: NoticeSeverity.WARNING,
+              messageHtml: 'testMessage',
+            },
+          };
+          const expected = 'testMessage';
+          const notice = ConfigUtils.getResourceNotices(
+            ResourceType.dashboard,
+            'gold.hive.core.fact_rides'
+          );
+          const actual = notice && notice.messageHtml;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+    });
+
+    describe('when there is a notice with a dynamic message', () => {
+      it('returns notice with dynamic message', () => {
+        AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+          'gold.hive.core.fact_rides': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: (resourceName) => {
+              const [cluster, datasource, schema, table] = resourceName.split(
+                '.'
+              );
+              return `${cluster}, ${datasource}, ${schema}, ${table}`;
+            },
+          },
+        };
+        const expected = 'gold, hive, core, fact_rides';
+        const notice = ConfigUtils.getResourceNotices(
+          ResourceType.dashboard,
+          'gold.hive.core.fact_rides'
+        );
+        const actual = notice && notice.messageHtml;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when there is a notice with a wildcard and dynamic message', () => {
+      it('returns notice with dynamic message', () => {
+        AppConfig.resourceConfig[ResourceType.dashboard].notices = {
+          'gold.hive.core.*': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: (resourceName) => {
+              const [cluster, datasource, schema, table] = resourceName.split(
+                '.'
+              );
+              return `${cluster}, ${datasource}, ${schema}, ${table}`;
+            },
+          },
+        };
+        const expected = 'gold, hive, core, fact_rides';
+        const notice = ConfigUtils.getResourceNotices(
+          ResourceType.dashboard,
+          'gold.hive.core.fact_rides'
         );
         const actual = notice && notice.messageHtml;
 


### PR DESCRIPTION
### Summary of Changes

Added wildcard functionality to notices (ie if we wanted to add a notice to every table in the shadow schema, could do that with ..shadow.*) and dynamic HTML messages (ie if we wanted to have each of those notices have a different message depending on which table it was)

### Tests

Added notices tests to test the functionality of the wildcard and the dynamic message.

### Documentation

Added documentation in frontend/docs/application_config.md
