### PR TITLE
feat: Common models to support better health checks

### DIFF
--- a/common/amundsen_common/models/api/health_check.py
+++ b/common/amundsen_common/models/api/health_check.py
@@ -22,14 +22,14 @@ class HealthCheck:
     checks: Dict[str, Any] = dict()
 
     @status.validator
-    def vaildate_status(self, attribute, value) -> None:
+    def vaildate_status(self, attribute: str, value: Any) -> None:
         if value not in _ELIGIBLE_HEALTH_CHECKS:
             raise ValueError(f"status must be one of {_ELIGIBLE_HEALTH_CHECKS}")
 
     def get_http_status(self) -> int:
         return _HEALTH_CHECK_HTTP_STATUS_MAP[self.status]
 
-    def dict(self) -> Dict:
+    def dict(self) -> Dict[str, Any]:
         return attr.asdict(self)
 
 

--- a/common/amundsen_common/models/api/health_check.py
+++ b/common/amundsen_common/models/api/health_check.py
@@ -22,14 +22,14 @@ class HealthCheck:
     checks: Dict[str, Any] = dict()
 
     @status.validator
-    def vaildate_status(self, attribute, value):
+    def vaildate_status(self, attribute, value) -> None:
         if value not in _ELIGIBLE_HEALTH_CHECKS:
             raise ValueError(f"status must be one of {_ELIGIBLE_HEALTH_CHECKS}")
 
-    def get_http_status(self):
+    def get_http_status(self) -> int:
         return _HEALTH_CHECK_HTTP_STATUS_MAP[self.status]
 
-    def dict(self):
+    def dict(self) -> Dict:
         return attr.asdict(self)
 
 

--- a/common/amundsen_common/models/api/health_check.py
+++ b/common/amundsen_common/models/api/health_check.py
@@ -1,0 +1,39 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import attr
+from http import HTTPStatus
+from typing import Any, Dict
+
+from marshmallow3_annotations.ext.attrs import AttrsSchema
+
+OK = 'ok'
+FAIL = 'fail'
+_ELIGIBLE_HEALTH_CHECKS = [OK, FAIL]
+_HEALTH_CHECK_HTTP_STATUS_MAP = {
+    OK: HTTPStatus.OK,
+    FAIL: HTTPStatus.SERVICE_UNAVAILABLE
+}
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class HealthCheck:
+    status: str = attr.ib()
+    checks: Dict[str, Any] = dict()
+
+    @status.validator
+    def vaildate_status(self, attribute, value):
+        if value not in _ELIGIBLE_HEALTH_CHECKS:
+            raise ValueError(f"status must be one of {_ELIGIBLE_HEALTH_CHECKS}")
+
+    def get_http_status(self):
+        return _HEALTH_CHECK_HTTP_STATUS_MAP[self.status]
+
+    def dict(self):
+        return attr.asdict(self)
+
+
+class HealthCheckSchema(AttrsSchema):
+    class Meta:
+        target = HealthCheck
+        register_as_scheme = True

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.18.1'
+__version__ = '0.18.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')


### PR DESCRIPTION
Signed-off-by: Grant Seward <grant@stemma.ai>

This content for PR is also contained in https://github.com/amundsen-io/amundsen/pull/1355 but is being submitted separately since the updated common version is required to be on pypi as a pre-requisite before the other PR tests can run.

### Summary of Changes

Added a health check model that will be used by the frontend, metadata and search service. Allows for multiple, arbitrary checks to be run by each of the services.

A health check has a status (e.g. `ok` or `fail`). The HTTP status code returned to the client is determined from the status of the health check (e.g. ok=200, fail=503) and any type of checks that the underlying service/proxy decides. Checks may look like:

```json
{
  "status": "ok",
  "checks": {
      "Neo4jProxy:connection": {
        "overview_enabled": false
      }
  }
}
```
or
```json
{
  "status": "ok",
  "checks": {
    "ElasticsearchProxy:connection": {
        "cluster_name": "docker-cluster",
        "status": "yellow",
        "timed_out": false,
        "number_of_in_flight_fetch": 0,
        "task_max_waiting_in_queue_millis": 0,
        "active_shards_percent_as_number": 51.61290322580645
    }
  }
}
```

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
