### PR TITLE
feat: Modifying the create issue action to send a link to the table from which the issue was created

### DIFF
--- a/frontend/amundsen_application/api/issue/issue.py
+++ b/frontend/amundsen_application/api/issue/issue.py
@@ -63,10 +63,12 @@ class IssueAPI(Resource):
             self.reqparse.add_argument('title', type=str, location='json')
             self.reqparse.add_argument('key', type=str, location='json')
             self.reqparse.add_argument('description', type=str, location='json')
+            self.reqparse.add_argument('resource_path', type=str, location='json')
             args = self.reqparse.parse_args()
             response = self.client.create_issue(description=args['description'],
                                                 table_uri=args['key'],
-                                                title=args['title'])
+                                                title=args['title'],
+                                                table_url=app.config['FRONTEND_BASE'] + args['resource_path'])
             return make_response(jsonify({'issue': response.serialize()}), HTTPStatus.OK)
 
         except IssueConfigurationException as e:

--- a/frontend/amundsen_application/api/issue/issue.py
+++ b/frontend/amundsen_application/api/issue/issue.py
@@ -68,7 +68,8 @@ class IssueAPI(Resource):
             response = self.client.create_issue(description=args['description'],
                                                 table_uri=args['key'],
                                                 title=args['title'],
-                                                table_url=app.config['FRONTEND_BASE'] + args['resource_path'])
+                                                table_url=app.config['FRONTEND_BASE'] + args['resource_path']
+                                                if args['resource_path'] else app.config['FRONTEND_BASE'])
             return make_response(jsonify({'issue': response.serialize()}), HTTPStatus.OK)
 
         except IssueConfigurationException as e:

--- a/frontend/amundsen_application/api/issue/issue.py
+++ b/frontend/amundsen_application/api/issue/issue.py
@@ -69,7 +69,7 @@ class IssueAPI(Resource):
                                                 table_uri=args['key'],
                                                 title=args['title'],
                                                 table_url=app.config['FRONTEND_BASE'] + args['resource_path']
-                                                if args['resource_path'] else app.config['FRONTEND_BASE'])
+                                                if args['resource_path'] else 'Not Found')
             return make_response(jsonify({'issue': response.serialize()}), HTTPStatus.OK)
 
         except IssueConfigurationException as e:

--- a/frontend/amundsen_application/base/base_issue_tracker_client.py
+++ b/frontend/amundsen_application/base/base_issue_tracker_client.py
@@ -21,7 +21,7 @@ class BaseIssueTrackerClient(abc.ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def create_issue(self, table_uri: str, title: str, description: str) -> DataIssue:
+    def create_issue(self, table_uri: str, title: str, description: str, table_url: str) -> DataIssue:
         """
         Given a title, description, and table key, creates a ticket in the configured project
         Automatically places the table_uri in the description of the ticket.
@@ -29,6 +29,7 @@ class BaseIssueTrackerClient(abc.ABC):
         :param description: user provided description for the jira ticket
         :param table_uri: Table URI ie databasetype://database/table
         :param title: Title of the ticket
+        :param table_url: Link to access the table
         :return: A single ticket
         """
         raise NotImplementedError  # pragma: no cover

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
@@ -57,12 +57,13 @@ class AsanaClient(BaseIssueTrackerClient):
             all_issues_url=self._task_url(table_parent_task_gid),
         )
 
-    def create_issue(self, table_uri: str, title: str, description: str) -> DataIssue:
+    def create_issue(self, table_uri: str, title: str, description: str, table_url: str) -> DataIssue:
         """
-        Creates an issue in Jira
-        :param description: Description of the Jira issue
+        Creates an issue in Asana
+        :param description: Description of the Asana issue
         :param table_uri: Table Uri ie databasetype://database/table
-        :param title: Title of the Jira ticket
+        :param title: Title of the Asana ticket
+        :param table_url: Link to access the table
         :return: Metadata about the newly created issue
         """
 
