### PR TITLE
chore: bump databuilder version to 5.2.6

### DIFF
--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '5.2.5'
+__version__ = '5.2.6'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
Signed-off-by: Parth Upadhyay <parth.upadhyay@gmail.com>

### Summary of Changes
Bumps databuilder to 5.2.6 to try again to release.

### Tests
N/A

### Documentation
N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [N/A] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [N/A] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
