### PR TITLE
fix: nested delta edge case

### DIFF
--- a/databuilder/tests/unit/extractor/test_deltalake_extractor.py
+++ b/databuilder/tests/unit/extractor/test_deltalake_extractor.py
@@ -76,6 +76,13 @@ class TestDeltaLakeExtractor(unittest.TestCase):
                        "map<struct<b:array<struct<c:int,d:string>>,e:double>,struct<f:array<struct<g:int,h:string>>,"
                        "i:double>>) using delta")
 
+        self.spark.sql("create table if not exists complex_schema.array_of_array (a array<array<string>>) using "
+                       "delta")
+        self.spark.sql("create table if not exists complex_schema.map_of_map (a map<int,map<int,int>>) using "
+                       "delta")
+        self.spark.sql("create table if not exists complex_schema.map_of_array_of_structs (a map<int,"
+                       "array<struct<b:int,c:string>>>) using delta")
+
     def test_get_all_schemas(self) -> None:
         '''Tests getting all schemas'''
         actual_schemas = self.dExtractor.get_schemas([])
@@ -192,7 +199,7 @@ class TestDeltaLakeExtractor(unittest.TestCase):
         while data is not None:
             ret.append(data)
             data = self.dExtractor.extract()
-        self.assertEqual(len(ret), 24)
+        self.assertEqual(len(ret), 30)
 
     def test_extract_with_only_specific_schemas(self) -> None:
         self.config_dict = {
@@ -227,7 +234,7 @@ class TestDeltaLakeExtractor(unittest.TestCase):
         while data is not None:
             ret.append(data)
             data = self.dExtractor.extract()
-        self.assertEqual(len(ret), 20)
+        self.assertEqual(len(ret), 26)
 
     def test_table_does_not_exist(self) -> None:
         table = Table(name="test_table5", database="test_schema1", description=None,
@@ -319,6 +326,18 @@ class TestDeltaLakeExtractor(unittest.TestCase):
                 ScrapedColumnMetadata(name="map_col.f.h", description=None, data_type="string", sort_order=4),
                 ScrapedColumnMetadata(name="map_col.i", description=None, data_type="double", sort_order=5),
             ],
+            "array_of_array": [
+                ScrapedColumnMetadata(name="a", description=None, data_type="array<array<string>>", sort_order=0),
+            ],
+            "map_of_map": [
+                ScrapedColumnMetadata(name="a", description=None, data_type="map<int,map<int,int>>", sort_order=0),
+            ],
+            "map_of_array_of_structs": [
+                ScrapedColumnMetadata(name="a", description=None, data_type="map<int,array<struct<b:int,c:string>>>",
+                                      sort_order=0),
+                ScrapedColumnMetadata(name="a.b", description=None, data_type="int", sort_order=1),
+                ScrapedColumnMetadata(name="a.c", description=None, data_type="string", sort_order=2),
+            ]
         }
         for table_name, expected in expected_dict.items():
             actual = self.dExtractor.fetch_columns(schema="complex_schema", table=table_name)


### PR DESCRIPTION
### Summary of Changes

This commit fixes/refactors the implementation of complex delta columns. There was an edge case not taken into account for arrays of arrays (`array<array<string>>`), maps of maps (`map<int,map<int,int>>`), and combinations where intermediate nested types were not struct fields. This also prompted a slight re-write of the function where the base case of the recursion is StructField. Basically we only want to add columns that are StructField types since they are named and can be accessed.

### Tests

I added three new test cases for these cases and made sure all previous test cases still passed.

### Documentation

N/A --> already documented

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
