### PR TITLE
feat: Adding ability to include conditions along with node and relation types in the neo4j staleness removal task

### DIFF
--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -1868,6 +1868,8 @@ Above configuration is trying to delete stale usage relation (READ, READ_BY), by
 #### Using node and relation conditions to remove stale data
 You may want to remove stale nodes and relations that meet certain conditions rather than all of a given type. To do this, you can specify the inputs to be a list of **TargetWithCondition** objects that each define a target type and a condition. Only stale nodes or relations of that type and that meet the condition will be removed when using this type of input.
 
+Node conditions can make use of the predefined variable `target` which represents the node. Relation conditions can include the variables `target`, `start_node`, and `end_node` where `target` represents the relation and `start_node`/`end_node` represent the nodes on either side of the target relation. For some examples of conditions see below.
+
     from databuilder.task.neo4j_staleness_removal_task import TargetWithCondition
     
     task = Neo4jStalenessRemovalTask()
@@ -1877,8 +1879,10 @@ You may want to remove stale nodes and relations that meet certain conditions ra
         'task.remove_stale_data.neo4j_user': neo4j_user,
         'task.remove_stale_data.neo4j_password': neo4j_password,
         'task.remove_stale_data.staleness_max_pct': 10,
-        'task.remove_stale_data.target_nodes': [TargetWithCondition('Table', '(target)-[:COLUMN]->(:Column)'), TargetWithCondition('Column', '(target)-[]-(:Table) AND target.name=\'column_name\'')],
-        'task.remove_stale_data.target_relations': [TargetWithCondition('COLUMN', '(start_node:Table)-[target]->(end_node:Column)'), TargetWithCondition('COLUMN', '(start_node)-[target]-(end_node)')],
+        'task.remove_stale_data.target_nodes': [TargetWithCondition('Table', '(target)-[:COLUMN]->(:Column)'),  # All Table nodes that have a directional COLUMN relation to a Column node
+                                                TargetWithCondition('Column', '(target)-[]-(:Table) AND target.name=\'column_name\'')],  # All Column nodes named 'column_name' that have some relation to a Table node
+        'task.remove_stale_data.target_relations': [TargetWithCondition('COLUMN', '(start_node:Table)-[target]->(end_node:Column)'),  # All COLUMN relations that connect from a Table node to a Column node
+                                                    TargetWithCondition('COLUMN', '(start_node:Column)-[target]-(end_node)')],  # All COLUMN relations that connect any direction between a Column node and another node
         'task.remove_stale_data.milliseconds_to_expire': 86400000 * 3
     }
     job_config = ConfigFactory.from_dict(job_config_dict)

--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -1865,6 +1865,28 @@ You can think this approach as TTL based eviction. This is particularly useful w
 
 Above configuration is trying to delete stale usage relation (READ, READ_BY), by deleting READ or READ_BY relation that has not been published past 3 days. If number of elements to be removed is more than 10% per type, this task will be aborted without executing any deletion.
 
+#### Using node and relation conditions to remove stale data
+You may want to remove stale nodes and relations that meet certain conditions rather than all of a given type. To do this, you can specify the inputs to be a list of **TargetWithCondition** objects that each define a target type and a condition. Only stale nodes or relations of that type and that meet the condition will be removed when using this type of input.
+
+    from databuilder.task.neo4j_staleness_removal_task import TargetWithCondition
+    
+    task = Neo4jStalenessRemovalTask()
+    job_config_dict = {
+        'job.identifier': 'remove_stale_data_job',
+        'task.remove_stale_data.neo4j_endpoint': neo4j_endpoint,
+        'task.remove_stale_data.neo4j_user': neo4j_user,
+        'task.remove_stale_data.neo4j_password': neo4j_password,
+        'task.remove_stale_data.staleness_max_pct': 10,
+        'task.remove_stale_data.target_nodes': [TargetWithCondition('Table', '(target)-[:COLUMN]->(:Column)'), TargetWithCondition('Column', '(target)-[]-(:Table) AND target.name=\'column_name\'')],
+        'task.remove_stale_data.target_relations': [TargetWithCondition('COLUMN', '(start_node:Table)-[target]->(end_node:Column)'), TargetWithCondition('COLUMN', '(start_node)-[target]-(end_node)')],
+        'task.remove_stale_data.milliseconds_to_expire': 86400000 * 3
+    }
+    job_config = ConfigFactory.from_dict(job_config_dict)
+    job = DefaultJob(conf=job_config, task=task)
+    job.launch()
+
+You can include multiple inputs of the same type with different conditions as seen in the **target_relations** list above. Attribute checks can also be added as shown in the **target_nodes** list.
+
 #### Dry run
 Deletion is always scary and it's better to perform dryrun before put this into action. You can use Dry run to see what sort of Cypher query will be executed.
 

