### PR TITLE
fix: Application model backwards compatibility

### DIFF
--- a/databuilder/databuilder/models/application.py
+++ b/databuilder/databuilder/models/application.py
@@ -55,6 +55,7 @@ class Application(GraphSerializable, TableSerializable, AtlasSerializable):
                  schema: str = '',
                  table_name: str = '',
                  application_type: str = 'Airflow',
+                 exec_date: str = '',
                  ) -> None:
         # todo: need to modify this hack
         self.application_url = application_url_template.format(dag_id=dag_id)

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.0.2'
+__version__ = '6.0.3'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

In #1398 we generalized the Application model to be any application not just airflow. In that PR, I removed a arguement to the init for the model. This broke the sample data loader but it could also break peoples workflows who are already using Application model.

This commit brings the argument back.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
