### PR TITLE
fix: key generation in databuilder query models.

### DIFF
--- a/databuilder/databuilder/models/query/base.py
+++ b/databuilder/databuilder/models/query/base.py
@@ -1,0 +1,69 @@
+from typing import Iterator
+
+from databuilder.models.graph_serializable import GraphSerializable
+
+
+class QueryBase(GraphSerializable):
+    @staticmethod
+    def _normalize(sql: str) -> str:
+        """
+        Normalizes a SQL query or SQL expression.
+
+        No checks are made to ensure that the input is valid SQL.
+        This is not a full normalization.  The following operations are preformed:
+
+        - Any run of whitespace characters outside of a quoted region is replaces by a single ' ' character.
+        - Characters outside of quoted regions are made lower case.
+        - If present, a trailing ';' is removed from the query.
+
+        Note:
+        Making characters outside quoted regions lower case does not in general result in an equivalent SQL statement.
+        For example, with MySQL the case sensitivity of table names is operating system dependant.
+        In practice, modern systems rarely rely on case sensitivity, and since making the non-quoted regions of the
+        query lowercase is very helpful in identifying queries, we go ahead and do so.
+
+        Also, this method fails to identify expressions such as `1 + 2` and `1+2`.
+        There are likely too many special cases in this area to make much progress without doing a proper parse.
+        """
+        text = sql.strip()
+        it = iter(text)
+        sb = []
+        for c in it:
+            if c.isspace():
+                c = QueryBase._process_whitespace(it)
+                sb.append(' ')
+            sb.append(c.lower())
+            if c in ('`', '"', "'"):
+                for d in QueryBase._process_quoted(it, c):
+                    sb.append(d)
+        if sb[-1] == ';':
+            sb.pop()
+        return ''.join(sb)
+
+    @staticmethod
+    def _process_quoted(it: Iterator[str], quote: str) -> Iterator[str]:
+        """
+        Yields characters up to and including the first occurrence of the (non-escaped) character `quote`.
+
+        Allows `quote` to be escaped with '\\'.
+        """
+        p = ''
+        for c in it:
+            yield c
+            if c == quote and p != '\\':
+                break
+            p = c
+
+    @staticmethod
+    def _process_whitespace(it: Iterator[str]) -> str:
+        """
+        Returns the first non-whitespace character encountered.
+
+        This should never return `None` since the query text is striped before being processed.
+        That is, if the current character is a whitespace character, then there remains at least one non-whitespace
+        character in the stream.
+        """
+        for c in it:
+            if not c.isspace():
+                return c
+        raise ValueError("Input string was not stripped!")

--- a/databuilder/databuilder/models/query/query.py
+++ b/databuilder/databuilder/models/query/query.py
@@ -2,19 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
-import textwrap
 from typing import (
     Iterator, List, Optional,
 )
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.query.base import QueryBase
 from databuilder.models.table_metadata import TableMetadata
 from databuilder.models.user import User as UserMetadata
 
 
-class QueryMetadata(GraphSerializable):
+class QueryMetadata(QueryBase):
     """
     Query model. This creates a Query object as well as relationships
     between the Query and the Table(s) that are used within the query.
@@ -78,19 +77,10 @@ class QueryMetadata(GraphSerializable):
 
     def _get_sql_hash(self, sql: str) -> str:
         """
