### PR TITLE
feat: add complex delta type rendering on frontend

### DIFF
--- a/databuilder/example/sample_data/sample_col.csv
+++ b/databuilder/example/sample_data/sample_col.csv
@@ -10,3 +10,5 @@ col3,"col3 description","string",3,dynamo,gold,test_schema,test_table2,
 col4,"col4 description","int",4,dynamo,gold,test_schema,test_table2,
 col1,"view col description","int",1,hive,gold,test_schema,test_view1,
 col1,"col1 description","int",1,hive,gold,test_schema,test_table3,
+col1,"col1 description","bigint",1,delta,gold,test_schema,delta_test_table
+col2,"col2 nested delta column","struct<col3:string,col4:bigint>",2,delta,gold,test_schema,delta_test_table

--- a/databuilder/example/sample_data/sample_table.csv
+++ b/databuilder/example/sample_data/sample_table.csv
@@ -4,3 +4,4 @@ dynamo,gold,test_schema,test_table2,"2nd test table",recommended,false,
 hive,gold,test_schema,test_view1,"1st test view","tag1",true,
 hive,gold,test_schema,test_table3,"3rd test","needs_documentation",false,
 hive,gold,test_schema,"test's_table4","4th test","needs_documentation",false,
+delta,gold,test_schema,"delta_test_table","test table for delta","delta",false

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnType/parser.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnType/parser.ts
@@ -11,12 +11,15 @@ export interface NestedType {
 enum DatabaseId {
   Hive = 'hive',
   Presto = 'presto',
+  Delta = 'delta',
 }
 const SUPPORTED_TYPES = {
   // https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes-ComplexTypes
   [DatabaseId.Hive]: ['array', 'map', 'struct', 'uniontype'],
   // https://prestosql.io/docs/current/language/types.html#structural
   [DatabaseId.Presto]: ['array', 'map', 'row'],
+  // https://docs.databricks.com/spark/latest/spark-sql/language-manual/sql-ref-datatypes.html#data-types
+  [DatabaseId.Delta]: ['array', 'map', 'struct'],
 };
 const OPEN_DELIMETERS = {
   '(': ')',


### PR DESCRIPTION
feat: add complex delta type rendering on frontend

This PR adds support to render complex delta types as nested columns on the UI. This is modeled after the implementation already done for `hive` and `presto` types.

### Summary of Changes
The change here is fairly simple in that it just adds a new `DatabaseId` to the `parser.ts` enum in order to render nested fields nicely on the UI. I also linked the docs for Delta Types above the `SUPPORTED_TYPES` const similar to `hive` and `presto`.

### Tests
I added tests to `parser.spec.ts` to specifically test for delta complex types and make sure they are turn into the proper column rendering.

I also added some sample delta tables to `sample_data/sample_table.csv ` and sample columns to `sample_data/sample_col.csv` with some nested fields and ran the application locally to verify it works:
<img width="1437" alt="Screen Shot 2021-07-09 at 11 43 59 AM" src="https://user-images.githubusercontent.com/10645992/125123802-005ca380-e0ac-11eb-8fa5-6f83dac5cb65.png">

I decided to commit the sample data as well since then folks who are testing can see what nested fields look like!

### Documentation
I added a link to delta complex types in the code I wrote to follow the convention of `hive` & `presto`

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
