### PR TITLE
fix: Update no partitions message

### DIFF
--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/WatermarkLabel/constants.ts
@@ -1,4 +1,4 @@
-export const NO_WATERMARK_LINE_1 = 'No partitions found';
+export const NO_WATERMARK_LINE_1 = 'No valid partitions found';
 export const NO_WATERMARK_LINE_2 = 'Unknown date range';
 export const LOW_WATERMARK_LABEL = 'From:';
 export const HIGH_WATERMARK_LABEL = 'To:';


### PR DESCRIPTION
"Data available for all dates" was promising a bit much. And saying the table is Non-Partitioned was a bit strong, given all we know is the lack of watermarks.
