### PR TITLE
fix: add description_source when inserting table/column description in mysql_proxy

### DIFF
--- a/metadata/metadata_service/proxy/mysql_proxy.py
+++ b/metadata/metadata_service/proxy/mysql_proxy.py
@@ -439,7 +439,10 @@ class MySQLProxy(BaseProxy):
         :return:
         """
         desc_key = table_uri + '/_description'
-        description = RDSTableDescription(rk=desc_key, description=description, table_rk=table_uri)
+        description = RDSTableDescription(rk=desc_key,
+                                          description_source='description',
+                                          description=description,
+                                          table_rk=table_uri)
         try:
             with self.client.create_session() as session:
                 session.merge(description)
@@ -608,7 +611,10 @@ class MySQLProxy(BaseProxy):
         """
         column_uri = table_uri + '/' + column_name
         desc_key = column_uri + '/_description'
-        description = RDSColumnDescription(rk=desc_key, description=description, column_rk=column_uri)
+        description = RDSColumnDescription(rk=desc_key,
+                                           description_source='description',
+                                           description=description,
+                                           column_rk=column_uri)
         try:
             with self.client.create_session() as session:
                 session.merge(description)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

Context: `description_source` is missing when inserting a new table/column description in mysql_proxy.py
slack link: https://amundsenworkspace.slack.com/archives/CHQERT0D7/p1626999566426200

Change: Add description_source 'description' for upserting table/column description in put_table/column_description() of mysql_proxy.py


### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
