### PR TITLE
feat: more general notices

### DIFF
--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -23,7 +23,6 @@ const withComputedMessage = (notice: NoticeType, resourceName) => {
   }
   return notice;
 };
-//determines whether or not a resource 
 const resourceMatches = (key: string, resource: string) => {
   if (key === resource || key === WILDCARD_SIGN) {
     return true;

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -23,6 +23,25 @@ const withComputedMessage = (notice: NoticeType, resourceName) => {
   }
   return notice;
 };
+//determines whether or not a resource 
+const resourceMatches = (key: string, resource: string) => {
+  if (key === resource || key === WILDCARD_SIGN) {
+    return true;
+  }
+  if (key.includes(WILDCARD_SIGN)) {
+    const wildcardIndex = key.indexOf(WILDCARD_SIGN);
+    const inverseWildcardIndex = -1 * (key.length - wildcardIndex - 1);
+    if (
+      key.slice(0, wildcardIndex) === resource.slice(0, wildcardIndex) &&
+      (wildcardIndex === key.length - 1 ||
+        key.slice(inverseWildcardIndex) ===
+          resource.slice(inverseWildcardIndex))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
 
 /**
  * Returns the display name for a given source id for a given resource type.
@@ -100,10 +119,7 @@ export function getResourceNotices(
       const decomposedResource = resourceName.split(RESOURCE_SEPARATOR);
 
       for (let i = 0; i < decomposedKey.length; i++) {
-        if (
-          decomposedKey[i] === decomposedResource[i] ||
-          decomposedKey[i] === WILDCARD_SIGN
-        ) {
+        if (resourceMatches(decomposedKey[i], decomposedResource[i])) {
           if (i === decomposedKey.length - 1) {
             wildcardNoticesArray[0] = notices[key];
             hasNotice = true;
@@ -114,7 +130,6 @@ export function getResourceNotices(
       }
     });
     if (hasNotice) {
-      // const noticeFromWildcard: NoticeType = wildcardNoticesArray[0];
       const [noticeFromWildcard] = wildcardNoticesArray;
       return withComputedMessage(noticeFromWildcard, resourceName);
     }

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -199,6 +199,18 @@ describe('getResourceNotices', () => {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
+          'gold.hive.core.fact_*': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
+          'gold.hive.core.*_rides': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
+          'gold.hive.core.fact*rides': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
         };
         const resources = [ResourceType.table, ResourceType.dashboard];
         for (const [noticeName, noticeParams] of Object.entries(noticesDict)) {
@@ -276,6 +288,10 @@ describe('getResourceNotices', () => {
             messageHtml: 'testMessage',
           },
           '*.hive.*.*': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+          },
+          '*.b*.*.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -113,7 +113,7 @@ describe('getResourceNotices', () => {
       const resources = [ResourceType.table, ResourceType.dashboard];
       resources.forEach((resource) => {
         AppConfig.resourceConfig[resource].notices = {
-          'gold.hive.core.fact_rides': {
+          'cluster1.datasource1.schema1.table1': {
             severity: NoticeSeverity.WARNING,
             messageHtml: (resourceName) => {
               const [cluster, datasource, schema, table] = resourceName.split(
@@ -123,10 +123,10 @@ describe('getResourceNotices', () => {
             },
           },
         };
-        const expected = 'gold, hive, core, fact_rides';
+        const expected = 'cluster1, datasource1, schema1, table1';
         const notice = ConfigUtils.getResourceNotices(
           resource,
-          'gold.hive.core.fact_rides'
+          'cluster1.datasource1.schema1.table1'
         );
         const actual = notice && notice.messageHtml;
 
@@ -139,77 +139,77 @@ describe('getResourceNotices', () => {
     describe('when there are wildcard(s) that match', () => {
       it('returns notice', () => {
         const noticesDict = {
-          '*.hive.core.fact_rides': {
+          '*.datasource.schema.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.*.core.fact_rides': {
+          'cluster.*.schema.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.hive.*.fact_rides': {
+          'cluster.datasource.*.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.hive.core.*': {
+          'cluster.datasource.schema.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          '*.*.core.fact_rides': {
+          '*.*.schema.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          '*.hive.*.fact_rides': {
+          '*.datasource.*.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          '*.hive.core.*': {
+          '*.datasource.schema.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.*.*.fact_rides': {
+          'cluster.*.*.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.*.core.*': {
+          'cluster.*.schema.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.hive.*.*': {
+          'cluster.datasource.*.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          '*.*.*.fact_rides': {
+          '*.*.*.table': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          '*.*.core.*': {
+          '*.*.schema.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.*.*.*': {
+          'cluster.*.*.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          '*.hive.*.*': {
+          '*.datasource.*.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
           '*.*.*.*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.hive.core.fact_*': {
+          'cluster.datasource.schema.tab*': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.hive.core.*_rides': {
+          'cluster.datasource.schema.*able': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
-          'gold.hive.core.fact*rides': {
+          'cluster.datasource.schema.ta*le': {
             severity: NoticeSeverity.WARNING,
-            messageHtml: 'testMessage',
+            messageHtml: 'testMessage1',
           },
         };
         const resources = [ResourceType.table, ResourceType.dashboard];
@@ -219,10 +219,10 @@ describe('getResourceNotices', () => {
             AppConfig.resourceConfig[resource].notices = {
               [noticeName]: noticeParams,
             };
-            const expected = 'testMessage';
+            const expected = 'testMessage1';
             const notice = ConfigUtils.getResourceNotices(
               resource,
-              'gold.hive.core.fact_rides'
+              'cluster.datasource.schema.table'
             );
             const actual = notice && notice.messageHtml;
 
@@ -235,59 +235,59 @@ describe('getResourceNotices', () => {
     describe("when there are wildcard(s) that don't match", () => {
       it('returns false', () => {
         const noticesDict = {
-          '*.hive.core.fact_rides': {
+          '*.datasource.schema.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.*.core.fact_rides': {
+          'cluster.*.schema.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.hive.*.fact_rides': {
+          'cluster.datasource.*.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.hive.core.*': {
+          'cluster.datasource.schema.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          '*.*.core.fact_rides': {
+          '*.*.schema.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          '*.hive.*.fact_rides': {
+          '*.datasource.*.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          '*.hive.core.*': {
+          '*.datasource.schema.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.*.*.fact_rides': {
+          'cluster.*.*.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.*.core.*': {
+          'cluster.*.schema.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.hive.*.*': {
+          'cluster.datasource.*.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          '*.*.*.fact_rides': {
+          '*.*.*.table': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          '*.*.core.*': {
+          '*.*.schema.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          'gold.*.*.*': {
+          'cluster.*.*.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
-          '*.hive.*.*': {
+          '*.datasource.*.*': {
             severity: NoticeSeverity.WARNING,
             messageHtml: 'testMessage',
           },
@@ -306,7 +306,7 @@ describe('getResourceNotices', () => {
             const expected = false;
             const notice = ConfigUtils.getResourceNotices(
               resource,
-              'cluster.datasource.schema.table'
+              'cluster1.datasource1.schema1.table1'
             );
             const actual = notice && notice.messageHtml;
 
@@ -321,11 +321,11 @@ describe('getResourceNotices', () => {
         const resources = [ResourceType.table, ResourceType.dashboard];
         resources.forEach((resource) => {
           AppConfig.resourceConfig[resource].notices = {
-            'gold.hive.*.*': {
+            'cluster.datasource.*.*': {
               severity: NoticeSeverity.WARNING,
               messageHtml: 'testMessage',
             },
-            'gold.hive.core.*': {
+            'cluster.datasource.schema.*': {
               severity: NoticeSeverity.WARNING,
               messageHtml: 'testMessage2',
             },
@@ -333,7 +333,7 @@ describe('getResourceNotices', () => {
           const expected = 'testMessage2';
           const notice = ConfigUtils.getResourceNotices(
             resource,
-            'gold.hive.core.fact_rides'
+            'cluster.datasource.schema.table'
           );
           const actual = notice && notice.messageHtml;
 
@@ -347,11 +347,11 @@ describe('getResourceNotices', () => {
         const resources = [ResourceType.table, ResourceType.dashboard];
         resources.forEach((resource) => {
           AppConfig.resourceConfig[resource].notices = {
-            'gold.hive.core.*': {
+            'cluster.datasource.schema.*': {
               severity: NoticeSeverity.WARNING,
               messageHtml: 'testMessage2',
             },
-            'gold.hive.shadow.*': {
+            'cluster.datasource.schema1.*': {
               severity: NoticeSeverity.WARNING,
               messageHtml: 'testMessage',
             },
@@ -359,7 +359,7 @@ describe('getResourceNotices', () => {
           const expected = 'testMessage2';
           const notice = ConfigUtils.getResourceNotices(
             resource,
-            'gold.hive.core.fact_rides'
+            'cluster.datasource.schema.table'
           );
           const actual = notice && notice.messageHtml;
 
@@ -373,7 +373,7 @@ describe('getResourceNotices', () => {
         const resources = [ResourceType.table, ResourceType.dashboard];
         resources.forEach((resource) => {
           AppConfig.resourceConfig[resource].notices = {
-            'gold.hive.core.*': {
+            'cluster1.datasource1.schema1.*': {
               severity: NoticeSeverity.WARNING,
               messageHtml: (resourceName) => {
                 const [cluster, datasource, schema, table] = resourceName.split(
@@ -383,10 +383,10 @@ describe('getResourceNotices', () => {
               },
             },
           };
-          const expected = 'gold, hive, core, fact_rides';
+          const expected = 'cluster1, datasource1, schema1, table1';
           const notice = ConfigUtils.getResourceNotices(
             resource,
-            'gold.hive.core.fact_rides'
+            'cluster1.datasource1.schema1.table1'
           );
           const actual = notice && notice.messageHtml;
 


### PR DESCRIPTION
### Summary of Changes

Update notices pattern matching to be more general so that `*.*.*.event_*` would put a notice on all tables that had a table name starting with event_ (for example). Right now, pattern matching on notices are only implemented so that you can match whole clusters, datasources, schemas, or tables, not part of tables.  One use case for this would be adding notices to all event tables in the case of a SEV.

### Tests

Added relevant test cases to existing tests for notices