-        Generates a unique SQL hash. Attempts to remove any formatting from the
+        Generates a deterministic SQL hash. Attempts to remove any formatting from the
         SQL code where possible.
         """
-        sql_no_fmt = (
-            textwrap.dedent(sql)
-            .replace('\n', '')
-            .replace(';', '')
-            .replace(' ', '')
-            .replace('"', '')
-            .replace("'", '')
-            .strip()
-            .lower()
-        )
+        sql_no_fmt = self._normalize(sql)
         return hashlib.md5(sql_no_fmt.encode('utf-8')).hexdigest()
 
     def create_next_node(self) -> Optional[GraphNode]:

--- a/databuilder/databuilder/models/query/query_where.py
+++ b/databuilder/databuilder/models/query/query_where.py
@@ -2,19 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
-import textwrap
 from typing import (
     Iterator, List, Optional,
 )
 
 from databuilder.models.graph_node import GraphNode
 from databuilder.models.graph_relationship import GraphRelationship
-from databuilder.models.graph_serializable import GraphSerializable
+from databuilder.models.query.base import QueryBase
 from databuilder.models.query.query import QueryMetadata
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
-class QueryWhereMetadata(GraphSerializable):
+class QueryWhereMetadata(QueryBase):
     """
     A Where clause used on a query.
     """
@@ -92,7 +91,7 @@ class QueryWhereMetadata(GraphSerializable):
         """
         Generates a unique hash for a where clause.
         """
-        sql_no_fmt = textwrap.dedent(where_clause).replace(' ', '').replace('\n', '').strip().lower()
+        sql_no_fmt = self._normalize(where_clause)
         return hashlib.md5(sql_no_fmt.encode('utf-8')).hexdigest()
 
     def create_next_node(self) -> Optional[GraphNode]:

--- a/databuilder/tests/unit/models/query/test_base.py
+++ b/databuilder/tests/unit/models/query/test_base.py
@@ -1,0 +1,30 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from databuilder.models.query.base import QueryBase
+
+
+class TestQueryBase(unittest.TestCase):
+    def test_normalize_mixed_case(self) -> None:
+        query = 'SELECT foo from BAR'
+        expected = 'select foo from bar'
+        self.assertEqual(QueryBase._normalize(query), expected)
+
+    def test_normalize_mixed_case_string(self) -> None:
+        query = "SELECT 'foo BaR'"
+        expected = "select 'foo BaR'"
+        self.assertEqual(QueryBase._normalize(query), expected)
+
+    def test_normalize_lots_of_space(self) -> None:
+        query = '''
+        SELECT foo AS   bar
+          FROM baz'''
+        expected = 'select foo as bar from baz'
+        self.assertEqual(QueryBase._normalize(query), expected)
+
+    def test_trailing_semicolon(self) -> None:
+        query = "select 'a;b;c';"
+        expected = "select 'a;b;c'"
+        self.assertEqual(QueryBase._normalize(query), expected)

--- a/databuilder/tests/unit/models/query/test_query.py
+++ b/databuilder/tests/unit/models/query/test_query.py
@@ -49,7 +49,7 @@ class TestQuery(unittest.TestCase):
         self.query_metadata = QueryMetadata(sql=self.sql,
                                             tables=[self.table_metadata],
                                             user=self.user)
-        self._query_hash = 'f70ffda4d06ff36fa507ece37980ab66'
+        self._query_hash = 'da44ff72560e593a8eca9ffcee6a2696'
 
     def test_get_model_key(self) -> None:
         key = QueryMetadata.get_key(sql_hash=self.query_metadata.sql_hash)
@@ -99,3 +99,21 @@ class TestQuery(unittest.TestCase):
         ]
 
         self.assertEquals(expected_relations, actual)
+
+    def test_keys_of_query_containing_strings_with_spaces(self) -> None:
+        query_metadata1 = QueryMetadata(sql="select * from table a where a.field == 'xyz'",
+                                        tables=[self.table_metadata])
+
+        query_metadata2 = QueryMetadata(sql="select * from table a where a.field == 'x y z'",
+                                        tables=[self.table_metadata])
+
+        self.assertNotEqual(query_metadata1.get_key_self(), query_metadata2.get_key_self())
+
+    def test_keys_of_query_containing_strings_with_mixed_case(self) -> None:
+        query_metadata1 = QueryMetadata(sql="select * from table a where a.field == 'x Y z'",
+                                        tables=[self.table_metadata])
+
+        query_metadata2 = QueryMetadata(sql="select * from table a where a.field == 'x y z'",
+                                        tables=[self.table_metadata])
+
+        self.assertNotEqual(query_metadata1.get_key_self(), query_metadata2.get_key_self())

--- a/databuilder/tests/unit/models/query/test_query_execution.py
+++ b/databuilder/tests/unit/models/query/test_query_execution.py
@@ -36,7 +36,7 @@ class TestQueryExecution(unittest.TestCase):
         self.query_join_metadata = QueryExecutionsMetadata(query_metadata=self.query_metadata,
                                                            start_time=10,
                                                            execution_count=7)
-        self._expected_key = '6caeee4c1c393848293d1aabea87355b-10'
+        self._expected_key = '748c28f86de411b1d2b9deb6ae105eba-10'
 
     def test_get_model_key(self) -> None:
         key = QueryExecutionsMetadata.get_key(query_key=self.query_metadata.get_key_self(), start_time=10)

--- a/databuilder/tests/unit/models/query/test_query_join.py
+++ b/databuilder/tests/unit/models/query/test_query_join.py
@@ -122,7 +122,7 @@ class TestQueryJoin(unittest.TestCase):
                 RELATION_END_KEY: self._expected_key,
                 RELATION_END_LABEL: QueryJoinMetadata.NODE_LABEL,
                 RELATION_REVERSE_TYPE: QueryJoinMetadata.INVERSE_QUERY_JOIN_RELATION_TYPE,
-                RELATION_START_KEY: '6caeee4c1c393848293d1aabea87355b',
+                RELATION_START_KEY: '748c28f86de411b1d2b9deb6ae105eba',
                 RELATION_START_LABEL: QueryMetadata.NODE_LABEL,
                 RELATION_TYPE: QueryJoinMetadata.QUERY_JOIN_RELATION_TYPE
             }

--- a/databuilder/tests/unit/models/query/test_query_where.py
+++ b/databuilder/tests/unit/models/query/test_query_where.py
@@ -38,7 +38,7 @@ class TestQueryWhere(unittest.TestCase):
                                                        right_arg='3',
                                                        operator='>',
                                                        query_metadata=self.query_metadata)
-        self._expected_key_hash = '795a2a16184c09b88ae518cd5230cfb5-0db8c6650b77c7ae1a5dedb549a76cfb'
+        self._expected_key_hash = '795a2a16184c09b88ae518cd5230cfb5-be8634550905b354508dc8aba8008c14'
 
     def test_get_model_key(self) -> None:
         key = QueryWhereMetadata.get_key(table_hash=self.query_where_metadata._table_hash,


### PR DESCRIPTION
### Summary of Changes

Currently key generation transforms a query into a key by making it
lowercase, removing all whitespace, and removing all ';' characters.

This fix:
- performs no transformations of the query inside of quoted regions (', ", `)
- collapses runs of whitespace characters to a single ' '
- only removes ';' from the end of the query

This ensures that the queries such as `select 'X; Y; Z'` and
`select 'xyz'` receive different keys.

While this does mean that a query will now most likely now be assigned a
different key than before, this is likely preferable to the current situation.

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Tests

Existing tests have been updated with the new keys and hashes as appropriate, and additional tests have been added which document and verify the new behavior and will help to prevent regressions. 

### Documentation

The docstrings provide additional details about the normalization procedure and its tradeoffs.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
