### PR TITLE
chore: pin rds package version in databuilder

### DIFF
--- a/databuilder/example/scripts/sample_data_loader_mysql.py
+++ b/databuilder/example/scripts/sample_data_loader_mysql.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-TODO: it needs db init(in dev) first in metadata service
+Please init/upgrade db first in metadata service if needed.
+
 This is a example script demonstrating how to load data into MySQL and
 Elasticsearch without using an Airflow DAG.
 

--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -26,4 +26,4 @@ pandas>=0.21.0,<1.2.0
 responses>=0.10.6
 
 amundsen-common>=0.16.0
-amundsen-rds>=0.0.4
+amundsen-rds==0.0.5

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.2.0'
+__version__ = '6.2.1'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
### Summary of Changes

- Pin rds package version to 0.0.5 in databuilder to make it consistent with [metadata_service](https://github.com/amundsen-io/amundsen/blob/main/metadata/setup.py#L24)
- Bump databuilder version to 6.2.1
- Removed the stale 'ToDo' comment in sample_data_loader_mysql.py

### Tests

No real code change

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