@@ -73,7 +74,7 @@ class AsanaClient(BaseIssueTrackerClient):
                 table_parent_task_gid,
                 {
                     'name': title,
-                    'notes': description,
+                    'notes': description + f'\n Table URL: {table_url}',
                 }
             )
         )

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -66,12 +66,13 @@ class JiraClient(BaseIssueTrackerClient):
             logging.exception(str(e))
             raise e
 
-    def create_issue(self, table_uri: str, title: str, description: str) -> DataIssue:
+    def create_issue(self, table_uri: str, title: str, description: str, table_url: str) -> DataIssue:
         """
         Creates an issue in Jira
         :param description: Description of the Jira issue
         :param table_uri: Table Uri ie databasetype://database/table
         :param title: Title of the Jira ticket
+        :param table_url: Link to access the table
         :return: Metadata about the newly created issue
         """
         try:
@@ -106,7 +107,8 @@ class JiraClient(BaseIssueTrackerClient):
                 summary=title,
                 description=(f'{description} '
                              f'\n Reported By: {user_email} '
-                             f'\n Table Key: {table_uri} [PLEASE DO NOT REMOVE]'),
+                             f'\n Table Key: {table_uri} [PLEASE DO NOT REMOVE] '
+                             f'\n Table URL: {table_url}'),
                 reporter=reporter))
             return self._get_issue_properties(issue=issue)
         except JIRAError as e:

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -526,14 +526,14 @@ exports[`eslint`] = {
     "js/ducks/issue/reducer.ts:1774302197": [
       [119, 6, 56, "Unexpected lexical declaration in case block.", "2031834906"]
     ],
-    "js/ducks/issue/tests/index.spec.ts:1694016813": [
-      [134, 8, 20, "\'allIssuesUrl\' is already declared in the upper scope.", "3551613994"],
-      [135, 8, 13, "\'total\' is already declared in the upper scope.", "1110344606"],
-      [245, 10, 32, "\'allIssuesUrl\' is already declared in the upper scope.", "3851993612"],
-      [246, 10, 25, "\'total\' is already declared in the upper scope.", "1495122296"],
-      [249, 8, 33, "Use object destructuring.", "2386588093"],
-      [250, 8, 31, "Use object destructuring.", "507617405"],
-      [251, 8, 45, "Use object destructuring.", "244310461"]
+    "js/ducks/issue/tests/index.spec.ts:2407012752": [
+      [136, 8, 20, "\'allIssuesUrl\' is already declared in the upper scope.", "3551613994"],
+      [137, 8, 13, "\'total\' is already declared in the upper scope.", "1110344606"],
+      [248, 10, 32, "\'allIssuesUrl\' is already declared in the upper scope.", "3851993612"],
+      [249, 10, 25, "\'total\' is already declared in the upper scope.", "1495122296"],
+      [252, 8, 33, "Use object destructuring.", "2386588093"],
+      [253, 8, 31, "Use object destructuring.", "507617405"],
+      [254, 8, 45, "Use object destructuring.", "244310461"]
     ],
     "js/ducks/lastIndexed/sagas.ts:1498244597": [
       [7, 2, 29, "\'action\' is defined but never used.", "566797395"]
@@ -900,26 +900,25 @@ exports[`eslint`] = {
       [63, 25, 1, "\'_\' is defined but never used.", "177658"],
       [66, 14, 204, "A control must be associated with a text label.", "3622841199"]
     ],
-    "js/pages/TableDetailPage/ReportTableIssue/index.spec.tsx:3198818853": [
+    "js/pages/TableDetailPage/ReportTableIssue/index.spec.tsx:834656134": [
       [7, 7, 9, "\'AppConfig\' is defined but never used.", "1320620174"],
       [11, 2, 14, "\'ComponentProps\' is defined but never used.", "2554343108"],
       [15, 2, 15, "\'mapStateToProps\' is defined but never used.", "1389821531"]
     ],
-    "js/pages/TableDetailPage/ReportTableIssue/index.tsx:2278973663": [
+    "js/pages/TableDetailPage/ReportTableIssue/index.tsx:3621699541": [
       [67, 4, 22, "Must use destructuring props assignment", "2426007440"],
-      [78, 11, 19, "Must use destructuring props assignment", "987121924"],
-      [83, 48, 24, "Must use destructuring props assignment", "2122165662"],
-      [84, 19, 22, "Must use destructuring props assignment", "2201312961"],
-      [90, 14, 20, "Must use destructuring props assignment", "1598284208"],
-      [100, 9, 17, "Must use destructuring state assignment", "4230747098"],
-      [103, 29, 17, "Must use destructuring state assignment", "4230747098"],
-      [103, 29, 10, "Use callback in setState when referencing the previous state.", "4014904506"],
-      [111, 15, 20, "Script URL is a form of eval.", "3959800777"],
-      [117, 9, 17, "Must use destructuring state assignment", "4230747098"],
-      [131, 16, 7, "A form label must be associated with a control.", "2729454337"],
-      [132, 16, 160, "A control must be associated with a text label.", "1834626670"],
-      [140, 16, 7, "A form label must be associated with a control.", "2729454337"],
-      [141, 16, 197, "A control must be associated with a text label.", "968313273"]
+      [82, 11, 19, "Must use destructuring props assignment", "987121924"],
+      [91, 19, 22, "Must use destructuring props assignment", "2201312961"],
+      [97, 14, 20, "Must use destructuring props assignment", "1598284208"],
+      [107, 9, 17, "Must use destructuring state assignment", "4230747098"],
+      [110, 29, 17, "Must use destructuring state assignment", "4230747098"],
+      [110, 29, 10, "Use callback in setState when referencing the previous state.", "4014904506"],
+      [118, 15, 20, "Script URL is a form of eval.", "3959800777"],
+      [124, 9, 17, "Must use destructuring state assignment", "4230747098"],
+      [138, 16, 7, "A form label must be associated with a control.", "2729454337"],
+      [139, 16, 160, "A control must be associated with a text label.", "1834626670"],
+      [147, 16, 7, "A form label must be associated with a control.", "2729454337"],
+      [148, 16, 197, "A control must be associated with a text label.", "968313273"]
     ],
     "js/pages/TableDetailPage/RequestDescriptionText/index.spec.tsx:2570104867": [
       [7, 7, 11, "\'globalState\' is defined but never used.", "1130616505"],

--- a/frontend/amundsen_application/static/js/ducks/issue/api/tests/index.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/api/tests/index.spec.ts
@@ -67,6 +67,7 @@ describe('createIssue', () => {
       key: 'key',
       title: 'title',
       description: 'description',
+      resource_path: 'resource_path',
     };
     sendNotificationPayload = {
       owners: ['owner1'],

--- a/frontend/amundsen_application/static/js/ducks/issue/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/api/v0.ts
@@ -32,6 +32,7 @@ export function createIssue(
       key: payload.key,
       title: payload.title,
       description: payload.description,
+      resource_path: payload.resource_path,
     })
     .then((response: AxiosResponse<IssueApi>) => {
       if (notificationsEnabled()) {

--- a/frontend/amundsen_application/static/js/ducks/issue/tests/index.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/tests/index.spec.ts
@@ -89,6 +89,7 @@ describe('issue ducks', () => {
         key,
         title,
         description,
+        resource_path: resourcePath,
       };
       const notificationPayload = {
         sender,
@@ -106,6 +107,7 @@ describe('issue ducks', () => {
       expect(payload.createIssuePayload.key).toBe(key);
       expect(payload.createIssuePayload.title).toBe(title);
       expect(payload.createIssuePayload.description).toBe(description);
+      expect(payload.createIssuePayload.resource_path).toBe(resourcePath);
       expect(payload.notificationPayload.options.resource_name).toBe(
         resourceName
       );
@@ -184,6 +186,7 @@ describe('issue ducks', () => {
         key,
         title,
         description,
+        resource_path: resourcePath,
       };
       const notificationPayload = {
         sender,
@@ -284,6 +287,7 @@ describe('issue ducks', () => {
           key,
           title,
           description,
+          resource_path: resourcePath,
         };
         const notificationPayload = {
           sender,

--- a/frontend/amundsen_application/static/js/interfaces/Issue.ts
+++ b/frontend/amundsen_application/static/js/interfaces/Issue.ts
@@ -11,4 +11,5 @@ export interface CreateIssuePayload {
   key: string;
   title: string;
   description: string;
+  resource_path: string;
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.spec.tsx
@@ -38,6 +38,7 @@ const mockCreateIssuePayload = {
   key: 'key',
   title: 'title',
   description: 'description',
+  resource_path: '/table_detail/cluster/database/schema/table_name',
 };
 
 const mockNotificationPayload = {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.tsx
@@ -70,7 +70,9 @@ export class ReportTableIssue extends React.Component<
   };
 
   getCreateIssuePayload = (formData: FormData): CreateIssuePayload => {
-    const { cluster, database, schema, name } = this.props.tableMetadata;
+    const {
+      tableMetadata: { cluster, database, schema, name },
+    } = this.props;
     const title = formData.get('title') as string;
     const description = formData.get('description') as string;
     const resourcePath = `/table_detail/${cluster}/${database}/${schema}/${name}`;
@@ -84,7 +86,9 @@ export class ReportTableIssue extends React.Component<
   };
 
   getNotificationPayload = (): NotificationPayload => {
-    const { cluster, database, schema, name } = this.props.tableMetadata;
+    const {
+      tableMetadata: { cluster, database, schema, name },
+    } = this.props;
     const owners = this.props.tableOwners;
     const resourceName = `${schema}.${name}`;
     const resourcePath = `/table_detail/${cluster}/${database}/${schema}/${name}`;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.tsx
@@ -70,13 +70,16 @@ export class ReportTableIssue extends React.Component<
   };
 
   getCreateIssuePayload = (formData: FormData): CreateIssuePayload => {
+    const { cluster, database, schema, name } = this.props.tableMetadata;
     const title = formData.get('title') as string;
     const description = formData.get('description') as string;
+    const resourcePath = `/table_detail/${cluster}/${database}/${schema}/${name}`;
 
     return {
       title,
       description,
       key: this.props.tableKey,
+      resource_path: resourcePath,
     };
   };
 

--- a/frontend/tests/unit/api/issue/test_issue.py
+++ b/frontend/tests/unit/api/issue/test_issue.py
@@ -15,6 +15,7 @@ local_app = create_app('amundsen_application.config.TestConfig', 'tests/template
 class IssueTest(unittest.TestCase):
 
     def setUp(self) -> None:
+        local_app.config['FRONTEND_BASE'] = 'http://url'
         local_app.config['ISSUE_TRACKER_URL'] = 'url'
         local_app.config['ISSUE_TRACKER_CLIENT_ENABLED'] = True
         self.mock_issue = {
@@ -99,7 +100,8 @@ class IssueTest(unittest.TestCase):
             response = test.post('/api/issue/issue', data={
                 'description': 'test description',
                 'title': 'test title',
-                'key': 'key'
+                'key': 'key',
+                'resource_path': '/table_detail/cluster/database/schema/table_name'
             })
             self.assertEqual(response.status_code, HTTPStatus.ACCEPTED)
 
@@ -115,7 +117,8 @@ class IssueTest(unittest.TestCase):
             response = test.post('/api/issue/issue', data={
                 'description': 'test description',
                 'title': 'test title',
-                'key': 'key'
+                'key': 'key',
+                'resource_path': '/table_detail/cluster/database/schema/table_name'
             })
             self.assertEqual(response.status_code, HTTPStatus.NOT_IMPLEMENTED)
 
@@ -128,6 +131,7 @@ class IssueTest(unittest.TestCase):
             response = test.post('/api/issue/issue', data={
                 'key': 'table_key',
                 'title': 'test title',
+                'resource_path': '/table_detail/cluster/database/schema/table_name'
             })
             self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
@@ -139,7 +143,8 @@ class IssueTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.post('/api/issue/issue', data={
                 'description': 'test description',
-                'title': 'test title'
+                'title': 'test title',
+                'resource_path': '/table_detail/cluster/database/schema/table_name'
             })
             self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
@@ -152,6 +157,20 @@ class IssueTest(unittest.TestCase):
             response = test.post('/api/issue/issue', data={
                 'description': 'test description',
                 'key': 'table_key',
+                'resource_path': '/table_detail/cluster/database/schema/table_name'
+            })
+            self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    def test_create_jira_issue_no_resource_path(self) -> None:
+        """
+         Test request failure if resource path is missing
+         :return:
+         """
+        with local_app.test_client() as test:
+            response = test.post('/api/issue/issue', data={
+                'description': 'test description',
+                'title': 'test title',
+                'key': 'key'
             })
             self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
@@ -169,7 +188,8 @@ class IssueTest(unittest.TestCase):
                                  data={
                                      'description': 'test description',
                                      'title': 'title',
-                                     'key': 'key'
+                                     'key': 'key',
+                                     'resource_path': '/table_detail/cluster/database/schema/table_name'
                                  })
             data = json.loads(response.data)
             self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/frontend/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/frontend/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -150,7 +150,7 @@ class JiraClientTest(unittest.TestCase):
                                          issue_tracker_password=app.config['ISSUE_TRACKER_PASSWORD'],
                                          issue_tracker_project_id=app.config['ISSUE_TRACKER_PROJECT_ID'],
                                          issue_tracker_max_results=app.config['ISSUE_TRACKER_MAX_RESULTS'])
-                jira_client.create_issue(description='desc', table_uri='key', title='title')
+                jira_client.create_issue(description='desc', table_uri='key', title='title', table_url='http://table')
             except JIRAError as e:
                 self.assertTrue(type(e), type(JIRAError))
                 self.assertTrue(e, 'Some exception')
@@ -169,7 +169,10 @@ class JiraClientTest(unittest.TestCase):
                                      issue_tracker_password=app.config['ISSUE_TRACKER_PASSWORD'],
                                      issue_tracker_project_id=app.config['ISSUE_TRACKER_PROJECT_ID'],
                                      issue_tracker_max_results=app.config['ISSUE_TRACKER_MAX_RESULTS'])
-            results = jira_client.create_issue(description='desc', table_uri='key', title='title')
+            results = jira_client.create_issue(description='desc',
+                                               table_uri='key',
+                                               title='title',
+                                               table_url='http://table')
             mock_JIRA_client.assert_called
             self.assertEqual(results, self.mock_issue_instance)
             mock_JIRA_client.return_value.create_issue.assert_called_with(fields=dict(project={
@@ -179,5 +182,8 @@ class JiraClientTest(unittest.TestCase):
                 'name': 'Bug',
             }, labels=mock_labels,
                 summary='title',
-                description='desc \n Reported By: test@email.com \n Table Key: key [PLEASE DO NOT REMOVE]',
+                description=("desc \n "
+                             "Reported By: test@email.com \n "
+                             "Table Key: key [PLEASE DO NOT REMOVE] \n "
+                             "Table URL: http://table"),
                 reporter={'name': 'test'}))


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

When Jira tickets are created from the `Report an issue` button in a table view, there is no way to return to the table from which the ticket was created. This change sends the link to the table in the create issue API, and the Jira client adds the link to the description for created tickets.

### Tests

I modified JS tests to include the resource path of the table wherever `CreateIssuePayload`s were defined, and I modified `test_jira_client.py` to ensure that the link is added to the description properly.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
