### PR TITLE
fix: PreviewData undefined pointer issue

### DIFF
--- a/frontend/amundsen_application/static/js/features/PreviewData/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/PreviewData/index.spec.tsx
@@ -57,6 +57,13 @@ describe('getSanitizedValue', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('returns undefined as empty string', () => {
+    const input = { 'key-1': 2 };
+    const expected = '';
+    const actual = getSanitizedValue(input['non-existent-key']);
+    expect(actual).toEqual(expected);
+  });
+
   it('returns a string as-is', () => {
     const input = 'hello';
     const expected = 'hello';

--- a/frontend/amundsen_application/static/js/features/PreviewData/index.tsx
+++ b/frontend/amundsen_application/static/js/features/PreviewData/index.tsx
@@ -37,6 +37,8 @@ export const getSanitizedValue = (value) => {
     sanitizedValue = value.toString();
   } else if (typeof value === 'object') {
     sanitizedValue = JSON.stringify(value);
+  } else if (typeof value === 'undefined') {
+    sanitizedValue = '';
   } else {
     sanitizedValue = value;
   }


### PR DESCRIPTION
### Summary of Changes

This commit fixes an issue where when you have PreviewData with list items that don't have all columns (which is can happen with nested data structures) the getSanitizedValue function returns an empty string rather than trying to do .length of undefined.

### Tests

Added a test case

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.