### PR TITLE
feat: extend search result click logging

### DIFF
--- a/frontend/amundsen_application/static/js/components/ResourceListItem/DashboardListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/DashboardListItem/index.tsx
@@ -48,6 +48,7 @@ class DashboardListItem extends React.Component<DashboardListItemProps, {}> {
             logClick(e, {
               target_id: 'dashboard_list_item',
               value: logging.source,
+              position: logging.index.toString(),
             })
           }
         >

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/FeatureListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/FeatureListItem/index.tsx
@@ -41,6 +41,7 @@ const FeatureListItem: React.FC<FeatureListItemProps> = ({
           logClick(e, {
             target_id: 'feature_list_item',
             value: logging.source,
+            position: logging.index.toString(),
           })
         }
       >

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -33,7 +33,7 @@ const TableListItem: React.FC<TableListItemProps> = ({ table, logging }) => (
       className="resource-list-item table-list-item"
       to={getLink(table, logging)}
       onClick={(e) =>
-        logClick(e, { target_id: 'table_list_item', value: logging.source })
+        logClick(e, { target_id: 'table_list_item', value: logging.source, position: logging.index.toString() })
       }
     >
       <div className="resource-info">

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -33,7 +33,11 @@ const TableListItem: React.FC<TableListItemProps> = ({ table, logging }) => (
       className="resource-list-item table-list-item"
       to={getLink(table, logging)}
       onClick={(e) =>
-        logClick(e, { target_id: 'table_list_item', value: logging.source, position: logging.index.toString() })
+        logClick(e, {
+          target_id: 'table_list_item',
+          value: logging.source,
+          position: logging.index.toString(),
+        })
       }
     >
       <div className="resource-info">

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/UserListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/UserListItem/index.tsx
@@ -45,7 +45,11 @@ class UserListItem extends React.Component<UserListItemProps, {}> {
           className="resource-list-item user-list-item"
           to={this.getLink()}
           onClick={(e) =>
-            logClick(e, { target_id: 'user_list_item', value: logging.source })
+            logClick(e, {
+              target_id: 'user_list_item',
+              value: logging.source,
+              position: logging.index.toString(),
+            })
           }
         >
           <div className="resource-info">

--- a/frontend/amundsen_application/static/js/ducks/log/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/log/api/v0.ts
@@ -14,6 +14,7 @@ export interface ClickLogParams {
   target_type?: string;
   label?: string;
   value?: string;
+  position?: string;
 }
 
 export const BASE_URL = '/api/log/v0/log_event';


### PR DESCRIPTION
Added field `position` to click log object which captures the position of the clicked search result on the search results page.