### PR TITLE
feat: Allow counting reads from different GCP project id as config in bigquery_usage_extactor

### DIFF
--- a/databuilder/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_usage_extractor.py
@@ -46,8 +46,10 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
         self.table_usage_counts: Dict[TableColumnUsageTuple, int] = {}
         # GCP console allows running queries using tables from a project different from the one the extractor is
         # used for; only usage metadata of referenced tables present in the given project_id_key for the
-        # extractor is taken into account and usage metadata of referenced tables from other projects is ignored by "default".
-        self.count_reads_only_from_same_project = conf.get_bool(BigQueryTableUsageExtractor.COUNT_READS_ONLY_FROM_PROJECT_ID_KEY, True)
+        # extractor is taken into account and usage metadata of referenced tables from other projects
+        # is ignored by "default".
+        self.count_reads_only_from_same_project = conf.get_bool(
+            BigQueryTableUsageExtractor.COUNT_READS_ONLY_FROM_PROJECT_ID_KEY, True)
         self._count_usage()
         self.iter = iter(self.table_usage_counts)
 
@@ -118,8 +120,10 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
                 tableId = tableId[:-BigQueryTableUsageExtractor.DATE_LENGTH]
 
             if refResource['projectId'] != self.project_id and self.count_reads_only_from_same_project:
-                LOGGER.debug(f'Not counting usage for {refResource} since {tableId} '
-                            f'is not present in {self.project_id} and {BigQueryTableUsageExtractor.COUNT_READS_ONLY_FROM_PROJECT_ID_KEY} is True')
+                LOGGER.debug(
+                    f'Not counting usage for {refResource} since {tableId} '
+                    f'is not present in {self.project_id} '
+                    f'and {BigQueryTableUsageExtractor.COUNT_READS_ONLY_FROM_PROJECT_ID_KEY} is True')
                 continue
             else:
                 key = TableColumnUsageTuple(database='bigquery',


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes
Following the discussion on slack [here](https://amundsenworkspace.slack.com/archives/C01857S0V1V/p1625767472165900)
* keeps default behavior of ignoring counts from different project_id
* Add configuration key to allow ingestion of counts from different project_id 

### Tests

Add a unit test case to enable the configuration variable and validate that `bigquery_usage_extractor` consume the reads that are outside of the defined project_id

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
