### PR TITLE
feat: blanket uneditable schema option

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/deployment-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-frontend.yaml
@@ -81,6 +81,10 @@ spec:
           - name: OVERWRITE_REDIRECT_URI
             value: {{ .Values.frontEnd.OVERWRITE_REDIRECT_URI }}
           {{- end }}
+          {{ - if .Values.frontEnd.ALL_UNEDITABLE_SCHEMAS }}
+          - name: ALL_UNEDITABLE_SCHEMAS
+            value: {{ .Values.frontEnd.ALL_UNEDITABLE_SCHEMAS }}
+          {{ - end } }
           - name: FLASK_OIDC_SECRET_KEY
             valueFrom:
               secretKeyRef:

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -179,6 +179,10 @@ frontEnd:
   # frontEnd.OVERWRITE_REDIRECT_URI -- The redirect uri for OIDC.
   OVERWRITE_REDIRECT_URI:
 
+  # frontEnd.ALL_UNEDITABLE_SCHEMAS -- Environment variable for allowing/disallowing editing schemas via the UI. All schemas are allowed to be edited by default. Set to 'true' to disallow.
+  # See https://www.amundsen.io/amundsen/frontend/docs/flask_config/#uneditable-table-descriptions for more
+  ALL_UNEDITABLE_SCHEMAS:
+
   # frontEnd.resources -- See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
   resources: {}
   #  limits:

--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -89,6 +89,9 @@ def is_table_editable(schema_name: str, table_name: str, cfg: Any = None) -> boo
     if cfg is None:
         cfg = app.config
 
+    if cfg['ALL_UNEDITABLE_SCHEMAS']:
+        return False
+
     if schema_name in cfg['UNEDITABLE_SCHEMAS']:
         return False
 

--- a/frontend/amundsen_application/config.py
+++ b/frontend/amundsen_application/config.py
@@ -32,8 +32,13 @@ class Config:
 
     COLUMN_STAT_ORDER = None  # type: Dict[str, int]
 
+    # The following three variables control whether table descriptions can be edited via the UI
+    # ALL_UNEDITABLE_SCHEMAS: set environment variable to 'true' if you don't want any schemas to be able to be edited
+    # UNEDITABLE_SCHEMAS: a set of schema names whose tables will not be editable
+    # UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES: a list of regex rules for schema name, table name, or both
+    # See https://www.amundsen.io/amundsen/frontend/docs/flask_config/#uneditable-table-descriptions for more info!
+    ALL_UNEDITABLE_SCHEMAS = os.getenv('ALL_UNEDITABLE_SCHEMAS', 'false') == 'true'  # type: bool
     UNEDITABLE_SCHEMAS = set()  # type: Set[str]
-
     UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES = []  # type: List[MatchRuleObject]
 
     # DEPRECATED (since version 3.9.0): Please use `POPULAR_RESOURCES_COUNT`

--- a/frontend/docs/flask_config.md
+++ b/frontend/docs/flask_config.md
@@ -109,14 +109,19 @@ be company specific which will not directly integrated with Amundsen.
 You can use different combinations of schema and table name for selecting tables.
 
 Here are some examples when this feature can be used:
-1. You want to set all tables with a given schema or schema pattern as un-editable.
-2. You want to set all tables with a specific table name pattern in a given schema pattern as un-editable.
-3. You want to set all tables with a given table name pattern as un-editable.
+1. You want to set ALL tables in your application as un-editable
+2. You want to set all tables with a given schema or schema pattern as un-editable.
+3. You want to set all tables with a specific table name pattern in a given schema pattern as un-editable.
+4. You want to set all tables with a given table name pattern as un-editable.
 
 Amundsen has two variables in `config.py` file which can be used to define match rules:
-1. `UNEDITABLE_SCHEMAS` : Set of schemas where all tables should be un-editable. It takes exact schema name.
-2. `UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES` : List of MatchRuleObject, where each MatchRuleObject consists of regex for
+1. `ALL_UNEDITABLE_SCHEMAS` : boolean on/off switch for ability to edit tables. This can also be set using the environment variable 'ALL_UNEDITABLE_SCHEMAS'
+2. `UNEDITABLE_SCHEMAS` : Set of schemas where all tables should be un-editable. It takes exact schema name.
+3. `UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES` : List of MatchRuleObject, where each MatchRuleObject consists of regex for
 schema name or regex for table name or both.
