### PR TITLE
fix: Fixed postgresql extractor airflow DAG

### DIFF
--- a/databuilder/example/dags/postgres_sample_dag.py
+++ b/databuilder/example/dags/postgres_sample_dag.py
@@ -75,7 +75,7 @@ def connection_string():
 
 
 def create_table_extract_job():
-    where_clause_suffix = f'where table_schema in {SUPPORTED_SCHEMA_SQL_IN_CLAUSE}'
+    where_clause_suffix = f'st.schemaname in {SUPPORTED_SCHEMA_SQL_IN_CLAUSE}'
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'
     node_files_folder = f'{tmp_folder}/nodes/'


### PR DESCRIPTION
### Summary of Changes

Changed the name of a column in a SQL snippet which was throwing errors when running the postgresql extractor dag. Previously there was an erroneous 'where' and a column name was incorrectly referenced, so the DAG would not run successfully. I removed the 'where' and replaced the undefined column name with the one that is defined.

### Tests

No tests were modified or added, however this was tested manually by extracting from a PostgreSQL db. No tests were added since a database instance, and Apache Airflow is required to run the code. The change was tested locally and it made the Airflow DAG run sucessfully.

### Documentation

No documentation added.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x ] PR includes a summary of changes.
- [x ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
