### PR TITLE
feat: Adding regional endpoint url for NeptunePublisher

### DIFF
--- a/databuilder/databuilder/publisher/neptune_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neptune_csv_publisher.py
@@ -50,7 +50,7 @@ class NeptuneCSVPublisher(Publisher):
     AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key'
     AWS_SESSION_TOKEN = 'aws_session_token'
     AWS_IAM_ROLE_NAME = 'aws_iam_role_name'
-
+    AWS_STS_ENDPOINT_URL = 'aws_sts_endpoint_url'
     FAIL_ON_ERROR = "fail_on_error"
     STATUS_POLLING_PERIOD = "status_polling_period"
 
@@ -80,7 +80,8 @@ class NeptuneCSVPublisher(Publisher):
             session=self._boto_session,
             endpoint_uri=neptune_bulk_endpoint_uri,
             s3_bucket_name=self.bucket_name,
-            iam_role_name=conf.get_string(NeptuneCSVPublisher.AWS_IAM_ROLE_NAME, default=None)
+            iam_role_name=conf.get_string(NeptuneCSVPublisher.AWS_IAM_ROLE_NAME, default=None),
+            sts_endpoint=conf.get_string(NeptuneCSVPublisher.AWS_STS_ENDPOINT_URL, default=None),
         )
         self.base_amundsen_data_path = conf.get_string(NeptuneCSVPublisher.AWS_BASE_S3_DATA_PATH)
         self.fail_on_error = conf.get_bool(NeptuneCSVPublisher.FAIL_ON_ERROR, default=False)

--- a/docs/tutorials/how-to-use-amundsen-with-aws-neptune.md
+++ b/docs/tutorials/how-to-use-amundsen-with-aws-neptune.md
@@ -3,7 +3,7 @@
 An alternative to Neo4j as Amundsen's database is [Amazon Neptune](https://docs.aws.amazon.com/neptune/latest/userguide/intro.html).
 
 This tutorial will go into setting up Amundsen to integrate with Neptune. If you want to find out how to set up a
