### PR TITLE
test: Trigger ci on all services for changes to common

### DIFF
--- a/.github/workflows/databuilder_pull_request.yml
+++ b/.github/workflows/databuilder_pull_request.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "databuilder/**"
+      - "common/**"
       - "requirements-dev.txt"
 jobs:
   test-unit-python:

--- a/.github/workflows/frontend_pull_request.yml
+++ b/.github/workflows/frontend_pull_request.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "frontend/**"
+      - "common/**"
       - "requirements*txt"
 jobs:
   test-unit-python:

--- a/.github/workflows/metadata_pull_request.yml
+++ b/.github/workflows/metadata_pull_request.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "metadata/**"
+      - "common/**"
       - "requirements*txt"
 jobs:
   test-unit-python:

--- a/.github/workflows/search_pull_request.yml
+++ b/.github/workflows/search_pull_request.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "search/**"
+      - "common/**"
       - "requirements*txt"
 jobs:
   test-unit-python:


### PR DESCRIPTION
### Summary of Changes

Adds `common/**` to pull request paths in github workflows for databuilder, frontend, metadata and search so that any changes to common will also trigger tests for these services. This should help catch changes to common that will break any services that were not updated within the same PR.

### Tests

No tests were changed since this PR was for CI changes.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
