### PR TITLE
feat: Update feature tags in search on user action

### DIFF
--- a/frontend/amundsen_application/api/metadata/v0.py
+++ b/frontend/amundsen_application/api/metadata/v0.py
@@ -12,6 +12,8 @@ from flask import current_app as app
 from flask.blueprints import Blueprint
 
 from amundsen_common.entity.resource_type import ResourceType, to_label
+
+from amundsen_application.api.utils.search_utils import generate_query_json
 from amundsen_application.log.action_log import action_logging
 
 from amundsen_application.models.user import load_user, dump_user
@@ -411,67 +413,66 @@ def _update_metadata_tag(table_key: str, method: str, tag: str) -> int:
     return status_code
 
 
-def _update_search_tag(table_key: str, method: str, tag: str) -> int:
+def _update_search_tag(key: str, resource_type: ResourceType, method: str, tag: str) -> int:
     """
-    call the search service endpoint to get whole table information uniquely identified by table_key
+    call the search service endpoint to get whole entity information uniquely identified by the key
     update tags list, call search service endpoint again to write back the updated field
     TODO: we should update dashboard tag in the future
-    :param table_key: table key e.g. 'database://cluster.schema/table'
+    :param key: e.g. 'database://cluster.schema/table'
     :param method: PUT or DELETE
-    :param tag: tag name to be put/delete
+    :param tag: tag name to be added/deleted
     :return: HTTP status code
     """
     searchservice_base = app.config['SEARCHSERVICE_BASE']
-    searchservice_get_table_url = f'{searchservice_base}/search_table'
 
-    # searchservice currently doesn't allow colon or / inside filters, thus can't get item based on key
-    # table key e.g: 'database://cluster.schema/table'
-    table_uri = TableUri.from_uri(table_key)
+    if resource_type == ResourceType.Table:
+        filter_url = f'{searchservice_base}/search_table'
+        update_url = f'{searchservice_base}/document_table'
+    elif resource_type == ResourceType.Feature:
+        filter_url = f'{searchservice_base}/search_feature_filter'
+        update_url = f'{searchservice_base}/document_feature'
+    else:
+        LOGGER.error(f'updating search tags not supported for {resource_type.name.lower()}')
+        return HTTPStatus.NOT_IMPLEMENTED
 
-    request_param_map = {
-        'search_request':
-            {
-                'type': 'AND',
-                'filters':
-                    {
-                        'database': [table_uri.database],
-                        'schema': [table_uri.schema],
-                        'table': [table_uri.table],
-                        'cluster': [table_uri.cluster]
-                    }
-            },
-        'query_term': ''
-    }
+    query = generate_query_json(filters={'key': [key]}, page_index=0, search_term='')
+    search_response = request_search(
+        url=filter_url,
+        method='POST',
+        headers={'Content-Type': 'application/json'},
+        data=json.dumps(query),
+    )
 
-    get_table_response = request_search(url=searchservice_get_table_url, method='POST', json=request_param_map)
-    get_status_code = get_table_response.status_code
-    if get_status_code != HTTPStatus.OK:
-        LOGGER.info(f'Fail to get table info from serviceservice, http status code: {get_status_code}')
-        LOGGER.debug(get_table_response.text)
-        return get_status_code
+    if search_response.status_code != HTTPStatus.OK:
+        LOGGER.info(f'Fail to get entity from serviceservice, http status code: {search_response.status_code}')
+        LOGGER.info(search_response.text)
+        return search_response.status_code
 
-    raw_data_map = json.loads(get_table_response.text)
-    # key is unique, thus (database, cluster, schema, table) should uniquely identify the table
+    raw_data_map = json.loads(search_response.text)
+    # key should uniquely identify this resource
     if len(raw_data_map['results']) > 1:
-        LOGGER.error(f'Error! Duplicate table key: {table_key}')
-    table = raw_data_map['results'][0]
+        LOGGER.error(f'Error! Duplicate table key: {key}')
+        return HTTPStatus.INTERNAL_SERVER_ERROR
 
-    old_tags_list = table['tags']
+    resource = raw_data_map['results'][0]
+    old_tags_list = resource['tags']
     new_tags_list = [item for item in old_tags_list if item['tag_name'] != tag]
     if method != 'DELETE':
         new_tags_list.append({'tag_name': tag})
-    table['tags'] = new_tags_list
+    resource['tags'] = new_tags_list
 
     # remove None values
-    pruned_table = {k: v for k, v in table.items() if v is not None}
-
+    pruned_table = {k: v for k, v in resource.items() if v is not None}
     post_param_map = {"data": pruned_table}
-    searchservice_update_url = f'{searchservice_base}/document_table'
-    update_table_response = request_search(url=searchservice_update_url, method='PUT', json=post_param_map)
-    update_status_code = update_table_response.status_code
-    if update_status_code != HTTPStatus.OK:
-        LOGGER.info(f'Fail to update table info in searchservice, http status code: {update_status_code}')
-        LOGGER.debug(update_table_response.text)
+    update_table_response = request_search(
+        url=update_url,
+        method='PUT',
+        headers={'Content-Type': 'application/json'},
+        data=json.dumps(post_param_map),
+    )
+    if update_table_response.status_code != HTTPStatus.OK:
+        LOGGER.info(f'Fail to update tag in searchservice, http status code: {update_table_response.status_code}')
+        LOGGER.info(update_table_response.text)
         return update_table_response.status_code
 
     return HTTPStatus.OK
@@ -495,7 +496,8 @@ def update_table_tags() -> Response:
         _log_update_table_tags(table_key=table_key, method=method, tag=tag)
 
         metadata_status_code = _update_metadata_tag(table_key=table_key, method=method, tag=tag)