--- a/databuilder/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/databuilder/task/neo4j_staleness_removal_task.py
@@ -5,7 +5,7 @@ import logging
 import textwrap
 import time
 from typing import (
-    Any, Dict, Iterable, Union
+    Any, Dict, Iterable, Union,
 )
 
 import neo4j

--- a/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -15,6 +15,7 @@ from pyhocon import ConfigFactory
 from databuilder.publisher import neo4j_csv_publisher
 from databuilder.task import neo4j_staleness_removal_task
 from databuilder.task.neo4j_staleness_removal_task import Neo4jStalenessRemovalTask
+from databuilder.task.neo4j_staleness_removal_task import TargetWithCondition
 
 
 class TestRemoveStaleData(unittest.TestCase):
@@ -38,8 +39,7 @@ class TestRemoveStaleData(unittest.TestCase):
             task.init(job_config)
             total_records = [{'type': 'foo', 'count': 100}]
             stale_records = [{'type': 'foo', 'count': 50}]
-            targets = {'foo'}
-            task._validate_staleness_pct(total_records=total_records, stale_records=stale_records, types=targets)
+            task._validate_staleness_pct(total_records=total_records, stale_records=stale_records)
 
     def test_validation(self) -> None:
 
@@ -57,8 +57,7 @@ class TestRemoveStaleData(unittest.TestCase):
             task.init(job_config)
             total_records = [{'type': 'foo', 'count': 100}]
             stale_records = [{'type': 'foo', 'count': 50}]
-            targets = {'foo'}
-            self.assertRaises(Exception, task._validate_staleness_pct, total_records, stale_records, targets)
+            self.assertRaises(Exception, task._validate_staleness_pct, total_records, stale_records)
 
     def test_validation_threshold_override(self) -> None:
 
@@ -79,8 +78,7 @@ class TestRemoveStaleData(unittest.TestCase):
                              {'type': 'bar', 'count': 100}]
             stale_records = [{'type': 'foo', 'count': 50},
                              {'type': 'bar', 'count': 3}]
-            targets = {'foo', 'bar'}
-            task._validate_staleness_pct(total_records=total_records, stale_records=stale_records, types=targets)
+            task._validate_staleness_pct(total_records=total_records, stale_records=stale_records)
 
     def test_marker(self) -> None:
         with patch.object(GraphDatabase, 'driver'):
@@ -123,6 +121,7 @@ class TestRemoveStaleData(unittest.TestCase):
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
                 neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
             })
 
@@ -131,30 +130,31 @@ class TestRemoveStaleData(unittest.TestCase):
 
             mock_execute.assert_called()
             mock_execute.assert_any_call(statement=textwrap.dedent("""
-            MATCH (n)
-            WITH DISTINCT labels(n) as node, count(*) as count
+            MATCH (target:Foo)
+            {}
+            WITH DISTINCT labels(target) as node, count(*) as count
             RETURN head(node) as type, count
-            """))
+            """.format(' ')))
 
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
-            MATCH (n)
+            MATCH (target:Foo)
             WHERE{}
-            n.published_tag <> $marker
-            OR NOT EXISTS(n.published_tag)
-            WITH DISTINCT labels(n) as node, count(*) as count
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            WITH DISTINCT labels(target) as node, count(*) as count
             RETURN head(node) as type, count
-            """.format(' ')))
+            """.format('   ')))
 
             task._validate_relation_staleness_pct()
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
-            MATCH ()-[n]-()
+            MATCH (start_node)-[target:BAR]-(end_node)
             WHERE{}
-            n.published_tag <> $marker
-            OR NOT EXISTS(n.published_tag)
-            RETURN type(n) as type, count(*) as count
-            """.format(' ')))
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            RETURN type(target) as type, count(*) as count
+            """.format('   ')))
 
     def test_validation_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
@@ -166,6 +166,8 @@ class TestRemoveStaleData(unittest.TestCase):
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
                 f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 9876543210
             })
 
@@ -174,30 +176,77 @@ class TestRemoveStaleData(unittest.TestCase):
 
             mock_execute.assert_called()
             mock_execute.assert_any_call(statement=textwrap.dedent("""
