### PR TITLE
fix: Removing hardcoded K8s Cluster Domain

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -29,7 +29,7 @@ This is setup templates for deploying [amundsen](https://github.com/amundsen-io/
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `clusterDomain`          | Cluster domain                                                                                            | `cluster.local` |
+| clusterDomain | string  | `cluster.local` | Kubernetes Cluster Domain |
 | LONG_RANDOM_STRING | int | `1234` | A long random string. You should probably provide your own. This is needed for OIDC. |
 | affinity | object | `{}` | amundsen application wide configuration of affinity. This applies to search, metadata, frontend and neo4j. Elasticsearch has it's own configuation properties for this. [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | dnsZone | string | `"teamname.company.com"` | **DEPRECATED - its not standard to pre construct urls this way.** The dns zone (e.g. group-qa.myaccount.company.com) the app is running in. Used to construct dns hostnames (on aws only). |

--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -29,6 +29,7 @@ This is setup templates for deploying [amundsen](https://github.com/amundsen-io/
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `clusterDomain`          | Cluster domain                                                                                            | `cluster.local` |
 | LONG_RANDOM_STRING | int | `1234` | A long random string. You should probably provide your own. This is needed for OIDC. |
 | affinity | object | `{}` | amundsen application wide configuration of affinity. This applies to search, metadata, frontend and neo4j. Elasticsearch has it's own configuation properties for this. [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | dnsZone | string | `"teamname.company.com"` | **DEPRECATED - its not standard to pre construct urls this way.** The dns zone (e.g. group-qa.myaccount.company.com) the app is running in. Used to construct dns hostnames (on aws only). |

--- a/amundsen-kube-helm/templates/helm/Chart.yaml
+++ b/amundsen-kube-helm/templates/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Amundsen is a metadata driven application for improving the productivity of data analysts, data scientists and engineers when interacting with data.
 name: amundsen
-version: 2.1.0
+version: 2.1.1
 icon: https://github.com/amundsen-io/amundsen/blob/master/docs/img/logos/amundsen_logo_on_light.svg
 home: https://github.com/amundsen-io/amundsen
 maintainers:

--- a/amundsen-kube-helm/templates/helm/templates/configmaps.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/configmaps.yaml
@@ -47,7 +47,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  PROXY_HOST: {{ if .Values.metadata.proxy.host }}{{ .Values.metadata.proxy.host }}{{ else }}bolt://{{ .Release.Name }}-neo4j.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
+  PROXY_HOST: {{ if .Values.metadata.proxy.host }}{{ .Values.metadata.proxy.host }}{{ else }}bolt://{{ .Release.Name }}-neo4j.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}{{ end }}
   {{ if .Values.metadata.proxy.port }}
   PROXY_PORT: {{ .Values.metadata.proxy.port }}
   {{ end }}
@@ -85,7 +85,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  PROXY_ENDPOINT: {{ if .Values.search.proxy.endpoint }}{{ .Values.search.proxy.endpoint }}{{ else }}{{ .Release.Name }}-elasticsearch-client.{{ .Release.Namespace }}.svc.cluster.local{{ end }}
+  PROXY_ENDPOINT: {{ if .Values.search.proxy.endpoint }}{{ .Values.search.proxy.endpoint }}{{ else }}{{ .Release.Name }}-elasticsearch-client.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}{{ end }}
   {{ if .Values.search.proxy.user }}
   CREDENTIALS_PROXY_USER: {{ .Values.search.proxy.user }}
   {{ end }}

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -1,5 +1,7 @@
 # Duplicate this file and put your customization here
 
+clusterDomain: cluster.local
+
 # common settings for all apps
 # NOTE - README table was generated with https://github.com/norwoodj/helm-docs
 # environment -- **DEPRECATED - its not standard to pre construct urls this way.** The environment the app is running in. Used to construct dns hostnames (on aws only) and ports.


### PR DESCRIPTION
### Summary of Changes

`cluster.local` was hardcoded in the ConfigMap which breaks the setup where the Kubernetes Cluster Domain is not the default. And, most of the production clusters running with custom domain names. It's good to have a variable to set the Cluster Domain. 

### Tests

- Deployed helm chart in Kubernetes cluster with different cluster domains
- Deployment completed 
- None of the apps were working as all apps were using services DNS with cluster.local as it was hardcoded in the ConfigMap

### Documentation

- Added `clusterDomain` variable and updated README.md

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