-Neptune instance you can find that information at https://docs.aws.amazon.com/neptune/latest/userguide/neptune-setup.html.
+Neptune instance you can find that information at [Neptune Setup](https://docs.aws.amazon.com/neptune/latest/userguide/neptune-setup.html).
 
 ## Configuring your Databuilder jobs to use Neptune
 
@@ -12,7 +12,7 @@ The Neptune integration follows the same pattern as the rest of Amundsen's datab
 
 Each job contains a task and a publisher and each task comprises of a extractor, transformer, and loader.
 
-The Neptune databuilder integration was built so that it was compatible with all the of the extractors 
+The Neptune databuilder integration was built so that it was compatible with all extractors 
 (and the models produced by those extractors) so that only the [loader](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/loader/file_system_neptune_csv_loader.py) 
 and [publisher](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/publisher/neptune_csv_publisher.py)
 diverge from the Neo4j integration.
@@ -22,7 +22,7 @@ diverge from the Neo4j integration.
 ### Loading data into Neptune
 
 The [sample_data_loader_neptune.py](https://github.com/amundsen-io/amundsendatabuilder/blob/master/example/scripts/sample_data_loader_neptune.py)
-script contains examples on how to ingest data into Neptune. However the main components are the 
+script contains an example on how to ingest data into Neptune. However, the main components are the 
 [FSNeptuneCSVLoader](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/loader/file_system_neptune_csv_loader.py)
 and the [NeptuneCSVPublisher](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/publisher/neptune_csv_publisher.py)
 
@@ -36,12 +36,12 @@ and [GraphRelationship](https://github.com/amundsen-io/amundsendatabuilder/blob/
 * `SHOULD_DELETE_CREATED_DIR` - Should the loader delete the files once the job is over (Default is True)
 * `JOB_PUBLISHER_TAG` - A tag that all models published by this job share. (should be unique)
 
-`NeptuneCSVPublisher` takes the csv files produced by the `FSNeptuneCSVLoader` and ingesting them into 
+`NeptuneCSVPublisher` takes the csv files produced by the `FSNeptuneCSVLoader` and ingest them into 
 Neptune. It achieves this by using the [Neptune's bulk loader API](https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load.html).
 The flow of the `NeptuneCSVPublisher` is:
 
-1. Upload the csv files to S3. 
-2. Initiating a bulk loading request 
+1. Upload the csv files to S3
+2. Initiating a bulk loading request
 3. Poll on that status of the request till it reports a success or failure
 
 The `NeptuneCSVPublisher` has the following configuration keys:
@@ -55,19 +55,19 @@ The `NeptuneCSVPublisher` has the following configuration keys:
 * `AWS_ACCESS_KEY` - AWS access key (Optional)
 * `AWS_SECRET_ACCESS_KEY` - AWS access secret access key (Optional)
 * `AWS_SESSION_TOKEN` - AWS session token if you are using temporary credentials (Optional)
-* `AWS_IAM_ROLE_NAME` - IAM ROLE NAME used for the the bulk loading
+* `AWS_IAM_ROLE_NAME` - IAM ROLE NAME used for the bulk loading
 * `AWS_STS_ENDPOINT_URL` - AWS STS endpoint url, if not set the global endpoint will be used (Optional)
 * `FAIL_ON_ERROR` - If set to True an exception will be raised on failure (default False)
 * `STATUS_POLLING_PERIOD` - Period in seconds checking on the status of the bulk loading request
 
-### Publishing data to Search from Neptune
+### Publishing data from Neptune to Amundsen Search
 
 In order to have your entities searchable on the front end you need to extract the data from Neptune and push it
-into your elasticsearch cluster so the search service can query it. To achieve this the data builder comes with the
+into your elasticsearch cluster, so the search service can query it. To achieve this, the data builder comes with the
 [NeptuneSearchDataExtractor](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/extractor/neptune_search_data_extractor.py)
 which can be integrated with the [FSElasticsearchJSONLoader](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/loader/file_system_elasticsearch_json_loader.py)
 and the [ElasticsearchPublisher](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/publisher/elasticsearch_publisher.py).
-A example job can be found in the [sample_data_loader_neptune.py](https://github.com/amundsen-io/amundsendatabuilder/blob/master/example/scripts/sample_data_loader_neptune.py) 
+An example job can be found in the [sample_data_loader_neptune.py](https://github.com/amundsen-io/amundsendatabuilder/blob/master/example/scripts/sample_data_loader_neptune.py) 
 in the `create_es_publisher_sample_job` function.
 
 The `NeptuneSearchDataExtractor` supports extracting table, user, and dashboard models in a format that 
@@ -92,7 +92,7 @@ The `NeptuneSessionClient` supports the following configuration keys:
 
 ### Removing stale data from Neptune
 
-Metadata often changes so the [neptune_staleness_removal_task](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/task/neptune_staleness_removal_task.py)
+Metadata often changes, so the [neptune_staleness_removal_task](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/task/neptune_staleness_removal_task.py)
  is used to remove old nodes and relationships. The databuilder contains an example [script](https://github.com/amundsen-io/amundsendatabuilder/blob/master/example/scripts/sample_neptune_data_cleanup_job.py)
 using the neptune_staleness_removal_task. 
 
@@ -112,5 +112,5 @@ The NeptuneConfig requires a few environment variables to be set these are:
 * `AWS_REGION` - The AWS region where the Neptune instance is located.
 * `S3_BUCKET_NAME`- The location where the proxy can upload S3 files for bulk uploader
 
-In addition to the Config the `IGNORE_NEPTUNE_SHARD` environment variable must be set to 'True'
+In addition to the Config parameters above, the `IGNORE_NEPTUNE_SHARD` environment variable must be set to 'True'
 if you are using the default databuilder integration.

--- a/docs/tutorials/how-to-use-amundsen-with-aws-neptune.md
+++ b/docs/tutorials/how-to-use-amundsen-with-aws-neptune.md
@@ -29,6 +29,7 @@ and the [NeptuneCSVPublisher](https://github.com/amundsen-io/amundsendatabuilder
 The `FSNeptuneCSVLoader` is responsible for converting the [GraphNode](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/models/graph_node.py)
 and [GraphRelationship](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/models/graph_relationship.py)
  into a csv format that the Neptune bulk loader expects. The `FSNeptuneCSVLoader` has 5 configuration keys
+
 * `NODE_DIR_PATH` - Where the node csv files should go
 * `RELATION_DIR_PATH` - Where the relationship csv files should go
 * `FORCE_CREATE_DIR` - Should the loader overwrite any existing files (Default is False)
@@ -38,11 +39,13 @@ and [GraphRelationship](https://github.com/amundsen-io/amundsendatabuilder/blob/
 `NeptuneCSVPublisher` takes the csv files produced by the `FSNeptuneCSVLoader` and ingesting them into 
 Neptune. It achieves this by using the [Neptune's bulk loader API](https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load.html).
 The flow of the `NeptuneCSVPublisher` is:
+
 1. Upload the csv files to S3. 
 2. Initiating a bulk loading request 
 3. Poll on that status of the request till it reports a success or failure
 
 The `NeptuneCSVPublisher` has the following configuration keys:
+
 * `NODE_FILES_DIR` - Where the publisher will look for node files
 * `RELATION_FILES_DIR` - Where the publisher will look for relationship files
 * `AWS_S3_BUCKET_NAME` - The name of the S3 bucket where the publisher will upload the files to.
@@ -53,6 +56,7 @@ The `NeptuneCSVPublisher` has the following configuration keys:
 * `AWS_SECRET_ACCESS_KEY` - AWS access secret access key (Optional)
 * `AWS_SESSION_TOKEN` - AWS session token if you are using temporary credentials (Optional)
 * `AWS_IAM_ROLE_NAME` - IAM ROLE NAME used for the the bulk loading
+* `AWS_STS_ENDPOINT_URL` - AWS STS endpoint url, if not set the global endpoint will be used (Optional)
 * `FAIL_ON_ERROR` - If set to True an exception will be raised on failure (default False)
 * `STATUS_POLLING_PERIOD` - Period in seconds checking on the status of the bulk loading request
 
@@ -68,6 +72,7 @@ in the `create_es_publisher_sample_job` function.
 
 The `NeptuneSearchDataExtractor` supports extracting table, user, and dashboard models in a format that 
 `FSElasticsearchJSONLoader` accepts. It has the following configuration keys:
+
 * `ENTITY_TYPE_CONFIG_KEY` - Type of model being extracted. This supports table, user, dashboard (defaults to table)
 * `MODEL_CLASS_CONFIG_KEY` - Python path of class to cast the extracted data to. (Optional)
 * `JOB_PUBLISH_TAG_CONFIG_KEY` - Allows you to filter your extraction to a job tag. (Optional)
@@ -78,6 +83,7 @@ The `NeptuneSearchDataExtractor` uses the
 [NeptuneSessionClient](https://github.com/amundsen-io/amundsendatabuilder/blob/master/databuilder/clients/neptune_client.py) 
 to extract data from Neptune.
 The `NeptuneSessionClient` supports the following configuration keys:
+
 * `NEPTUNE_HOST_NAME` - The Neptune host in the format of `<HOST>:<PORT>` no protocol included
 * `AWS_REGION` - The AWS region where the Neptune instance is located.
 * `AWS_ACCESS_KEY` - AWS access key (Optional)
@@ -100,7 +106,8 @@ point the environment variable `METADATA_SVC_CONFIG_MODULE_CLASS` to it. For exa
 export METADATA_SVC_CONFIG_MODULE_CLASS=metadata_service.config.NeptuneConfig
 ```
 
-The NeptuneConfig requires a few environment variables to be set these are: 
+The NeptuneConfig requires a few environment variables to be set these are:
+
 * `PROXY_HOST` - The host name of the Neptune instance. Formatted like: `wss://<NEPTUNE_URL>:<NEPTUNE_PORT>/gremlin`
 * `AWS_REGION` - The AWS region where the Neptune instance is located.
 * `S3_BUCKET_NAME`- The location where the proxy can upload S3 files for bulk uploader


### PR DESCRIPTION
### Summary of Changes

As described in the issue #1338, we could use STS regional endpoint instead global one, since AWS recommends it.

### Tests
I added an optional parameter to the NeptunePublisher  which does not have unit tests

### Documentation
I changed the Neptune tutorial adding the new parameter

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