-            MATCH (n)
-            WITH DISTINCT labels(n) as node, count(*) as count
+            MATCH (target:Foo)
+            {}
+            WITH DISTINCT labels(target) as node, count(*) as count
             RETURN head(node) as type, count
-            """))
+            """.format(' ')))
 
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
-            MATCH (n)
+            MATCH (target:Foo)
             WHERE{}
-            n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
-            OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
-            WITH DISTINCT labels(n) as node, count(*) as count
+            target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
+            OR NOT EXISTS(target.publisher_last_updated_epoch_ms)
+            WITH DISTINCT labels(target) as node, count(*) as count
             RETURN head(node) as type, count
-            """.format(' ')))
+            """.format('   ')))
 
             task._validate_relation_staleness_pct()
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
-            MATCH ()-[n]-()
+            MATCH (start_node)-[target:BAR]-(end_node)
             WHERE{}
-            n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
-            OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
-            RETURN type(n) as type, count(*) as count
-            """.format(' ')))
+            target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
+            OR NOT EXISTS(target.publisher_last_updated_epoch_ms)
+            RETURN type(target) as type, count(*) as count
+            """.format('   ')))
+
+    def test_validation_statement_with_target_condition(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
+                as mock_execute:
+            task = Neo4jStalenessRemovalTask()
+            job_config = ConfigFactory.from_dict({
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': [TargetWithCondition('Foo', '(target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'')],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': [TargetWithCondition('BAR', '(start_node:Foo)-[target]->(end_node:Foo)')],
+                neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
+            })
+
+            task.init(job_config)
+            task._validate_node_staleness_pct()
+
+            mock_execute.assert_called()
+            mock_execute.assert_any_call(statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            {}
+            WITH DISTINCT labels(target) as node, count(*) as count
+            RETURN head(node) as type, count
+            """.format('WHERE (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'')))
+
+            mock_execute.assert_any_call(param_dict={'marker': u'foo'},
+                                         statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            WHERE{}
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            WITH DISTINCT labels(target) as node, count(*) as count
+            RETURN head(node) as type, count
+            """.format(' (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\' AND ')))
+
+            task._validate_relation_staleness_pct()
+            mock_execute.assert_any_call(param_dict={'marker': u'foo'},
+                                         statement=textwrap.dedent("""
+            MATCH (start_node)-[target:BAR]-(end_node)
+            WHERE{}
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            RETURN type(target) as type, count(*) as count
+            """.format(' (start_node:Foo)-[target]->(end_node:Foo) AND ')))
 
     def test_delete_statement_publish_tag(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
@@ -222,26 +271,26 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(dry_run=False,
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
-            MATCH (n:Foo)
+            MATCH (target:Foo)
             WHERE{}
-            n.published_tag <> $marker
-            OR NOT EXISTS(n.published_tag)
-            WITH n LIMIT $batch_size
-            DETACH DELETE (n)
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            WITH target LIMIT $batch_size
+            DETACH DELETE (target)
             RETURN COUNT(*) as count;
-            """.format(' ')))
+            """.format('   ')))
 
             mock_execute.assert_any_call(dry_run=False,
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
-            MATCH ()-[n:BAR]-()
+            MATCH (start_node)-[target:BAR]-(end_node)
             WHERE{}
-            n.published_tag <> $marker
-            OR NOT EXISTS(n.published_tag)
-            WITH n LIMIT $batch_size
-            DELETE n
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            WITH target LIMIT $batch_size
+            DELETE target
             RETURN count(*) as count;
-                        """.format(' ')))
+                        """.format('   ')))
 
     def test_delete_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
