### PR TITLE
feat: Add bigquery column mode when consuming bigquery metadata

### DIFF
--- a/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
@@ -89,7 +89,8 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                            column: Dict[str, str],
                            cols: List[ColumnMetadata],
                            total_cols: int) -> int:
-        get_column_type:Callable[[dict], str] = lambda column: column.get('mode') + ':' + column['type'] if column.get('mode') else column['type']
+        get_column_type: Callable[[dict], str] = lambda column: column.get('mode') + ':' + column['type']\
+            if column.get('mode') else column['type']
         if len(parent) > 0:
             col_name = f'{parent}.{column["name"]}'
         else:
@@ -111,7 +112,6 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                 total_cols = self._iterate_over_cols(col_name, field_casted, cols, total_cols)
             return total_cols
         else:
-            col_type = column.get('mode') + ':' + column['type'] if column.get('mode') else column['type']
             col = ColumnMetadata(
                 name=col_name,
                 description=column.get('description', ''),

--- a/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
@@ -3,7 +3,7 @@
 
 import logging
 from typing import (
-    Any, Dict, List, Set, cast,
+    Any, Callable, Dict, List, Set, cast,
 )
 
 from pyhocon import ConfigTree
@@ -89,6 +89,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                            column: Dict[str, str],
                            cols: List[ColumnMetadata],
                            total_cols: int) -> int:
+        get_column_type:Callable[[dict], str] = lambda column: column.get('mode') + ':' + column['type'] if column.get('mode') else column['type']
         if len(parent) > 0:
             col_name = f'{parent}.{column["name"]}'
         else:
@@ -98,7 +99,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
             col = ColumnMetadata(
                 name=col_name,
                 description=column.get('description', ''),
-                col_type=column['type'],
+                col_type=get_column_type(column),
                 sort_order=total_cols)
             cols.append(col)
             total_cols += 1
@@ -110,10 +111,11 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                 total_cols = self._iterate_over_cols(col_name, field_casted, cols, total_cols)
             return total_cols
         else:
+            col_type = column.get('mode') + ':' + column['type'] if column.get('mode') else column['type']
             col = ColumnMetadata(
                 name=col_name,
                 description=column.get('description', ''),
-                col_type=column['type'],
+                col_type=get_column_type(column),
                 sort_order=total_cols)
             cols.append(col)
             return total_cols + 1

--- a/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
@@ -89,7 +89,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                            column: Dict[str, str],
                            cols: List[ColumnMetadata],
                            total_cols: int) -> int:
-        get_column_type: Callable[[dict], str] = lambda column: column.get('mode') + ':' + column['type']\
+        get_column_type: Callable[[dict], str] = lambda column: column['type'] + ':' + column['mode']\
             if column.get('mode') else column['type']
         if len(parent) > 0:
             col_name = f'{parent}.{column["name"]}'

--- a/databuilder/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/databuilder/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -383,4 +383,4 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEqual(second_col.type, 'RECORD')
         third_col = result.columns[2]
         self.assertEqual(third_col.name, 'nested.nested2.repeated')
-        self.assertEqual(third_col.type, 'REPEATED:STRING')
+        self.assertEqual(third_col.type, 'STRING:REPEATED')

--- a/databuilder/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/databuilder/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -164,6 +164,23 @@ NESTED_DATA = {
     'location': 'EU'
 }  # noqa
 
+REPEATED_DATA = {
+    'kind': 'bigquery#table', 'etag': 'Hzc/56Rp9VR4Y6jhZApD/g==', 'id': 'your-project-here:fdgdfgh.test',
+    'selfLink': 'https://www.googleapis.com/bigquery/v2/projects/your-project-here/datasets/fdgdfgh/tables/test',
+    'tableReference': {'projectId': 'your-project-here', 'datasetId': 'fdgdfgh', 'tableId': 'test'},
+    'schema': {
+        'fields': [{
+            'name': 'nested', 'type': 'RECORD',
+            'fields': [{
+                'name': 'nested2', 'type': 'RECORD',
+                'fields': [{'name': 'repeated', 'type': 'STRING', 'mode': 'REPEATED'}]
+            }]
+        }]
+    },
+    'type': 'TABLE',
+    'location': 'EU'
+}  # noqa
+
 try:
     FileNotFoundError
 except NameError:
@@ -349,3 +366,21 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
 
         self.assertEqual(count, 1)
         self.assertEqual(table_name, 'date_range_')
+
+    @patch('databuilder.extractor.base_bigquery_extractor.build')
+    def test_table_with_repeated_records(self, mock_build: Any) -> None:
+        mock_build.return_value = MockBigQueryClient(ONE_DATASET, ONE_TABLE, REPEATED_DATA)
+        extractor = BigQueryMetadataExtractor()
+        extractor.init(Scoped.get_scoped_conf(conf=self.conf,
+                                              scope=extractor.get_scope()))
+        result = extractor.extract()
+
+        first_col = result.columns[0]
+        self.assertEqual(first_col.name, 'nested')
+        self.assertEqual(first_col.type, 'RECORD')
+        second_col = result.columns[1]
+        self.assertEqual(second_col.name, 'nested.nested2')
+        self.assertEqual(second_col.type, 'RECORD')
+        third_col = result.columns[2]
+        self.assertEqual(third_col.name, 'nested.nested2.repeated')
+        self.assertEqual(third_col.type, 'REPEATED:STRING')


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

This PR intends to add the column mode when consuming column metadata for bigquery. The column mode indicates if the column is of an array type.

### Tests

Added a test case for a repeated nested field
### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
