### PR TITLE
fix: return empty list from exceptions in fetch_columns on deltalake extractor

### DIFF
--- a/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -299,7 +299,7 @@ class DeltaLakeMetadataExtractor(Extractor):
                 field_dict[field.name] = field
         except AnalysisException as e:
             LOGGER.error(e)
-            return raw_columns
+            return []
         parsed_columns: Dict[str, ScrapedColumnMetadata] = {}
         partition_cols = False
         sort_order = 0

--- a/databuilder/tests/unit/extractor/test_deltalake_extractor.py
+++ b/databuilder/tests/unit/extractor/test_deltalake_extractor.py
@@ -158,6 +158,10 @@ class TestDeltaLakeExtractor(unittest.TestCase):
         for a, b in zip(actual, expected):
             self.assertEqual(a, b)
 
+    def test_fetch_delta_columns_failure(self) -> None:
+        actual = self.dExtractor.fetch_columns("test_schema1", "nonexistent_table")
+        self.assertEquals(actual, [])
+
     def test_scrape_tables(self) -> None:
         table = Table(name="test_table1", database="test_schema1", description=None,
                       tableType="delta", isTemporary=False)


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes
For the deltalake metadata extractor, when fetching columns the code `describe`s the table, and then tries to look at schema by doing `spark.table('<table>').schema`; this is wrapped in a try-catch to fail gracefully.

We ran into an issue recently where running `spark.table('<table>').schema` raised an exception, causing this method to drop into the except and log the error and return `raw_columns`. However, the type of `raw_columns` is not `List[ScrapedColumnMetadata]`, it's a list of spark Row objects, e.g.

```
[Row(col_name='date', data_type='date', comment=''),
 Row(col_name='hour_start', data_type='timestamp', comment=None),
...
```

which caused the eventual user of the result (`create_table_metadata`) to encounter an exception because the metadata was not the type it was expecting.

This commit fixes this by returning an empty list instead of `raw_columns`, and adds a test to assert that this is the behavior if an exception is returned in `fetch_columns`.

### Tests
I added a test to simulate the behavior of `fetch_columns` with a non-existent table, which will cause an exception in the method.

### Documentation
N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