@@ -266,26 +315,70 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(dry_run=False,
                                          param_dict={'marker': 9876543210, 'batch_size': 100},
                                          statement=textwrap.dedent("""
-            MATCH (n:Foo)
+            MATCH (target:Foo)
             WHERE{}
-            n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
-            OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
-            WITH n LIMIT $batch_size
-            DETACH DELETE (n)
+            target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
+            OR NOT EXISTS(target.publisher_last_updated_epoch_ms)
+            WITH target LIMIT $batch_size
+            DETACH DELETE (target)
             RETURN COUNT(*) as count;
-            """.format(' ')))
+            """.format('   ')))
 
             mock_execute.assert_any_call(dry_run=False,
                                          param_dict={'marker': 9876543210, 'batch_size': 100},
                                          statement=textwrap.dedent("""
-            MATCH ()-[n:BAR]-()
+            MATCH (start_node)-[target:BAR]-(end_node)
             WHERE{}
-            n.publisher_last_updated_epoch_ms < (timestamp() - $marker)
-            OR NOT EXISTS(n.publisher_last_updated_epoch_ms)
-            WITH n LIMIT $batch_size
-            DELETE n
+            target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
+            OR NOT EXISTS(target.publisher_last_updated_epoch_ms)
+            WITH target LIMIT $batch_size
+            DELETE target
             RETURN count(*) as count;
-                        """.format(' ')))
+                        """.format('   ')))
+
+    def test_delete_statement_with_target_condition(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
+                as mock_execute:
+            mock_execute.return_value.single.return_value = {'count': 0}
+            task = Neo4jStalenessRemovalTask()
+            job_config = ConfigFactory.from_dict({
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': [TargetWithCondition('Foo', '(target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'')],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': [TargetWithCondition('BAR', '(start_node:Foo)-[target]->(end_node:Foo)')],
+                neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
+            })
+
+            task.init(job_config)
+            task._delete_stale_nodes()
+            task._delete_stale_relations()
+
+            mock_execute.assert_any_call(dry_run=False,
+                                         param_dict={'marker': u'foo', 'batch_size': 100},
+                                         statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            WHERE{}
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            WITH target LIMIT $batch_size
+            DETACH DELETE (target)
+            RETURN COUNT(*) as count;
+            """.format(' (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\' AND ')))
+
+            mock_execute.assert_any_call(dry_run=False,
+                                         param_dict={'marker': u'foo', 'batch_size': 100},
+                                         statement=textwrap.dedent("""
+            MATCH (start_node)-[target:BAR]-(end_node)
+            WHERE{}
+            target.published_tag <> $marker
+            OR NOT EXISTS(target.published_tag)
+            WITH target LIMIT $batch_size
+            DELETE target
+            RETURN count(*) as count;
+                        """.format(' (start_node:Foo)-[target]->(end_node:Foo) AND ')))
 
     def test_ms_to_expire_too_small(self) -> None:
         with patch.object(GraphDatabase, 'driver'):

--- a/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -141,18 +141,16 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_called()
             mock_execute.assert_any_call(statement=textwrap.dedent("""
             MATCH (target:Foo)
-            {}
-            WITH DISTINCT labels(target) as node, count(*) as count
-            RETURN head(node) as type, count
-            """.format(' ')))
+            WHERE true
+            RETURN count(*) as count
+            """))
 
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
             WHERE (target.published_tag <> $marker
             OR NOT EXISTS(target.published_tag))
-            WITH DISTINCT labels(target) as node, count(*) as count
-            RETURN head(node) as type, count
+            RETURN count(*) as count
             """))
 
             task._validate_relation_staleness_pct()
@@ -161,7 +159,7 @@ class TestRemoveStaleData(unittest.TestCase):
             MATCH (start_node)-[target:BAR]-(end_node)
             WHERE (target.published_tag <> $marker
             OR NOT EXISTS(target.published_tag))
-            RETURN type(target) as type, count(*) as count
+            RETURN count(*) as count
             """))
 
     def test_validation_statement_ms_to_expire(self) -> None:
