### PR TITLE
fix: Table Lineage - Upstream rendering adjustments

### DIFF
--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.spec.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.spec.ts
@@ -3,6 +3,7 @@
 /* eslint-disable no-underscore-dangle */
 
 import { LineageItem } from 'interfaces';
+import globalState from 'fixtures/globalState';
 
 import {
   buildEdges,
@@ -10,8 +11,13 @@ import {
   buildSVG,
   compactLineage,
   decompactLineage,
-  hasLineageData,
+  generateNodeId,
   generatePath,
+  getChildren,
+  hasLineageData,
+  prepareNodeForRender,
+  nodeXFromParents,
+  reflowLineage,
   toggler,
 } from './chart';
 
@@ -21,7 +27,7 @@ const item: LineageItem = {
   badges: [],
   cluster: 'cluster',
   database: 'database',
-  key: 'table-key',
+  key: 'h/root',
   level: 0,
   name: 'table',
   parent: null,
@@ -48,8 +54,29 @@ const nodeWithParent = {
 };
 
 describe('D3 Lineage chart', () => {
-  describe('lineageDataPredicate', () => {
-    it('Needs only one of upstream/downstream to render', () => {
+  describe('utilities', () => {
+    it('node id generation should be consistent', () => {
+      expect(generateNodeId(1, 0)).toEqual(1);
+      expect(generateNodeId(2, 0)).toEqual(2);
+      expect(generateNodeId(1, 1)).toEqual(1001);
+      expect(generateNodeId(1, 2)).toEqual(2001);
+    });
+
+    it('node path should be using correct coordinates', () => {
+      expect(generatePath({ x: 3, y: 5 }, { x: 1, y: 1 })).toMatch(/C 3 3/);
+    });
+
+    it("x coords for a child node should be the avg of parents' x", () => {
+      expect(nodeXFromParents([{ x: 4 }, { x: 8 }])).toEqual(6);
+    });
+
+    it('should be possible to get folded/unfolded children', () => {
+      expect(getChildren({ ...item, children: [1] })).toHaveLength(1);
+      expect(getChildren({ ...item, _children: [1, 4] })).toHaveLength(2);
+      expect(getChildren(item)).toHaveLength(0);
+    });
+
+    it('should be possible to verify presence of lineage data', () => {
       expect(
         hasLineageData({ upstream_entities: [], downstream_entities: [] })
       ).toBe(false);
@@ -60,48 +87,93 @@ describe('D3 Lineage chart', () => {
         hasLineageData({ upstream_entities: [item], downstream_entities: [] })
       ).toBe(true);
     });
+
+    it('should be possible to prepare coordinates & id', () => {
+      const nodeWithId = prepareNodeForRender({ ...rootNode, id: null }, 5);
+      expect(nodeWithId.id).toEqual(5);
+      expect(nodeWithId.x0).toEqual(100);
+      expect(nodeWithId.y0).toEqual(100);
+
+      const anotherNodeWithId = prepareNodeForRender(
+        { ...nodeWithId, x: 7 },
+        3
+      );
+      expect(anotherNodeWithId.id).toEqual(5);
+      expect(anotherNodeWithId.x0).toEqual(7);
+    });
   });
 
-  describe('Lineage compact for tree rendering', () => {
-    it('should collapse duplicate nodes with different parents', () => {
+  describe('graph structure', () => {
+    it('node with multiple parents should be deduplicated by compact', () => {
       const withMultipleParents: LineageItem[] = [
         item,
         { ...item, key: 'another-parent' },
         { ...item, level: 1, key: 'no-parent-level-1', parent: '' },
-        { ...item, key: 'child', parent: 'table-key' },
+        { ...item, key: 'child', parent: 'h/root' },
         { ...item, key: 'child', parent: 'another-parent' },
       ];
+
       const compacted = compactLineage(withMultipleParents);
+      expect(compacted).toHaveLength(4);
+
       const compactedChild = compacted.find((i) => i.key === 'child');
+      expect(compactedChild?._parents).toHaveLength(2);
+
       const withAddedRootParent = compacted.find(
         (i) => i.key === 'no-parent-level-1'
       );
-      expect(compacted).toHaveLength(4);
-      expect(compactedChild?._parents).toHaveLength(2);
-      expect(withAddedRootParent?.parent).toEqual('table-key');
+      expect(withAddedRootParent?.parent).toEqual('h/root');
+    });
+
+    it('node with multiple parents should be unfolded # of parents times', () => {
+      const withMultipleParents: LineageItem[] = [
+        item,
+        { ...item, key: 'another-parent' },
+        { ...item, key: 'child', parent: 'h/root' },
+        { ...item, key: 'child', parent: 'another-parent' },
+      ];
+      const compacted = compactLineage(withMultipleParents);
+
+      const compactedNodes = compacted.map((i, idx) => ({
+        ...i,
+        id: idx,
+        data: { data: { key: i.key, _parents: i._parents } },
+        y: 100,
+        x: 100,
+      }));
+
+      const decompactedNodes = decompactLineage(compactedNodes);
+      expect(decompactedNodes).toHaveLength(4);
+    });
+
+    it('should swap parent -> child to child -> parent relationship', () => {
+      const upstreamLineage = [
+        item,
+        ...globalState.lineage.lineageTree.upstream_entities,
+      ];
+
+      const invertedLineage = reflowLineage(upstreamLineage);
+      const parentOne = invertedLineage.find((n) => n.key === 'h/parent-1');
+      const parentTwoSolo = invertedLineage.find(
+        (n) => n.key === 'h/parent-2-solo'
+      );
+      const parentThree = invertedLineage.find((n) => n.key === 'h/parent-3');
+      expect(invertedLineage).toHaveLength(6);
+      expect(parentOne?.parent).toEqual('h/root');
+      expect(parentTwoSolo?.parent).toEqual('h/parent-1');
+      expect(parentThree?.parent).toEqual('h/parent-2');
     });
   });
 
-  describe('Decompacting for edge rendering', () => {
-    const withMultipleParents: LineageItem[] = [
-      item,
-      { ...item, key: 'another-parent' },
-      { ...item, key: 'child', parent: 'table-key' },
-      { ...item, key: 'child', parent: 'another-parent' },
-    ];
-    const compacted = compactLineage(withMultipleParents);
-    const compactedNodes = compacted.map((i) => ({
-      ...i,
-      data: { data: { key: i.key, _parents: i._parents } },
-      y: 100,
-      x: 100,
-    }));
-    const decompactedNodes = decompactLineage(compactedNodes);
-    expect(decompactedNodes).toHaveLength(4);
-  });
+  describe('render', () => {
+    it('should render an svg', () => {
+      const el = document.createElement('div');
+      buildSVG(el, { height: 100, width: 100 });
+      expect(el.getElementsByTagName('svg').length).toBe(1);
+      expect(el.getElementsByTagName('g').length).toBe(1);
+    });
 
-  describe('toggler callback is fired with correct item', () => {
-    it('Click on a root works', () => {
+    it('click on a root behaves as expected', () => {
       const clickSpy = jest.fn();
       const onClickRoot = toggler(clickSpy);
       onClickRoot(rootNode, [rootNode, nodeWithParent, rootNode]);
@@ -113,28 +185,17 @@ describe('D3 Lineage chart', () => {
       expect(clickSpy.mock.calls.length).toBe(2);
       expect(clickSpy.mock.calls[1][0]).toBe(rootNode);
     });
-  });
 
-  describe('patch generations connects two coordiantes', () => {
-    expect(generatePath({ x: 3, y: 5 }, { x: 1, y: 1 })).toMatch(/C 3 3/);
-  });
+    it('should not error out on building nodes and edges', () => {
+      const el = document.createElement('div');
+      const { g } = buildSVG(el, { height: 100, width: 100 });
+      const edges = [nodeWithParent];
+      const clickSpy = jest.fn();
+      const onClickRoot = toggler(clickSpy);
 
-  describe('building an svg should work', () => {
-    const el = document.createElement('div');
-    buildSVG(el, { height: 100, width: 100 });
-    expect(el.getElementsByTagName('svg').length).toBe(1);
-    expect(el.getElementsByTagName('g').length).toBe(1);
-  });
-
-  describe('testing builder d3 functions for nodes & edges', () => {
-    const el = document.createElement('div');
-    const { g } = buildSVG(el, { height: 100, width: 100 });
-    const edges = [nodeWithParent];
-    const clickSpy = jest.fn();
-    const onClickRoot = toggler(clickSpy);
-
-    // Not sure how this could be tested.
-    buildEdges(g, rootNode, edges);
-    buildNodes(g, rootNode, edges, onClickRoot);
+      // Not sure how this could be tested.
+      buildEdges(g, rootNode, edges);
+      buildNodes(g, rootNode, edges, onClickRoot);
+    });
   });
 });

--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/types.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/types.ts
@@ -24,4 +24,4 @@ export type TreeLineageItem = LineageItem & {
 
 export type TreeLineageNode = HierarchyPointNode<
   LineageItem & { id?: string; data: TreeLineageItem }
-> & { _children?: TreeLineageNode[]; x0?: number; y0: number; key?: string };
+> & { _children?: TreeLineageNode[]; x0?: number; y0?: number; key?: string };

--- a/frontend/amundsen_application/static/js/components/Lineage/GraphContainer/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Lineage/GraphContainer/index.spec.tsx
@@ -6,24 +6,26 @@ import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 
 import globalState from 'fixtures/globalState';
-
+import { LineageItem } from 'interfaces';
 import { GraphContainer } from './index';
+
+const item: LineageItem = {
+  badges: [],
+  cluster: 'cluster',
+  database: 'database',
+  key: 'h/root',
+  level: 0,
+  name: 'table',
+  parent: null,
+  schema: 'schema',
+  usage: null,
+};
 
 describe('GraphContainer', () => {
   const setup = () => {
     const props = {
       lineage: globalState.lineage.lineageTree,
-      rootNode: {
-        badges: [],
-        cluster: 'cluster',
-        database: 'database',
-        key: 'table-key',
-        level: 0,
-        name: 'table',
-        parent: null,
-        schema: 'schema',
-        usage: null,
-      },
+      rootNode: item,
     };
     const wrapper = mount(
       <MemoryRouter>

--- a/frontend/amundsen_application/static/js/fixtures/globalState.ts
+++ b/frontend/amundsen_application/static/js/fixtures/globalState.ts
@@ -2,11 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { GlobalState } from 'ducks/rootReducer';
-import { ResourceType, SendingState } from 'interfaces';
+import { LineageItem, ResourceType, SendingState } from 'interfaces';
 
 import { defaultEmptyFilters } from './search/filters';
 
 import { dashboardMetadata } from './metadata/dashboard';
+
+const sharedLineageItemCore = {
+  badges: [],
+  cluster: 'cluster',
+  database: 'h',
+  schema: 'schema',
+  source: 'source',
+  usage: 0,
+};
 
 const globalState: GlobalState = {
   announcements: {
@@ -321,7 +330,44 @@ const globalState: GlobalState = {
   ui: {},
   lineage: {
     lineageTree: {
-      upstream_entities: [],
+      upstream_entities: [
+        {
+          ...sharedLineageItemCore,
+          key: 'h/parent-3',
+          level: 3,
+          name: 'parent-3',
+          parent: '',
+        },
+        {
+          ...sharedLineageItemCore,
+          key: 'h/parent-1',
+          level: 1,
+          name: 'parent-1',
+          parent: 'h/parent-2-solo',
+        },
+        {
+          ...sharedLineageItemCore,
+          key: 'h/parent-1',
+          level: 1,
+          name: 'parent-1',
+          parent: 'h/parent-2',
+        },
+
+        {
+          ...sharedLineageItemCore,
+          key: 'h/parent-2',
+          level: 2,
+          name: 'parent-2',
+          parent: 'h/parent-3',
+        },
+        {
+          ...sharedLineageItemCore,
+          key: 'h/parent-2-solo',
+          level: 2,
+          name: 'parent-2-solo',
+          parent: '',
+        },
+      ] as LineageItem[],
       downstream_entities: [],
       key: '',
       direction: 'both',


### PR DESCRIPTION
### Summary of Changes

The current rendering relies on two graphs emerging from a single root.
This PR adds the ability to reflow the direction of relationships described in the upstream_entities response to support this.


Examples below:

<details>
  <summary>Example 1</summary>

```javascript
{
  "downstream_entities": [
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.sri_lanka/murphy_taylor_and_rivera",
      "level": 2,
      "name": "murphy_taylor_and_rivera",
      "parent": "hive_table://demo.sri_lanka/howard_harrington_and_mendoza",
      "schema": "sri_lanka",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.sri_lanka/howard_harrington_and_mendoza",
      "level": 1,
      "name": "howard_harrington_and_mendoza",
      "parent": "hive_table://demo.togo/morris_plc",
      "schema": "sri_lanka",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.christmas_island/oliver_davis_and_reid",
      "level": 1,
      "name": "oliver_davis_and_reid",
      "parent": "hive_table://demo.togo/morris_plc",
      "schema": "christmas_island",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.sri_lanka/murphy_taylor_and_rivera",
      "level": 2,
      "name": "murphy_taylor_and_rivera",
      "parent": "hive_table://demo.christmas_island/oliver_davis_and_reid",
      "schema": "sri_lanka",
      "source": "hive_table",
      "usage": 0
    }
  ],
  "upstream_entities": [
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.sri_lanka/alvarez_and_sons",
      "level": 2,
      "name": "alvarez_and_sons",
      "parent": "",
      "schema": "sri_lanka",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.austria/owen_lester",
      "level": 1,
      "name": "owen_lester",
      "parent": "hive_table://demo.sri_lanka/alvarez_and_sons",
      "schema": "austria",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.austria/peterson_plc",
      "level": 1,
      "name": "peterson_plc",
      "parent": "",
      "schema": "austria",
      "source": "hive_table",
      "usage": 0
    }
  ]
}
```
Expected:
![lineage_desired_1](https://user-images.githubusercontent.com/6582764/123938074-758af300-d99f-11eb-90ae-0a3b69246507.png)

Actual:

![lineage_actual_1](https://user-images.githubusercontent.com/6582764/123938097-7cb20100-d99f-11eb-8874-dfbd43b892c5.png)
</details>

<details>
  <summary>Example 2</summary>

```javascript
{
  "downstream_entities": [
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.sri_lanka/murphy_taylor_and_rivera",
      "level": 1,
      "name": "murphy_taylor_and_rivera",
      "parent": "hive_table://demo.sri_lanka/howard_harrington_and_mendoza",
      "schema": "sri_lanka",
      "source": "hive_table",
      "usage": 0
    }
  ],
  "upstream_entities": [
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.sri_lanka/alvarez_and_sons",
      "level": 3,
      "name": "alvarez_and_sons",
      "parent": "",
      "schema": "sri_lanka",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.togo/morris_plc",
      "level": 1,
      "name": "morris_plc",
      "parent": "hive_table://demo.austria/peterson_plc",
      "schema": "togo",
      "source": "hive_table",
      "usage": 0
    },
     {                                                                                                                                                                                      
       "badges": [],                                                                                                                                                                          
       "cluster": "demo",                                                                                                                                                                     
       "database": "hive_table",                                                                                                                                                              
       "key": "hive_table://demo.togo/morris_plc",                                                                                                                                            
       "level": 1,                                                                                                                                                                            
       "name": "morris_plc",                                                                                                                                                                  
       "parent": "hive_table://demo.austria/owen_lester",                                                                                                                                     
       "schema": "togo",                                                                                                                                                                      
       "source": "hive_table",                                                                                                                                                                
       "usage": 0                                                                                                                                                                             
     }, 
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.austria/owen_lester",
      "level": 2,
      "name": "owen_lester",
      "parent": "hive_table://demo.sri_lanka/alvarez_and_sons",
      "schema": "austria",
      "source": "hive_table",
      "usage": 0
    },
    {
      "badges": [],
      "cluster": "demo",
      "database": "hive_table",
      "key": "hive_table://demo.austria/peterson_plc",
      "level": 2,
      "name": "peterson_plc",
      "parent": "",
      "schema": "austria",
      "source": "hive_table",
      "usage": 0
    }
  ]
}
```

Expected:
![lineage_desired_2](https://user-images.githubusercontent.com/6582764/123939012-5ccf0d00-d9a0-11eb-9f84-d7baaf97516b.png)

Actual:

![lineage_actual_2](https://user-images.githubusercontent.com/6582764/123939602-f5fe2380-d9a0-11eb-8aee-c2c76016df91.png)


</details>

### Tests

Added tests to confirm correct upstream lineage transformation.
Added lineage sample to global state Fixture and support for actually testing the successful graph rendering.

### Documentation



### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
