### PR TITLE
fix: Handle ParseException when reading schema property

### DIFF
--- a/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -15,7 +15,7 @@ from pyspark.sql.catalog import Table
 from pyspark.sql.types import (
     ArrayType, MapType, StructField, StructType,
 )
-from pyspark.sql.utils import AnalysisException
+from pyspark.sql.utils import AnalysisException, ParseException
 
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.models.table_last_updated import TableLastUpdated
@@ -297,7 +297,7 @@ class DeltaLakeMetadataExtractor(Extractor):
             raw_columns = self.spark.sql(f"describe {table_name}").collect()
             for field in self.spark.table(f"{table_name}").schema:
                 field_dict[field.name] = field
-        except AnalysisException as e:
+        except (AnalysisException, ParseException) as e:
             LOGGER.error(e)
             return []
         parsed_columns: Dict[str, ScrapedColumnMetadata] = {}


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

PR #1329 added a call to the schema property of the Dataframe.  For certain tables (a presto view in our case) Spark can throw a `ParseException`.  This change adds `ParseException` in the try block, and returns an empty list.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [N/A] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [N/A] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
