### PR TITLE
chore: bump frontend image in helm chart

### DIFF
--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -147,7 +147,7 @@ frontEnd:
   # - name: "image-pull-secret"
 
   # frontEnd.imageTag -- The image tag of the frontend container.
-  imageTag: 3.7.0
+  imageTag: 3.11.1
 
   # frontEnd.servicePort -- The port the frontend service will be exposed on via the loadbalancer.
   servicePort: 80


### PR DESCRIPTION
### Summary of Changes

A new frontend build was released: https://hub.docker.com/layers/amundsendev/amundsen-frontend/3.11.1/images/sha256-5211d896cf9ebdc07288cb91008cf4ffa1df1d417d3fa5b1c6e13b883a09be36?context=explore. Bump the helm chart frontend image tag.

### Tests

N/A

### Documentation

Linked the dockerhub image tag in the commit description

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
