### PR TITLE
docs: databuilder/README: add es version

### DIFF
--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -12,6 +12,7 @@ For information about Amundsen and our other services, visit the [main repositor
 
 ## Requirements
 - Python >= 3.6.x
+- elasticsearch 6.x (currently it doesn't support 7.x)
 
 ## Doc
 - https://www.amundsen.io/amundsen/


### PR DESCRIPTION
### Documentation

databuilder will only work with elasticsearch version 6.x. I tried using es 7.10 and it threw an error because es 7 removes mapping types (https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html) and amundsen uses these in the index declaration templates (ex: https://github.com/amundsen-io/amundsen/blob/main/common/amundsen_common/models/index_map.py\#L13-L114). This commit adds a single line to the databuilder README that says the elasticsearch requirements. This line is already in the search_service README so it makes sense to have in the databuilder README as well.

### CheckList
- [X] PR includes a summary of changes.