-        search_status_code = _update_search_tag(table_key=table_key, method=method, tag=tag)
+        search_status_code = _update_search_tag(
+            key=table_key, resource_type=ResourceType.Table, method=method, tag=tag)
 
         http_status_code = HTTPStatus.OK
         if metadata_status_code == HTTPStatus.OK and search_status_code == HTTPStatus.OK:
@@ -1004,11 +1006,6 @@ def _update_metadata_feature_tag(endpoint: str, feature_key: str, method: str, t
     return status_code
 
 
-def _update_search_feature_tag(endpoint: str, feature_key: str, method: str, tag: str) -> int:
-    # TODO when search service feature work is done
-    return HTTPStatus.OK
-
-
 @metadata_blueprint.route('/update_feature_tags', methods=['PUT', 'DELETE'])
 def update_feature_tags() -> Response:
     try:
@@ -1022,9 +1019,8 @@ def update_feature_tags() -> Response:
         metadata_status_code = _update_metadata_feature_tag(endpoint=endpoint,
                                                             feature_key=feature_key,
                                                             method=method, tag=tag)
-        search_status_code = _update_search_feature_tag(endpoint=endpoint,
-                                                        feature_key=feature_key,
-                                                        method=method, tag=tag)
+        search_status_code = _update_search_tag(
+            key=feature_key, resource_type=ResourceType.Feature, method=method, tag=tag)
 
         http_status_code = HTTPStatus.OK
         if metadata_status_code == HTTPStatus.OK and search_status_code == HTTPStatus.OK:

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -45,7 +45,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-__version__ = '3.11.1'
+__version__ = '3.12.0'
 
 oidc = ['flaskoidc==1.0.0']
 pyarrrow = ['pyarrow==3.0.0']

--- a/frontend/tests/unit/api/metadata/test_v0.py
+++ b/frontend/tests/unit/api/metadata/test_v0.py
@@ -1320,12 +1320,13 @@ class MetadataTest(unittest.TestCase):
         responses.add(responses.PUT, url, json={}, status=HTTPStatus.OK)
 
         searchservice_base = local_app.config['SEARCHSERVICE_BASE']
-        get_table_url = f'{searchservice_base}/search_table'
-        responses.add(responses.POST, get_table_url,
+        search_url = f'{searchservice_base}/search_feature_filter'
+        responses.add(responses.POST, search_url,
                       json={'results': [{'id': '1', 'tags': [{'tag_name': 'tag_1'}, {'tag_name': 'tag_2'}]}]},
                       status=HTTPStatus.OK)
 
-        # TODO when search implemented add search service response
+        search_update_url = f'{searchservice_base}/document_feature'
+        responses.add(responses.PUT, search_update_url, json={}, status=HTTPStatus.OK)
 
         with local_app.test_client() as test:
             response = test.put(

--- a/search/search_service/proxy/elasticsearch.py
+++ b/search/search_service/proxy/elasticsearch.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-import itertools
 import logging
 import uuid
 from typing import (

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '2.10.0'
+__version__ = '2.11.0'
 
 oidc = ['flaskoidc==1.0.0']
 

--- a/search/tests/unit/proxy/test_elasticsearch.py
+++ b/search/tests/unit/proxy/test_elasticsearch.py
@@ -390,29 +390,13 @@ class TestElasticsearchProxy(unittest.TestCase):
         self.assertEqual(self.es_proxy.parse_filters(filter_list,
                                                      index=TABLE_INDEX), '')
 
-    def test_validate_wrong_filters_values(self) -> None:
-        search_request = {
-            "type": "AND",
-            "filters": {
-                "schema": ["test_schema:test_schema"],
-                "table": ["test/table"]
-            },
-            "query_term": "",
-            "page_index": 0
+    def test_parse_filter_escapes_special_characters(self) -> None:
+        filter_list = {
+            'key': ['foo://bar/baz'],
         }
-        self.assertEqual(self.es_proxy.validate_filter_values(search_request), False)
-
-    def test_validate_accepted_filters_values(self) -> None:
-        search_request = {
-            "type": "AND",
-            "filters": {
-                "schema": ["test_schema"],
-                "table": ["test_table"]
-            },
-            "query_term": "a",
-            "page_index": 0
-        }
-        self.assertEqual(self.es_proxy.validate_filter_values(search_request), True)
+        expected_result = r"key:(foo\:\/\/bar\/baz)"
+        self.assertEqual(self.es_proxy.parse_filters(filter_list,
+                                                     index=TABLE_INDEX), expected_result)
 
     def test_parse_query_term(self) -> None:
         term = 'test'


### PR DESCRIPTION
Signed-off-by: Dmitriy Kunitskiy <dkunitskiy@lyft.com>

### Summary of Changes

This PR changes the method that updates tags with the search service after a user adds/deletes them in the UI. The method is made more generic to work with other entity types (ML Features, specifically). 

I also simplified this slightly by removing the validation in the search service which disallowed the `:` and `/` characters. These characters simply needed to be escaped. This validation was added here: https://github.com/amundsen-io/amundsensearchlibrary/pull/100. After this validation was removed, we can filter more simply by `key`.

I have also changed the `request_search` call from passing `json` to passing `data`. The `data` arg is what all other API calls from frontend use. The `json` arg is a bit of syntactic sugar which saves the caller from doing `json.dumps` and manually adding the `content-type`. However, if a user configures their own search client as [here](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/api/utils/request_utils.py#L100) it may not support this so the `data` arg is more bulletproof. Only the standard `requests` client supports the `json` arg. 

NOTE: this is technically backwards incompatible, as a deploy of FE without redeploying Search will cause a breakage when updating tags. But this is pretty mild as the only thing that would break is the realtime update in Search.

### Tests

- Updated the relevant search tests and frontend tests. 
- Have also manually tested the new _update_search_tag for PUTs and DELETEs.

