### PR TITLE
fix: deployment-frontend env nested & quote issue

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/deployment-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-frontend.yaml
@@ -64,6 +64,10 @@ spec:
             value: http://{{ .Chart.Name }}-{{ .Values.metadata.serviceName }}:5002
           - name: LONG_RANDOM_STRING
             value: {{ quote .Values.LONG_RANDOM_STRING }}
+        {{- if .Values.frontEnd.ALL_UNEDITABLE_SCHEMAS }}
+        - name: ALL_UNEDITABLE_SCHEMAS
+          value: {{ quote .Values.frontEnd.ALL_UNEDITABLE_SCHEMAS }}
+        {{- end }}
         {{- if .Values.frontEnd.oidcEnabled }}
           - name: FRONTEND_SVC_CONFIG_MODULE_CLASS
             value: amundsen_application.oidc_config.OidcConfig
@@ -81,10 +85,6 @@ spec:
           - name: OVERWRITE_REDIRECT_URI
             value: {{ .Values.frontEnd.OVERWRITE_REDIRECT_URI }}
           {{- end }}
-          {{ - if .Values.frontEnd.ALL_UNEDITABLE_SCHEMAS }}
-          - name: ALL_UNEDITABLE_SCHEMAS
-            value: {{ .Values.frontEnd.ALL_UNEDITABLE_SCHEMAS }}
-          {{ - end } }
           - name: FLASK_OIDC_SECRET_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
### Summary of Changes

This commit fixes the deployment-frontend.yaml from a slightly bad change that was introduced in #1353. Namely:

- The logic to render the env var for `ALL_UNEDITABLE_SCHEMAS` was improperly nested in the OIDC config so if you wanted to use it but didn't populate OIDC config then the logic would not work
- Use the quote function to properly make an environment variable.

### Tests

Unforuntely there are no integration tests to make sure the helm chart compiles for different sets of values. I was only able to expose this issue when I tried to deploy #1353 in my production build. It would be nice to have that though? Maybe helm has something? Unsure at the moment.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
