### PR TITLE
chore: allow google-auth, google-api-python-client < 3

### DIFF
--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -31,9 +31,12 @@ athena = ['PyAthena[SQLAlchemy]>=1.0.0, <2.0.0']
 # License: Apache Software License
 # Upstream url: https://github.com/googleapis/google-api-python-client
 bigquery = [
-    'google-api-python-client>=1.6.0, <2.0.0dev',
+    'google-api-python-client>=1.6.0, <3.0.0dev',
     'google-auth-httplib2>=0.0.1',
-    'google-auth>=1.0.0, <2.0.0dev'
+    # Maintainers, please do not require google-api-core>=2.x.x
+    # Until this issue is closed
+    # https://github.com/googleapis/google-cloud-python/issues/10566
+    'google-auth>=1.0.0, <3.0.0dev'
 ]
 
 jsonpath = ['jsonpath_rw==1.4.0']


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

This PR expands the upper range on `google-auth` and `google-api-python-client` to <3.0.0.

#### Justification for `google-auth`

`google-auth` recently published a 2.0.0 release which removed support for Python 2.7. `google-auth` now requires Python >=3.6. No other breaking changes were made. You can see the full list of changes [here](https://github.com/googleapis/google-auth-library-python/commit/560cf1ed02a900436c5d9e0a0fb3f94b5fd98c55).

I am opening PRs to expand google-auth version ranges for packages that meet either of the following criteria:
* Package has >10,000 monthly downloads as of June 2021
* Package is owned by a Google team

`google-auth` is a dependency of many different libraries that interact with Google APIs. Increasing the time and number of packages with compatible pins on `google-auth` lowers the chance end developers who use multiple libraries will see dependency conflicts. 

If possible, please do not require `google-auth>2.0.0` until this issue is resolved
https://github.com/googleapis/google-cloud-python/issues/10566, as that will further reduce the likelihood of diamond dependency conflicts.

Googlers, see [this doc](https://docs.google.com/document/d/1euAvUsia_4zf98lNvpwA3K0o2b4y5Xr9xAkyzCnIMzQ/edit) for more information.

#### Justification for `google-api-python-client`

Code written against 1.x.x versions of google-api-python-client is compatible with 2.x.x versions. A full list of changes are described in [this document](https://github.com/googleapis/google-api-python-client/blob/main/UPGRADING.md). 

Notable changes:
- Removed support for Python 2.7.
- Fetches discovery documents (API definitions) from the library package rather than from https://www.googleapis.com/discovery/v1/apis at runtime, which is better for reliability.

Similar to google-auth, it would be nice to expand the pins on this package if possible to lower the likelihood of dependency conflicts.






### Tests

N/A, dependency-only change

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