+
+Purpose of `ALL_UNEDITABLE_SCHEMAS` is to provide a blanket on/off switch for disabling editing schemas. This should be used if you plan to up
+all of your schemas via databuilder rather then allow users to do it via the UI.
 
 Purpose of `UNEDITABLE_SCHEMAS` can be fulfilled by `UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES` but we are keeping both
 variables for backward compatibility.

--- a/frontend/tests/unit/utils/test_metadata_utils.py
+++ b/frontend/tests/unit/utils/test_metadata_utils.py
@@ -151,8 +151,20 @@ class TableEditabilityWrapper(unittest.TestCase):
     def setUp(self) -> None:
         pass
 
+    def test_no_schemas_editable(self) -> None:
+        mockConfig: Dict = {
+            'ALL_UNEDITABLE_SCHEMAS': True,
+            'UNEDITABLE_SCHEMAS': [],
+            'UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES': [],
+        }
+
+        self.assertFalse(is_table_editable('anyschema', 'anytable', mockConfig))
+        self.assertFalse(is_table_editable('anotherschema', 'anothertable', mockConfig))
+        self.assertFalse(is_table_editable('athirdschema', 'athirdtable', mockConfig))
+
     def test_empty_allowed(self) -> None:
         mockConfig: Dict = {
+            'ALL_UNEDITABLE_SCHEMAS': False,
             'UNEDITABLE_SCHEMAS': [],
             'UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES': [],
         }
@@ -161,6 +173,7 @@ class TableEditabilityWrapper(unittest.TestCase):
 
     def test_schema(self) -> None:
         mockConfig = {
+            'ALL_UNEDITABLE_SCHEMAS': False,
             'UNEDITABLE_SCHEMAS': ['uneditable_schema'],
             'UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES': [],
         }
@@ -170,6 +183,7 @@ class TableEditabilityWrapper(unittest.TestCase):
 
     def test_schema_match_rule(self) -> None:
         mockConfig = {
+            'ALL_UNEDITABLE_SCHEMAS': False,
             'UNEDITABLE_SCHEMAS': [''],
             'UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES': [
                 MatchRuleObject(schema_regex=r"^(uneditable).*"),
@@ -181,6 +195,7 @@ class TableEditabilityWrapper(unittest.TestCase):
 
     def test_schema_table_match_rule(self) -> None:
         mockConfig = {
+            'ALL_UNEDITABLE_SCHEMAS': False,
             'UNEDITABLE_SCHEMAS': [''],
             'UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES': [
                 MatchRuleObject(schema_regex=r"^first.*", table_name_regex=r".*bad.*")


### PR DESCRIPTION
### Summary of Changes

This commit adds a new configuration value for the concept of uneditable schemas. The two options right now UNEDITABLE_SCHEMAS and UNEDITABLE_TABLE_DESCRIPTION_MATCH_RULES are not conducive to folks who are deploying amundsen from the docker containers in dockerhub. Here we add a new configuration value ALL_UNEDITABLE_SCHEMAS that pulls it's value from an environment variable andand is a blanket on/off switch to allow schema editing on the UI.

Within my organization, we want don't want users updating anything on the UI. We want to handle all of the metadata during ETL and not allow users to mess with it. I suspect other people using amundsen will want to do the same.

I added some comments in the code about these config values and also updated the documentation for Uneditable Table Descriptions (https://www.amundsen.io/amundsen/frontend/docs/flask_config/#uneditable-table-descriptions) to note this change.

Lastly, I added a value to the helm chart to set this environment variable for those who are deploying to K8s using helm...which I am doing :)

### Tests
I added a new test to the metadata util test suite to verify this config works. I also had added this option to existing MockConfigs in existing tests to verify functionality did not change.

### Documentation
I added some comments in `frontend/config.py` as to what the editeable schema values are and I updated the frontend developer config guide with the new options (https://www.amundsen.io/amundsen/frontend/docs/flask_config/#uneditable-table-descriptions).

### CheckList
Make sure you have checked all steps below to ensure a timely review.

[X] PR title addresses the issue accurately and concisely.
[X] PR includes a summary of changes.
[X] PR adds unit tests, updates existing unit tests, OR documents why no test additions or modifications are needed.
[X] In case of new functionality, my PR adds documentation that describes how to use it.