### PR TITLE
refactor: Updates Postgres extractor to not use information_schema

### DIFF
--- a/databuilder/databuilder/extractor/base_postgres_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/base_postgres_metadata_extractor.py
@@ -36,7 +36,7 @@ class BasePostgresMetadataExtractor(Extractor):
     DEFAULT_CLUSTER_NAME = 'master'
 
     DEFAULT_CONFIG = ConfigFactory.from_dict(
-        {WHERE_CLAUSE_SUFFIX_KEY: ' ', CLUSTER_KEY: DEFAULT_CLUSTER_NAME, USE_CATALOG_AS_CLUSTER_NAME: True}
+        {WHERE_CLAUSE_SUFFIX_KEY: 'true', CLUSTER_KEY: DEFAULT_CLUSTER_NAME, USE_CATALOG_AS_CLUSTER_NAME: True}
     )
 
     @abc.abstractmethod

--- a/databuilder/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/postgres_metadata_extractor.py
@@ -22,7 +22,7 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
             cluster_source = f"'{self._cluster}'"
 
         return """
-            SELECT 
+            SELECT
                 {cluster_source} as cluster,
                 st.schemaname as schema,
                 st.relname as name,

--- a/databuilder/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/postgres_metadata_extractor.py
@@ -17,24 +17,35 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
 
     def get_sql_statement(self, use_catalog_as_cluster_name: bool, where_clause_suffix: str) -> str:
         if use_catalog_as_cluster_name:
-            cluster_source = "c.table_catalog"
+            cluster_source = "current_database()"
         else:
             cluster_source = f"'{self._cluster}'"
 
         return """
-        SELECT
-          {cluster_source} as cluster, c.table_schema as schema, c.table_name as name, pgtd.description as description
-          ,c.column_name as col_name, c.data_type as col_type
-          , pgcd.description as col_description, ordinal_position as col_sort_order
-        FROM INFORMATION_SCHEMA.COLUMNS c
-        INNER JOIN
-          pg_catalog.pg_statio_all_tables as st on c.table_schema=st.schemaname and c.table_name=st.relname
-        LEFT JOIN
-          pg_catalog.pg_description pgcd on pgcd.objoid=st.relid and pgcd.objsubid=c.ordinal_position
-        LEFT JOIN
-          pg_catalog.pg_description pgtd on pgtd.objoid=st.relid and pgtd.objsubid=0
-        {where_clause_suffix}
-        ORDER by cluster, schema, name, col_sort_order ;
+            SELECT 
+                {cluster_source} as cluster,
+                st.schemaname as schema,
+                st.relname as name,
+                pgtd.description as description,
+                att.attname as col_name,
+                pgtyp.typname as col_type,
+                pgcd.description as col_description,
+                att.attnum as col_sort_order
+            FROM pg_catalog.pg_attribute att
+            INNER JOIN
+                pg_catalog.pg_statio_all_tables as st
+                on att.attrelid=st.relid
+            LEFT JOIN
+                pg_catalog.pg_type pgtyp
+                on pgtyp.oid=att.atttypid
+            LEFT JOIN
+                pg_catalog.pg_description pgtd
+                on pgtd.objoid=st.relid and pgtd.objsubid=0
+            LEFT JOIN
+              pg_catalog.pg_description pgcd
+              on pgcd.objoid=st.relid and pgcd.objsubid=att.attnum
+            WHERE att.attnum >=0 and {where_clause_suffix}
+            ORDER by cluster, schema, name, col_sort_order;
         """.format(
             cluster_source=cluster_source,
             where_clause_suffix=where_clause_suffix,

--- a/databuilder/example/scripts/sample_postgres_loader.py
+++ b/databuilder/example/scripts/sample_postgres_loader.py
@@ -65,7 +65,7 @@ def connection_string():
 
 def run_postgres_job():
     where_clause_suffix = textwrap.dedent("""
-        where table_schema = 'public'
+        schemaname = 'public'
     """)
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'

--- a/databuilder/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/databuilder/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -302,7 +302,7 @@ class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
         with patch.object(SQLAlchemyExtractor, '_get_connection'):
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
-            self.assertTrue('table_catalog' in extractor.sql_stmt)
+            self.assertTrue('current_database()' in extractor.sql_stmt)
             self.assertFalse(self.cluster_key in extractor.sql_stmt)
 
 


### PR DESCRIPTION
Signed-off-by: verdan <verdan.mahmood@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

In PostgreSQL information_schema is limited to only tables you have access to. However, the pg_catalog tables are not.
This means that if we want to do a metadata-only integration via a User that has read access to zero tables, at present they'd have to do a materialized view of information_schema. 

This PR makes use of pg_catalog instead properly, to make sure the data is ingested for all users, even with no access. 

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
