### PR TITLE
docs: Use HTTPS Git clone command instead of SSH in installation documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ The following instructions are for setting up a version of Amundsen using Docker
 1. Make sure you have at least 3GB available to docker. Install `docker` and  `docker-compose`.
 2. Clone [this repo](https://github.com/amundsen-io/amundsen) and its submodules by running:
    ```bash
-   $ git clone --recursive git@github.com:amundsen-io/amundsen.git
+   $ git clone --recursive https://github.com/amundsen-io/amundsen.git
    ```
 3. Enter the cloned directory and run below:
     ```bash


### PR DESCRIPTION
### Summary of Changes

Changed git clone command to use HTTPS instead of SSH, so that Windows users can follow along with the documentation. This alternative command will also work the same for Mac and Linux users.

### Tests

No new tests are needed. 

### Documentation

Changed git clone command to use HTTPS instead of SSH, so that Windows users can follow along with the documentation. This alternative command will also work the same for Mac and Linux users.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