@@ -185,18 +183,16 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_called()
             mock_execute.assert_any_call(statement=textwrap.dedent("""
             MATCH (target:Foo)
-            {}
-            WITH DISTINCT labels(target) as node, count(*) as count
-            RETURN head(node) as type, count
-            """.format(' ')))
+            WHERE true
+            RETURN count(*) as count
+            """))
 
             mock_execute.assert_any_call(param_dict={'marker': 9876543210},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
             WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(target.publisher_last_updated_epoch_ms))
-            WITH DISTINCT labels(target) as node, count(*) as count
-            RETURN head(node) as type, count
+            RETURN count(*) as count
             """))
 
             task._validate_relation_staleness_pct()
@@ -205,7 +201,7 @@ class TestRemoveStaleData(unittest.TestCase):
             MATCH (start_node)-[target:BAR]-(end_node)
             WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(target.publisher_last_updated_epoch_ms))
-            RETURN type(target) as type, count(*) as count
+            RETURN count(*) as count
             """))
 
     def test_validation_statement_with_target_condition(self) -> None:
@@ -229,9 +225,8 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_called()
             mock_execute.assert_any_call(statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'
-            WITH DISTINCT labels(target) as node, count(*) as count
-            RETURN head(node) as type, count
+            WHERE true AND (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'
+            RETURN count(*) as count
             """))
 
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
@@ -239,8 +234,7 @@ class TestRemoveStaleData(unittest.TestCase):
             MATCH (target:Foo)
             WHERE (target.published_tag <> $marker
             OR NOT EXISTS(target.published_tag)) AND (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'
-            WITH DISTINCT labels(target) as node, count(*) as count
-            RETURN head(node) as type, count
+            RETURN count(*) as count
             """))
 
             task._validate_relation_staleness_pct()
@@ -249,7 +243,7 @@ class TestRemoveStaleData(unittest.TestCase):
             MATCH (start_node)-[target:BAR]-(end_node)
             WHERE (target.published_tag <> $marker
             OR NOT EXISTS(target.published_tag)) AND (start_node:Foo)-[target]->(end_node:Foo)
-            RETURN type(target) as type, count(*) as count
+            RETURN count(*) as count
             """))
 
     def test_validation_receives_correct_counts(self) -> None:
@@ -270,13 +264,13 @@ class TestRemoveStaleData(unittest.TestCase):
             task.init(job_config)
 
             with patch.object(Neo4jStalenessRemovalTask, '_validate_staleness_pct') as mock_validate:
-                mock_execute.side_effect = [[{'type': 'Foo', 'count': 100}], [{'type': 'Foo', 'count': 50}]]
+                mock_execute.side_effect = [[{'count': 100}], [{'count': 50}]]
                 task._validate_node_staleness_pct()
                 mock_validate.assert_called_with(total_record_count=100,
                                                  stale_record_count=50,
                                                  target_type='Foo')
 
-                mock_execute.side_effect = [[{'type': 'BAR', 'count': 100}], [{'type': 'BAR', 'count': 50}]]
+                mock_execute.side_effect = [[{'count': 100}], [{'count': 50}]]
                 task._validate_relation_staleness_pct()
                 mock_validate.assert_called_with(total_record_count=100,
                                                  stale_record_count=50,
@@ -310,7 +304,7 @@ class TestRemoveStaleData(unittest.TestCase):
             OR NOT EXISTS(target.published_tag))
             WITH target LIMIT $batch_size
             DETACH DELETE (target)
-            RETURN COUNT(*) as count;
+            RETURN count(*) as count
             """))
 
             mock_execute.assert_any_call(dry_run=False,
@@ -321,7 +315,7 @@ class TestRemoveStaleData(unittest.TestCase):
             OR NOT EXISTS(target.published_tag))
             WITH target LIMIT $batch_size
             DELETE target
-            RETURN count(*) as count;
+            RETURN count(*) as count
             """))
 
     def test_delete_statement_ms_to_expire(self) -> None:
@@ -352,7 +346,7 @@ class TestRemoveStaleData(unittest.TestCase):
             OR NOT EXISTS(target.publisher_last_updated_epoch_ms))
             WITH target LIMIT $batch_size
             DETACH DELETE (target)
-            RETURN COUNT(*) as count;
+            RETURN count(*) as count
             """))
 
             mock_execute.assert_any_call(dry_run=False,
@@ -363,7 +357,7 @@ class TestRemoveStaleData(unittest.TestCase):
             OR NOT EXISTS(target.publisher_last_updated_epoch_ms))
             WITH target LIMIT $batch_size
             DELETE target
-            RETURN count(*) as count;
+            RETURN count(*) as count
             """))
 
     def test_delete_statement_with_target_condition(self) -> None:
@@ -394,7 +388,7 @@ class TestRemoveStaleData(unittest.TestCase):
             OR NOT EXISTS(target.published_tag)) AND (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'
             WITH target LIMIT $batch_size
             DETACH DELETE (target)
-            RETURN COUNT(*) as count;
+            RETURN count(*) as count
             """))
 
             mock_execute.assert_any_call(dry_run=False,
@@ -405,7 +399,7 @@ class TestRemoveStaleData(unittest.TestCase):
             OR NOT EXISTS(target.published_tag)) AND (start_node:Foo)-[target]->(end_node:Foo)
             WITH target LIMIT $batch_size
             DELETE target
-            RETURN count(*) as count;
+            RETURN count(*) as count
             """))
 
     def test_ms_to_expire_too_small(self) -> None:

--- a/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -14,8 +14,7 @@ from pyhocon import ConfigFactory
 
 from databuilder.publisher import neo4j_csv_publisher
 from databuilder.task import neo4j_staleness_removal_task
-from databuilder.task.neo4j_staleness_removal_task import Neo4jStalenessRemovalTask
-from databuilder.task.neo4j_staleness_removal_task import TargetWithCondition
+from databuilder.task.neo4j_staleness_removal_task import Neo4jStalenessRemovalTask, TargetWithCondition
 
 
 class TestRemoveStaleData(unittest.TestCase):

--- a/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -78,17 +78,12 @@ class TestRemoveStaleData(unittest.TestCase):
             })
 
             task.init(job_config)
-            total_records = [{'type': 'foo', 'count': 100},
-                             {'type': 'bar', 'count': 100}]
-            stale_records = [{'type': 'foo', 'count': 50},
-                             {'type': 'bar', 'count': 3}]
-            total_count_dict = {record['type']: int(record['count']) for record in total_records}
-            for stale_record in stale_records:
-                target_type = stale_record['type']
-                stale_count = stale_record['count']
-                task._validate_staleness_pct(total_record_count=total_count_dict[target_type],
-                                             stale_record_count=stale_count,
-                                             target_type=target_type)
+            task._validate_staleness_pct(total_record_count=100,
+                                         stale_record_count=50,
+                                         target_type='foo')
+            task._validate_staleness_pct(total_record_count=100,
+                                         stale_record_count=3,
+                                         target_type='bar')
 
     def test_marker(self) -> None:
         with patch.object(GraphDatabase, 'driver'):


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Currently, the neo4j staleness removal task can only remove stale nodes and/or relations based on specified types. This new functionality allows users to specify a condition along with the type. To do this, you can specify the inputs to be a list of `TargetWithCondition` objects that each define a target type and a condition. Only stale nodes or relations of that type and that meet the condition will be removed when using this type of input.

For example, you could add a condition that you only want to remove stale nodes of type Table that have some kind of relation to a node of type Column, rather than deleting all stale Table nodes.

This change is backwards compatible so users may continue to only specify the type without conditions for deleting stale nodes or relations.

### Tests

The tests have been updated in test_neo4j_staleness_removal_task.py along with the addition of two new tests: test_validation_statement_with_target_condition and test_delete_statement_with_target_condition. These test the validation and deletion of nodes and relations when target conditions are included.

### Documentation

A description of the feature has been added to databuilder/README.md to describe what the feature does and how to use it.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
