### PR TITLE
feat: Allow override of default issue tracking project and improving sorting of issues displayed

### DIFF
--- a/frontend/amundsen_application/api/issue/issue.py
+++ b/frontend/amundsen_application/api/issue/issue.py
@@ -66,12 +66,14 @@ class IssueAPI(Resource):
             self.reqparse.add_argument('owner_ids', type=list, location='json')
             self.reqparse.add_argument('frequent_user_ids', type=list, location='json')
             self.reqparse.add_argument('priority_level', type=str, location='json')
+            self.reqparse.add_argument('project_key', type=str, location='json')
             self.reqparse.add_argument('resource_path', type=str, location='json')
             args = self.reqparse.parse_args()
             response = self.client.create_issue(description=args['description'],
                                                 owner_ids=args['owner_ids'],
                                                 frequent_user_ids=args['frequent_user_ids'],
                                                 priority_level=args['priority_level'],
+                                                project_key=args['project_key'],
                                                 table_uri=args['key'],
                                                 title=args['title'],
                                                 table_url=app.config['FRONTEND_BASE'] + args['resource_path']

--- a/frontend/amundsen_application/base/base_issue_tracker_client.py
+++ b/frontend/amundsen_application/base/base_issue_tracker_client.py
@@ -39,9 +39,6 @@ class BaseIssueTrackerClient(abc.ABC):
         :param table_uri: Table URI ie databasetype://database/table
         :param title: Title of the ticket
         :param table_url: Link to access the table
-        :param owner_ids: List of user ids that represent the owners of the table
-        :param frequent_user_ids: List of user ids that represent the frequent users of the table
-        :param project_key: Issue tracking project key to specify where the ticket should be created
         :return: A single ticket
         """
         raise NotImplementedError  # pragma: no cover

--- a/frontend/amundsen_application/base/base_issue_tracker_client.py
+++ b/frontend/amundsen_application/base/base_issue_tracker_client.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-from typing import List
 
 from amundsen_application.models.data_issue import DataIssue
 from amundsen_application.models.issue_results import IssueResults
@@ -27,23 +26,21 @@ class BaseIssueTrackerClient(abc.ABC):
                      table_uri: str,
                      title: str,
                      description: str,
-                     owner_ids: List[str],
-                     frequent_user_ids: List[str],
                      priority_level: str,
-                     project_key: str,
-                     table_url: str) -> DataIssue:
+                     table_url: str,
+                     **kwargs) -> DataIssue:
         """
         Given a title, description, and table key, creates a ticket in the configured project
         Automatically places the table_uri in the description of the ticket.
         Returns the ticket information, including URL.
         :param description: User provided description for the jira ticket
-        :param owner_ids: List of user ids that represent the owners of the table
-        :param frequent_user_ids: List of user ids that represent the frequent users of the table
         :param priority_level: Priority level for the ticket
-        :param project_key: Issue tracking project key to specify where the ticket should be created
         :param table_uri: Table URI ie databasetype://database/table
         :param title: Title of the ticket
         :param table_url: Link to access the table
+        :param owner_ids: List of user ids that represent the owners of the table
+        :param frequent_user_ids: List of user ids that represent the frequent users of the table
+        :param project_key: Issue tracking project key to specify where the ticket should be created
         :return: A single ticket
         """
         raise NotImplementedError  # pragma: no cover

--- a/frontend/amundsen_application/base/base_issue_tracker_client.py
+++ b/frontend/amundsen_application/base/base_issue_tracker_client.py
@@ -30,6 +30,7 @@ class BaseIssueTrackerClient(abc.ABC):
                      owner_ids: List[str],
                      frequent_user_ids: List[str],
                      priority_level: str,
+                     project_key: str,
                      table_url: str) -> DataIssue:
         """
         Given a title, description, and table key, creates a ticket in the configured project
@@ -39,6 +40,7 @@ class BaseIssueTrackerClient(abc.ABC):
         :param owner_ids: List of user ids that represent the owners of the table
         :param frequent_user_ids: List of user ids that represent the frequent users of the table
         :param priority_level: Priority level for the ticket
+        :param project_key: Issue tracking project key to specify where the ticket should be created
         :param table_uri: Table URI ie databasetype://database/table
         :param title: Title of the ticket
         :param table_url: Link to access the table

--- a/frontend/amundsen_application/base/base_issue_tracker_client.py
+++ b/frontend/amundsen_application/base/base_issue_tracker_client.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
+from typing import Any
 
 from amundsen_application.models.data_issue import DataIssue
 from amundsen_application.models.issue_results import IssueResults
@@ -28,7 +29,7 @@ class BaseIssueTrackerClient(abc.ABC):
                      description: str,
                      priority_level: str,
                      table_url: str,
-                     **kwargs) -> DataIssue:
+                     **kwargs: Any) -> DataIssue:
         """
         Given a title, description, and table key, creates a ticket in the configured project
         Automatically places the table_uri in the description of the ticket.

--- a/frontend/amundsen_application/models/issue_results.py
+++ b/frontend/amundsen_application/models/issue_results.py
@@ -9,18 +9,30 @@ class IssueResults:
     def __init__(self,
                  issues: List[DataIssue],
                  total: int,
-                 all_issues_url: str) -> None:
+                 open_count: int,
+                 all_issues_url: str,
+                 open_issues_url: str,
+                 closed_issues_url: str) -> None:
         """
         Returns an object representing results from an issue tracker.
         :param issues: Issues in the issue tracker matching the requested table
         :param total: How many issues in all are associated with this table
+        :param open_count: How many open issues are associated with this table
         :param all_issues_url: url to the all issues in the issue tracker
+        :param open_issues_url: url to the open issues in the issue tracker
+        :param closed_issues_url: url to the closed issues in the issue tracker
         """
         self.issues = issues
         self.total = total
+        self.open_count = open_count
         self.all_issues_url = all_issues_url
+        self.open_issues_url = open_issues_url
+        self.closed_issues_url = closed_issues_url
 
     def serialize(self) -> Dict:
         return {'issues': [issue.serialize() for issue in self.issues],
                 'total': self.total,
-                'all_issues_url': self.all_issues_url}
+                'open_count': self.open_count,
+                'all_issues_url': self.all_issues_url,
+                'open_issues_url': self.open_issues_url,
+                'closed_issues_url': self.closed_issues_url}

--- a/frontend/amundsen_application/models/issue_results.py
+++ b/frontend/amundsen_application/models/issue_results.py
@@ -2,37 +2,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from amundsen_application.models.data_issue import DataIssue
-from typing import List, Dict
+from typing import Dict, List, Optional
 
 
 class IssueResults:
     def __init__(self,
                  issues: List[DataIssue],
                  total: int,
-                 open_count: int,
                  all_issues_url: str,
-                 open_issues_url: str,
-                 closed_issues_url: str) -> None:
+                 open_issues_url: Optional[str] = '',
+                 closed_issues_url: Optional[str] = '',
+                 open_count: Optional[int] = 0) -> None:
         """
         Returns an object representing results from an issue tracker.
         :param issues: Issues in the issue tracker matching the requested table
         :param total: How many issues in all are associated with this table
-        :param open_count: How many open issues are associated with this table
         :param all_issues_url: url to the all issues in the issue tracker
         :param open_issues_url: url to the open issues in the issue tracker
         :param closed_issues_url: url to the closed issues in the issue tracker
+        :param open_count: How many open issues are associated with this table
         """
         self.issues = issues
         self.total = total
-        self.open_count = open_count
         self.all_issues_url = all_issues_url
         self.open_issues_url = open_issues_url
         self.closed_issues_url = closed_issues_url
+        self.open_count = open_count
 
     def serialize(self) -> Dict:
         return {'issues': [issue.serialize() for issue in self.issues],
                 'total': self.total,
-                'open_count': self.open_count,
                 'all_issues_url': self.all_issues_url,
                 'open_issues_url': self.open_issues_url,
-                'closed_issues_url': self.closed_issues_url}
+                'closed_issues_url': self.closed_issues_url,
+                'open_count': self.open_count}

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
@@ -54,7 +54,10 @@ class AsanaClient(BaseIssueTrackerClient):
                 self._asana_task_to_amundsen_data_issue(task) for task in tasks
             ],
             total=len(tasks),
+            open_count=0,
             all_issues_url=self._task_url(table_parent_task_gid),
+            open_issues_url='',
+            closed_issues_url=''
         )
 
     def create_issue(self,
@@ -64,6 +67,7 @@ class AsanaClient(BaseIssueTrackerClient):
                      owner_ids: List[str],
                      frequent_user_ids: List[str],
                      priority_level: str,
+                     project_key: str,
                      table_url: str) -> DataIssue:
         """
         Creates an issue in Asana
@@ -71,6 +75,7 @@ class AsanaClient(BaseIssueTrackerClient):
         :param owner_ids: List of user ids that represent the owners of the table
         :param frequent_user_ids: List of user ids that represent the frequent users of the table
         :param priority_level: Priority level for the ticket
+        :param project_key: Issue tracking project key to specify where the ticket should be created
         :param table_uri: Table Uri ie databasetype://database/table
         :param title: Title of the Asana ticket
         :param table_url: Link to access the table

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
@@ -54,10 +54,7 @@ class AsanaClient(BaseIssueTrackerClient):
                 self._asana_task_to_amundsen_data_issue(task) for task in tasks
             ],
             total=len(tasks),
-            open_count=0,
-            all_issues_url=self._task_url(table_parent_task_gid),
-            open_issues_url='',
-            closed_issues_url=''
+            all_issues_url=self._task_url(table_parent_task_gid)
         )
 
     def create_issue(self,

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
@@ -3,7 +3,7 @@
 
 import asana
 import logging
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from amundsen_application.base.base_issue_tracker_client import BaseIssueTrackerClient
 from amundsen_application.models.data_issue import DataIssue, Priority
@@ -66,7 +66,7 @@ class AsanaClient(BaseIssueTrackerClient):
                      description: str,
                      priority_level: str,
                      table_url: str,
-                     **kwargs) -> DataIssue:
+                     **kwargs: Any) -> DataIssue:
         """
         Creates an issue in Asana
         :param description: Description of the Asana issue

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/asana_client.py
@@ -64,18 +64,13 @@ class AsanaClient(BaseIssueTrackerClient):
                      table_uri: str,
                      title: str,
                      description: str,
-                     owner_ids: List[str],
-                     frequent_user_ids: List[str],
                      priority_level: str,
-                     project_key: str,
-                     table_url: str) -> DataIssue:
+                     table_url: str,
+                     **kwargs) -> DataIssue:
         """
         Creates an issue in Asana
         :param description: Description of the Asana issue
-        :param owner_ids: List of user ids that represent the owners of the table
-        :param frequent_user_ids: List of user ids that represent the frequent users of the table
         :param priority_level: Priority level for the ticket
-        :param project_key: Issue tracking project key to specify where the ticket should be created
         :param table_uri: Table Uri ie databasetype://database/table
         :param title: Title of the Asana ticket
         :param table_url: Link to access the table

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -3,7 +3,7 @@
 
 from http import HTTPStatus
 from jira import JIRA, JIRAError, Issue, User as JiraUser
-from typing import List
+from typing import Any, List
 
 from flask import current_app as app
 
@@ -104,7 +104,7 @@ class JiraClient(BaseIssueTrackerClient):
                      description: str,
                      priority_level: str,
                      table_url: str,
-                     **kwargs) -> DataIssue:
+                     **kwargs: Any) -> DataIssue:
         """
         Creates an issue in Jira
         :param description: Description of the Jira issue

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime, timedelta
 from http import HTTPStatus
 from jira import JIRA, JIRAError, Issue, User as JiraUser
 from typing import List
@@ -19,7 +20,14 @@ from amundsen_common.models.user import User
 import urllib.parse
 import logging
 
-SEARCH_STUB_ALL_ISSUES = 'text ~ "\\"Table Key: {table_key} [PLEASE DO NOT REMOVE]\\"" order by createdDate DESC'
+SEARCH_STUB_ALL_ISSUES = ('text ~ "\\"Table Key: {table_key} [PLEASE DO NOT REMOVE]\\"" '
+                          'order by resolution DESC, priority DESC, createdDate DESC')
+SEARCH_STUB_OPEN_ISSUES = ('text ~ "\\"Table Key: {table_key} [PLEASE DO NOT REMOVE]\\"" '
+                           'and resolution = unresolved '
+                           'order by priority DESC, createdDate DESC')
+SEARCH_STUB_CLOSED_ISSUES = ('text ~ "\\"Table Key: {table_key} [PLEASE DO NOT REMOVE]\\"" '
+                             'and resolution != unresolved '
+                             'order by priority DESC, createdDate DESC')
 # this is provided by jira as the type of a bug
 ISSUE_TYPE_ID = 1
 ISSUE_TYPE_NAME = 'Bug'
@@ -63,10 +71,23 @@ class JiraClient(BaseIssueTrackerClient):
             issues = self.jira_client.search_issues(SEARCH_STUB_ALL_ISSUES.format(
                 table_key=table_uri),
                 maxResults=self.jira_max_results)
+            # Call search_issues for only 1 open issue just to get the total value from the response
+            open_issues = self.jira_client.search_issues(SEARCH_STUB_OPEN_ISSUES.format(
+                table_key=table_uri),
+                maxResults=1)
             returned_issues = self._sort_issues(issues)
             return IssueResults(issues=returned_issues,
                                 total=issues.total,
-                                all_issues_url=self._generate_all_issues_url(table_uri, returned_issues))
+                                open_count=open_issues.total,
+                                all_issues_url=self._generate_issues_url(SEARCH_STUB_ALL_ISSUES,
+                                                                         table_uri,
+                                                                         issues.total),
+                                open_issues_url=self._generate_issues_url(SEARCH_STUB_OPEN_ISSUES,
+                                                                          table_uri,
+                                                                          open_issues.total),
+                                closed_issues_url=self._generate_issues_url(SEARCH_STUB_CLOSED_ISSUES,
+                                                                            table_uri,
+                                                                            issues.total - open_issues.total))
         except JIRAError as e:
             logging.exception(str(e))
             raise e
@@ -78,6 +99,7 @@ class JiraClient(BaseIssueTrackerClient):
                      owner_ids: List[str],
                      frequent_user_ids: List[str],
                      priority_level: str,
+                     project_key: str,
                      table_url: str) -> DataIssue:
         """
         Creates an issue in Jira
@@ -85,6 +107,7 @@ class JiraClient(BaseIssueTrackerClient):
         :param owner_ids: List of table owners user ids
         :param frequent_user_ids: List of table frequent users user ids
         :param priority_level: Priority level for the ticket
+        :param project_key: Issue tracking project key to specify where the ticket should be created
         :param table_uri: Table Uri ie databasetype://database/table
         :param title: Title of the Jira ticket
         :param table_url: Link to access the table
@@ -113,6 +136,9 @@ class JiraClient(BaseIssueTrackerClient):
             if app.config['ISSUE_TRACKER_ISSUE_TYPE_ID']:
                 issue_type_id = app.config['ISSUE_TRACKER_ISSUE_TYPE_ID']
 
+            proj_key = 'key' if project_key else 'id'
+            proj_value = project_key if project_key else self.jira_project_id
+
             owners = self._get_users_from_ids(owner_ids)
             frequent_users = self._get_users_from_ids(frequent_user_ids)
 
@@ -122,7 +148,7 @@ class JiraClient(BaseIssueTrackerClient):
                                                                                        frequent_users_description_str)
 
             issue = self.jira_client.create_issue(fields=dict(project={
-                'id': self.jira_project_id
+                proj_key: proj_value
             }, issuetype={
                 'id': issue_type_id,
                 'name': ISSUE_TYPE_NAME,
@@ -179,23 +205,24 @@ class JiraClient(BaseIssueTrackerClient):
                          status=issue.fields.status.name,
                          priority=Priority.from_jira_severity(issue.fields.priority.name))
 
-    def _generate_all_issues_url(self, table_uri: str, issues: List[DataIssue]) -> str:
+    def _generate_issues_url(self, search_stub: str, table_uri: str, issueCount: int) -> str:
         """
-        Way to get the full list of jira tickets
+        Way to get list of jira tickets
         SDK doesn't return a query
+        :param search_stub: search stub for type of query to build
         :param table_uri: table uri from the ui
-        :param issues: list of jira issues, only needed to grab a ticket name
-        :return: url to the full list of issues in jira
+        :param issueCount: number of jira issues associated to the search
+        :return: url to a list of issues in jira
         """
-        if not issues or len(issues) == 0:
+        if issueCount == 0:
             return ''
-        search_query = urllib.parse.quote(SEARCH_STUB_ALL_ISSUES.format(table_key=table_uri))
+        search_query = urllib.parse.quote(search_stub.format(table_key=table_uri))
         return f'{self.jira_url}/issues/?jql={search_query}'
 
     def _sort_issues(self, issues: List[Issue]) -> List[DataIssue]:
         """
         Sorts issues by resolution, first by unresolved and then by resolved. Also maps the issues to
-        the object used by the front end.
+        the object used by the front end. Doesn't include closed issues that are older than 90 days.
         :param issues: Issues returned from the JIRA API
         :return: List of data issues
         """
@@ -206,7 +233,10 @@ class JiraClient(BaseIssueTrackerClient):
             if not issue.fields.resolution:
                 open.append(data_issue)
             else:
-                closed.append(data_issue)
+                created_date = datetime.strptime(issue.fields.created.split(".")[0], '%Y-%m-%dT%H:%M:%S')
+                oldest_allowed_date = datetime.today() - timedelta(days=90)
+                if created_date > oldest_allowed_date:
+                    closed.append(data_issue)
         return open + closed
 
     @staticmethod

--- a/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/frontend/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -84,7 +84,6 @@ class JiraClient(BaseIssueTrackerClient):
             returned_issues = self._sort_issues(issues)
             return IssueResults(issues=returned_issues,
                                 total=open_issues.total + closed_issues.total,
-                                open_count=open_issues.total,
                                 all_issues_url=self._generate_issues_url(SEARCH_STUB_ALL_ISSUES,
                                                                          table_uri,
                                                                          open_issues.total + closed_issues.total),
@@ -93,7 +92,8 @@ class JiraClient(BaseIssueTrackerClient):
                                                                           open_issues.total),
                                 closed_issues_url=self._generate_issues_url(SEARCH_STUB_CLOSED_ISSUES,
                                                                             table_uri,
-                                                                            closed_issues.total))
+                                                                            closed_issues.total),
+                                open_count=open_issues.total)
         except JIRAError as e:
             logging.exception(str(e))
             raise e

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -480,13 +480,9 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:2140395601": [
-      [2, 0, 72, "\`../interfaces\` import should occur before import of \`./config-types\`", "1449508543"],
-      [334, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
-      [335, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
-    ],
-    "js/config/config-utils.ts:390651672": [
-      [11, 0, 45, "\`../interfaces\` import should occur before import of \`./config-types\`", "3885176344"]
+    "js/config/config-default.ts:2868041571": [
+      [338, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
+      [339, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
       [3, 0, 148, "\`.\` import should occur after import of \`./types\`", "4154971894"]
@@ -516,17 +512,8 @@ exports[`eslint`] = {
     "js/ducks/dashboard/api/v0.ts:2755958463": [
       [38, 28, 104, "Do not nest ternary expressions.", "1163212497"]
     ],
-    "js/ducks/issue/reducer.ts:1774302197": [
-      [119, 6, 56, "Unexpected lexical declaration in case block.", "2031834906"]
-    ],
-    "js/ducks/issue/tests/index.spec.ts:422548239": [
-      [150, 8, 20, "\'allIssuesUrl\' is already declared in the upper scope.", "3551613994"],
-      [151, 8, 13, "\'total\' is already declared in the upper scope.", "1110344606"],
-      [265, 10, 32, "\'allIssuesUrl\' is already declared in the upper scope.", "3851993612"],
-      [266, 10, 25, "\'total\' is already declared in the upper scope.", "1495122296"],
-      [269, 8, 33, "Use object destructuring.", "2386588093"],
-      [270, 8, 31, "Use object destructuring.", "507617405"],
-      [271, 8, 45, "Use object destructuring.", "244310461"]
+    "js/ducks/issue/reducer.ts:2750523607": [
+      [141, 6, 56, "Unexpected lexical declaration in case block.", "2031834906"]
     ],
     "js/ducks/lastIndexed/sagas.ts:1498244597": [
       [7, 2, 29, "\'action\' is defined but never used.", "566797395"]
@@ -893,17 +880,9 @@ exports[`eslint`] = {
       [63, 25, 1, "\'_\' is defined but never used.", "177658"],
       [66, 14, 204, "A control must be associated with a text label.", "3622841199"]
     ],
-    "js/pages/TableDetailPage/ReportTableIssue/index.tsx:415814826": [
-      [71, 4, 22, "Must use destructuring props assignment", "2426007440"],
-      [102, 19, 22, "Must use destructuring props assignment", "2201312961"],
-      [108, 14, 20, "Must use destructuring props assignment", "1598284208"],
-      [118, 9, 17, "Must use destructuring state assignment", "4230747098"],
-      [121, 29, 17, "Must use destructuring state assignment", "4230747098"],
-      [121, 29, 10, "Use callback in setState when referencing the previous state.", "4014904506"],
-      [135, 15, 20, "Script URL is a form of eval.", "3959800777"],
-      [155, 16, 7, "A form label must be associated with a control.", "2729454337"],
-      [156, 16, 160, "A control must be associated with a text label.", "1834626670"],
-      [164, 16, 7, "A form label must be associated with a control.", "2729454337"]
+    "js/pages/TableDetailPage/ReportTableIssue/index.tsx:2627382373": [
+      [168, 15, 20, "Script URL is a form of eval.", "3959800777"],
+      [189, 16, 160, "A control must be associated with a text label.", "1834626670"]
     ],
     "js/pages/TableDetailPage/RequestDescriptionText/index.spec.tsx:2570104867": [
       [7, 7, 11, "\'globalState\' is defined but never used.", "1130616505"],
@@ -946,9 +925,6 @@ exports[`eslint`] = {
       [45, 48, 17, "Must use destructuring props assignment", "2741866010"],
       [52, 14, 19, "Must use destructuring props assignment", "2861102024"],
       [57, 13, 18, "Must use destructuring props assignment", "58025767"]
-    ],
-    "js/pages/TableDetailPage/TableIssues/index.tsx:3303396066": [
-      [45, 12, 9, "\'getIssues\' is already declared in the upper scope.", "34848249"]
     ],
     "js/pages/TableDetailPage/TableOwnerEditor/index.spec.tsx:3400494524": [
       [3, 12, 5, "\'React\' is defined but never used.", "229961444"]

--- a/frontend/amundsen_application/static/js/config/config-custom.ts
+++ b/frontend/amundsen_application/static/js/config/config-custom.ts
@@ -28,6 +28,11 @@ const configCustom: AppConfigCustom = {
   issueTracking: {
     enabled: false,
     issueDescriptionTemplate: '',
+    projectSelection: {
+      enabled: false,
+      title: 'Issue project key (optional)',
+      inputHint: '',
+    },
   },
 };
 

--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -1,6 +1,5 @@
-import { AppConfig } from './config-types';
-
 import { FilterType, ResourceType, SortDirection } from '../interfaces';
+import { AppConfig } from './config-types';
 
 const configDefault: AppConfig = {
   badges: {},
@@ -34,6 +33,11 @@ const configDefault: AppConfig = {
   issueTracking: {
     enabled: false,
     issueDescriptionTemplate: '',
+    projectSelection: {
+      enabled: false,
+      title: 'Issue project key (optional)',
+      inputHint: '',
+    },
   },
   logoPath: null,
   logoTitle: 'AMUNDSEN',

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -375,12 +375,24 @@ interface EditableTextConfig {
 /**
  * IssueTrackingConfig - configures whether to display the issue tracking feature
  * that allows users to display tickets associated with a table and create ones
- * linked to a table, and allows a customized template that will be prepopulated
- * in the description for reporting an issue
+ * linked to a table
+ *
+ * issueDescriptionTemplate - prepopulated in the description for reporting an issue
+ *
+ * NOTE: project selection is currently only implemented for Jira issue tracking
+ * projectSelection.enabled - allows users to override the default project in which to create the issue
+ * projectSelection.title - title for selection field that allows more specificity in what you ask the user to enter
+ * projectSelection.inputHint - hint to show the user what type of value is expected, such as the name of the
+ *                              default project
  */
 interface IssueTrackingConfig {
   enabled: boolean;
-  issueDescriptionTemplate: string;
+  issueDescriptionTemplate?: string;
+  projectSelection?: {
+    enabled: boolean;
+    title: string;
+    inputHint?: string;
+  };
 }
 
 export enum NumberStyle {

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -3,13 +3,13 @@ import { BadgeStyle, BadgeStyleConfig } from 'config/config-types';
 import { convertText, CaseType } from 'utils/textUtils';
 
 import { TableMetadata } from 'interfaces/TableMetadata';
+import { ResourceType } from '../interfaces';
 import {
   AnalyticsConfig,
   FilterConfig,
   LinkConfig,
   NoticeType,
 } from './config-types';
-import { ResourceType } from '../interfaces';
 
 export const DEFAULT_DATABASE_ICON_CLASS = 'icon-database icon-color';
 export const DEFAULT_DASHBOARD_ICON_CLASS = 'icon-dashboard icon-color';
@@ -231,8 +231,32 @@ export function issueTrackingEnabled(): boolean {
  * text field with a template to suggest more detailed information
  * to be provided by the user when an issue is reported
  */
-export function getIssueDescriptionTemplate(): string {
+export function getIssueDescriptionTemplate(): string | undefined {
   return AppConfig.issueTracking.issueDescriptionTemplate;
+}
+
+/**
+ * Returns whether users are able to override the default project in which to create the issue
+ */
+export function issueTrackingProjectSelectionEnabled(): boolean {
+  const config = AppConfig.issueTracking.projectSelection;
+  return config ? config.enabled : false;
+}
+
+/**
+ * Returns the title for the selection field that allows more specificity in what you ask the user to enter
+ */
+export function getProjectSelectionTitle(): string {
+  const config = AppConfig.issueTracking.projectSelection;
+  return config ? config.title : '';
+}
+
+/**
+ * Returns the hint to show the user what type of value is expected, such as the name of the default project
+ */
+export function getProjectSelectionHint(): string | undefined {
+  const config = AppConfig.issueTracking.projectSelection;
+  return config ? config.inputHint : '';
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -544,6 +544,35 @@ describe('getIssueDescriptionTemplate', () => {
   });
 });
 
+describe('issueTrackingProjectSelectionEnabled', () => {
+  it('returns whether or not project selection within the issueTracking feature is enabled', () => {
+    const config = AppConfig.issueTracking.projectSelection;
+    expect(ConfigUtils.issueTrackingProjectSelectionEnabled()).toBe(
+      config ? config.enabled : false
+    );
+  });
+});
+
+describe('getProjectSelectionTitle', () => {
+  it('returns an issue description template string', () => {
+    const config = AppConfig.issueTracking.projectSelection;
+    if (config) config.title = 'Project key';
+    expect(ConfigUtils.getProjectSelectionTitle()).toBe(
+      config ? config.title : ''
+    );
+  });
+});
+
+describe('getProjectSelectionHint', () => {
+  it('returns an issue description template string', () => {
+    const config = AppConfig.issueTracking.projectSelection;
+    if (config) config.inputHint = 'PROJECTKEY';
+    expect(ConfigUtils.getProjectSelectionHint()).toBe(
+      config ? config.inputHint : ''
+    );
+  });
+});
+
 describe('indexDashboardsEnabled', () => {
   it('returns whether or not the indexDashboards feature is enabled', () => {
     expect(ConfigUtils.indexDashboardsEnabled()).toBe(

--- a/frontend/amundsen_application/static/js/ducks/issue/api/tests/index.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/api/tests/index.spec.ts
@@ -70,6 +70,7 @@ describe('createIssue', () => {
       owner_ids: ['owner_ids'],
       frequent_user_ids: ['frequent_user_ids'],
       priority_level: 'priority_level',
+      project_key: 'project_key',
       resource_path: 'resource_path',
     };
     sendNotificationPayload = {

--- a/frontend/amundsen_application/static/js/ducks/issue/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/api/v0.ts
@@ -9,7 +9,10 @@ export type IssuesAPI = {
   issues: {
     issues: Issue[];
     total: number;
+    open_count: number;
     all_issues_url: string;
+    open_issues_url: string;
+    closed_issues_url: string;
   };
 };
 
@@ -35,6 +38,7 @@ export function createIssue(
       owner_ids: payload.owner_ids,
       frequent_user_ids: payload.frequent_user_ids,
       priority_level: payload.priority_level,
+      project_key: payload.project_key,
       resource_path: payload.resource_path,
     })
     .then((response: AxiosResponse<IssueApi>) => {

--- a/frontend/amundsen_application/static/js/ducks/issue/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/reducer.ts
@@ -52,14 +52,20 @@ export function getIssues(tableKey: string): GetIssuesRequest {
 export function getIssuesSuccess(
   issues: Issue[],
   total?: number,
-  allIssuesUrl?: string
+  openCount?: number,
+  allIssuesUrl?: string,
+  openIssuesUrl?: string,
+  closedIssuesUrl?: string
 ): GetIssuesResponse {
   return {
     type: GetIssues.SUCCESS,
     payload: {
       issues,
       total,
+      openCount,
       allIssuesUrl,
+      openIssuesUrl,
+      closedIssuesUrl,
     },
   };
 }
@@ -67,14 +73,20 @@ export function getIssuesSuccess(
 export function getIssuesFailure(
   issues: Issue[],
   total?: number,
-  allIssuesUrl?: string
+  openCount?: number,
+  allIssuesUrl?: string,
+  openIssuesUrl?: string,
+  closedIssuesUrl?: string
 ): GetIssuesResponse {
   return {
     type: GetIssues.FAILURE,
     payload: {
       issues,
       total,
+      openCount,
       allIssuesUrl,
+      openIssuesUrl,
+      closedIssuesUrl,
     },
   };
 }
@@ -83,15 +95,23 @@ export function getIssuesFailure(
 export interface IssueReducerState {
   issues: Issue[];
   allIssuesUrl?: string;
+  openIssuesUrl?: string;
+  closedIssuesUrl?: string;
   total?: number;
+  openCount?: number;
   isLoading: boolean;
+  createIssueFailure: boolean;
 }
 
 export const initialIssuestate: IssueReducerState = {
   issues: [],
   allIssuesUrl: undefined,
+  openIssuesUrl: undefined,
+  closedIssuesUrl: undefined,
   total: 0,
+  openCount: 0,
   isLoading: false,
+  createIssueFailure: false,
 };
 
 export default function reducer(
@@ -103,6 +123,7 @@ export default function reducer(
       return {
         ...initialIssuestate,
         isLoading: true,
+        createIssueFailure: false,
       };
     case GetIssues.FAILURE:
       return { ...initialIssuestate };
@@ -111,11 +132,12 @@ export default function reducer(
         ...state,
         ...(<GetIssuesResponse>action).payload,
         isLoading: false,
+        createIssueFailure: false,
       };
     case CreateIssue.REQUEST:
-      return { ...state, isLoading: true };
+      return { ...state, isLoading: true, createIssueFailure: false };
     case CreateIssue.FAILURE:
-      return { ...state, isLoading: false };
+      return { ...state, isLoading: false, createIssueFailure: true };
     case CreateIssue.SUCCESS:
       const { issue } = (<CreateIssueResponse>action).payload;
       if (issue === undefined) {
@@ -125,6 +147,7 @@ export default function reducer(
         ...state,
         issues: [issue, ...state.issues],
         isLoading: false,
+        createIssueFailure: false,
       };
     default:
       return state;

--- a/frontend/amundsen_application/static/js/ducks/issue/sagas.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/sagas.ts
@@ -24,10 +24,17 @@ export function* getIssuesWorker(action: GetIssuesRequest): SagaIterator {
     const response = yield call(API.getIssues, key);
 
     yield put(
-      getIssuesSuccess(response.issues, response.total, response.all_issues_url)
+      getIssuesSuccess(
+        response.issues,
+        response.total,
+        response.open_count,
+        response.all_issues_url,
+        response.open_issues_url,
+        response.closed_issues_url
+      )
     );
   } catch (e) {
-    yield put(getIssuesFailure([], 0, undefined));
+    yield put(getIssuesFailure([], 0, 0, undefined, undefined, undefined));
   }
 }
 

--- a/frontend/amundsen_application/static/js/ducks/issue/tests/index.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/tests/index.spec.ts
@@ -39,12 +39,16 @@ describe('issue ducks', () => {
   let ownerIds;
   let frequentUserIds;
   let priorityLevel;
+  let projectKey;
   let resourceName;
   let resourcePath;
   let owners;
   let sender;
   let total;
+  let openCount;
   let allIssuesUrl;
+  let openIssuesUrl;
+  let closedIssuesUrl;
 
   beforeAll(() => {
     tableKey = 'key';
@@ -54,6 +58,7 @@ describe('issue ducks', () => {
     ownerIds = ['user1@email.com', 'user2@email.com'];
     frequentUserIds = ['user1@email.com', 'user2@email.com'];
     priorityLevel = 'P2';
+    projectKey = 'Project';
     resourceName = 'resource_name';
     resourcePath = 'resource_path';
     owners = ['email@email'];
@@ -69,7 +74,10 @@ describe('issue ducks', () => {
 
     issues = [issue];
     total = 0;
+    openCount = 0;
     allIssuesUrl = 'testurl';
+    openIssuesUrl = 'testurl';
+    closedIssuesUrl = 'testurl';
   });
 
   describe('actions', () => {
@@ -81,7 +89,14 @@ describe('issue ducks', () => {
     });
 
     it('getIssuesSuccess - returns the action to process success', () => {
-      const action = getIssuesSuccess(issues, total, allIssuesUrl);
+      const action = getIssuesSuccess(
+        issues,
+        total,
+        openCount,
+        allIssuesUrl,
+        openIssuesUrl,
+        closedIssuesUrl
+      );
       expect(action.type).toBe(GetIssues.SUCCESS);
     });
 
@@ -98,6 +113,7 @@ describe('issue ducks', () => {
         owner_ids: ownerIds,
         frequent_user_ids: frequentUserIds,
         priority_level: priorityLevel,
+        project_key: projectKey,
         resource_path: resourcePath,
       };
       const notificationPayload = {
@@ -121,6 +137,7 @@ describe('issue ducks', () => {
         frequentUserIds
       );
       expect(payload.createIssuePayload.priority_level).toBe(priorityLevel);
+      expect(payload.createIssuePayload.project_key).toBe(projectKey);
       expect(payload.createIssuePayload.resource_path).toBe(resourcePath);
       expect(payload.notificationPayload.options.resource_name).toBe(
         resourceName
@@ -148,16 +165,21 @@ describe('issue ducks', () => {
 
   describe('reducer', () => {
     let testState: IssueReducerState;
-    let allIssuesUrl: string;
-    let total: number;
     beforeAll(() => {
       const stateIssues: Issue[] = [];
       total = 0;
+      openCount = 0;
       allIssuesUrl = 'testUrl';
+      openIssuesUrl = 'testUrl';
+      closedIssuesUrl = 'testUrl';
       testState = {
         total,
+        openCount,
         allIssuesUrl,
+        openIssuesUrl,
+        closedIssuesUrl,
         isLoading: false,
+        createIssueFailure: false,
         issues: stateIssues,
       };
     });
@@ -170,28 +192,50 @@ describe('issue ducks', () => {
       expect(reducer(testState, getIssues(tableKey))).toEqual({
         issues: [],
         isLoading: true,
+        createIssueFailure: false,
         allIssuesUrl: undefined,
+        openIssuesUrl: undefined,
+        closedIssuesUrl: undefined,
         total: 0,
+        openCount: 0,
       });
     });
 
     it('should handle GetIssues.SUCCESS', () => {
       expect(
-        reducer(testState, getIssuesSuccess(issues, total, allIssuesUrl))
+        reducer(
+          testState,
+          getIssuesSuccess(
+            issues,
+            total,
+            openCount,
+            allIssuesUrl,
+            openIssuesUrl,
+            closedIssuesUrl
+          )
+        )
       ).toEqual({
         issues,
         total,
+        openCount,
         allIssuesUrl,
+        openIssuesUrl,
+        closedIssuesUrl,
         isLoading: false,
+        createIssueFailure: false,
       });
     });
 
     it('should handle GetIssues.FAILURE', () => {
       expect(reducer(testState, getIssuesFailure([], 0, undefined))).toEqual({
         total,
+        openCount,
         issues: [],
         isLoading: false,
+        createIssueFailure: false,
         allIssuesUrl: undefined,
+        openIssuesUrl: undefined,
+        closedIssuesUrl: undefined,
       });
     });
 
@@ -203,6 +247,7 @@ describe('issue ducks', () => {
         owner_ids: ownerIds,
         frequent_user_ids: frequentUserIds,
         priority_level: priorityLevel,
+        project_key: projectKey,
         resource_path: resourcePath,
       };
       const notificationPayload = {
@@ -218,9 +263,13 @@ describe('issue ducks', () => {
         reducer(testState, createIssue(createIssuePayload, notificationPayload))
       ).toEqual({
         allIssuesUrl,
+        openIssuesUrl,
+        closedIssuesUrl,
         total,
+        openCount,
         issues: [],
         isLoading: true,
+        createIssueFailure: false,
       });
     });
 
@@ -229,6 +278,7 @@ describe('issue ducks', () => {
         ...testState,
         issues: [issue],
         isLoading: false,
+        createIssueFailure: false,
       });
     });
 
@@ -243,9 +293,13 @@ describe('issue ducks', () => {
     it('should handle CreateIssue.FAILURE', () => {
       expect(reducer(testState, createIssueFailure())).toEqual({
         total,
+        openCount,
         allIssuesUrl,
+        openIssuesUrl,
+        closedIssuesUrl,
         issues: [],
         isLoading: false,
+        createIssueFailure: true,
       });
     });
   });
@@ -263,19 +317,38 @@ describe('issue ducks', () => {
 
     describe('getIssuesWorker', () => {
       let action: GetIssuesRequest;
-      let allIssuesUrl: string | undefined;
-      let total: number | undefined;
       beforeAll(() => {
         action = getIssues(tableKey);
-        issues = globalState.issue.issues;
-        total = globalState.issue.total;
-        allIssuesUrl = globalState.issue.allIssuesUrl;
+        const {
+          issues: gsIssues,
+          total: gsTotal,
+          openCount: gsOpenCount,
+          allIssuesUrl: gsAllIssuesUrl,
+          openIssuesUrl: gsOpenIssuesUrl,
+          closedIssuesUrl: gsClosedIssuesUrl,
+        } = globalState.issue;
+        issues = gsIssues;
+        total = gsTotal;
+        openCount = gsOpenCount;
+        allIssuesUrl = gsAllIssuesUrl;
+        openIssuesUrl = gsOpenIssuesUrl;
+        closedIssuesUrl = gsClosedIssuesUrl;
       });
 
       it('gets issues', () =>
         expectSaga(getIssuesWorker, action)
           .provide([
-            [matchers.call.fn(API.getIssues), { issues, total, allIssuesUrl }],
+            [
+              matchers.call.fn(API.getIssues),
+              {
+                issues,
+                total,
+                openCount,
+                allIssuesUrl,
+                openIssuesUrl,
+                closedIssuesUrl,
+              },
+            ],
           ])
           .put(getIssuesSuccess(issues, total))
           .run());
@@ -283,7 +356,7 @@ describe('issue ducks', () => {
       it('handles request error', () =>
         expectSaga(getIssuesWorker, action)
           .provide([[matchers.call.fn(API.getIssues), throwError(new Error())]])
-          .put(getIssuesFailure([], 0, undefined))
+          .put(getIssuesFailure([], 0, 0, undefined, undefined, undefined))
           .run());
     });
 
@@ -307,6 +380,7 @@ describe('issue ducks', () => {
           owner_ids: ownerIds,
           frequent_user_ids: frequentUserIds,
           priority_level: priorityLevel,
+          project_key: projectKey,
           resource_path: resourcePath,
         };
         const notificationPayload = {

--- a/frontend/amundsen_application/static/js/ducks/issue/types.ts
+++ b/frontend/amundsen_application/static/js/ducks/issue/types.ts
@@ -31,7 +31,10 @@ export interface GetIssuesResponse {
   payload: {
     issues: Issue[];
     total?: number;
+    openCount?: number;
     allIssuesUrl?: string;
+    openIssuesUrl?: string;
+    closedIssuesUrl?: string;
   };
 }
 

--- a/frontend/amundsen_application/static/js/fixtures/globalState.ts
+++ b/frontend/amundsen_application/static/js/fixtures/globalState.ts
@@ -130,8 +130,12 @@ const globalState: GlobalState = {
   issue: {
     issues: [],
     allIssuesUrl: '',
+    openIssuesUrl: '',
+    closedIssuesUrl: '',
     total: 0,
+    openCount: 0,
     isLoading: true,
+    createIssueFailure: false,
   },
   notification: {
     requestIsOpen: false,

--- a/frontend/amundsen_application/static/js/interfaces/Issue.ts
+++ b/frontend/amundsen_application/static/js/interfaces/Issue.ts
@@ -14,5 +14,6 @@ export interface CreateIssuePayload {
   owner_ids: string[];
   frequent_user_ids: string[];
   priority_level: string;
+  project_key: string;
   resource_path: string;
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/constants.ts
@@ -1,4 +1,6 @@
 export const REPORT_DATA_ISSUE_TEXT = 'Report an issue';
+export const TITLE_LABEL = 'Title';
+export const DESCRIPTION_LABEL = 'Description';
 export const PRIORITY_LABEL = 'Priority';
 export const PRIORITY = { P3: 'P3', P2: 'P2', P1: 'P1', P0: 'P0' };
 export const TABLE_OWNERS_NOTE =

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/index.spec.tsx
@@ -12,11 +12,14 @@ import { ReportTableIssue, ReportTableIssueProps, mapDispatchToProps } from '.';
 const globalAny: any = global;
 
 let mockGetIssueDescriptionTemplate = 'This is a description template';
+let mockIssueTrackingProjectSelectionEnabled = true;
 jest.mock('config/config-utils', () => {
   const configUtilsModule = jest.requireActual('config/config-utils');
   return {
     ...configUtilsModule,
     getIssueDescriptionTemplate: () => mockGetIssueDescriptionTemplate,
+    issueTrackingProjectSelectionEnabled: () =>
+      mockIssueTrackingProjectSelectionEnabled,
   };
 });
 
@@ -27,6 +30,7 @@ const mockFormData = {
   owner_ids: ['owner@email'],
   frequent_user_ids: ['frequent@email'],
   priority_level: 'priority level',
+  project_key: 'project key',
   resource_name: 'resource name',
   resource_path: 'path',
   owners: 'test@test.com',
@@ -46,6 +50,7 @@ const mockCreateIssuePayload = {
   owner_ids: ['owner@email'],
   frequent_user_ids: ['frequent@email'],
   priority_level: 'P2',
+  project_key: 'project key',
   resource_path: '/table_detail/cluster/database/schema/table_name',
 };
 
@@ -102,7 +107,7 @@ describe('ReportTableIssue', () => {
       const { wrapper } = setup();
       wrapper.setState({ isOpen: true });
 
-      expect(wrapper.find('textarea').props().children).toBe(
+      expect(wrapper.find('textarea').props().defaultValue).toEqual(
         mockGetIssueDescriptionTemplate
       );
     });
@@ -112,9 +117,27 @@ describe('ReportTableIssue', () => {
       const { wrapper } = setup();
       wrapper.setState({ isOpen: true });
 
-      expect(wrapper.find('textarea').props().children).toBe(
+      expect(wrapper.find('textarea').props().defaultValue).toEqual(
         mockGetIssueDescriptionTemplate
       );
+    });
+
+    it('Does not render project selection field', () => {
+      mockIssueTrackingProjectSelectionEnabled = false;
+      const { wrapper } = setup();
+      wrapper.setState({ isOpen: true });
+
+      // There should only be one input for issue title
+      expect(wrapper.find('input')).toHaveLength(1);
+    });
+
+    it('Renders project selection field', () => {
+      mockIssueTrackingProjectSelectionEnabled = true;
+      const { wrapper } = setup();
+      wrapper.setState({ isOpen: true });
+
+      // There should be two inputs, one for issue title and one for project selection
+      expect(wrapper.find('input')).toHaveLength(2);
     });
 
     describe('toggle', () => {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/styles.scss
@@ -3,6 +3,8 @@
 
 @import 'variables';
 
+$submit-row-gap: 15%;
+
 .report-table-issue-modal {
   background-color: $white;
   border-radius: 6px;
@@ -30,7 +32,7 @@
 
   .submit-row {
     display: flex;
-    gap: 15%;
+    gap: $submit-row-gap;
     justify-content: space-between;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/styles.scss
@@ -28,8 +28,9 @@
     margin: 5px 0 0;
   }
 
-  .report-table-issue-buttons {
+  .submit-row {
     display: flex;
+    gap: 40px;
     justify-content: space-between;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ReportTableIssue/styles.scss
@@ -30,7 +30,7 @@
 
   .submit-row {
     display: flex;
-    gap: 40px;
+    gap: 15%;
     justify-content: space-between;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/constants.ts
@@ -1,1 +1,3 @@
+export const ISSUES_TITLE = 'Issues';
 export const NO_DATA_ISSUES_TEXT = 'No associated issues';
+export const CREATE_ISSUE_ERROR_TEXT = 'Could not create issue!';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.spec.tsx
@@ -19,11 +19,15 @@ describe('TableIssues', () => {
   const setup = (propOverrides?: Partial<TableIssueProps>) => {
     const props: TableIssueProps = {
       isLoading: false,
+      createIssueFailure: false,
       issues: [],
       tableKey: 'key',
       tableName: 'tableName',
       total: 0,
+      openCount: 0,
       allIssuesUrl: 'testUrl',
+      openIssuesUrl: 'testUrl',
+      closedIssuesUrl: 'testUrl',
       getIssues: jest.fn(),
       ...propOverrides,
     };
@@ -77,7 +81,10 @@ describe('TableIssues', () => {
       const { wrapper } = setup({
         issues: [],
         total: 0,
+        openCount: 0,
         allIssuesUrl: undefined,
+        openIssuesUrl: undefined,
+        closedIssuesUrl: undefined,
       });
       expect(wrapper.find('.table-issue-more-issues').length).toEqual(0);
     });
@@ -95,10 +102,39 @@ describe('TableIssues', () => {
           },
         ],
         total: 1,
+        openCount: 1,
         allIssuesUrl: 'url',
+        openIssuesUrl: undefined,
+        closedIssuesUrl: undefined,
       });
       expect(wrapper.find('.table-issue-more-issues').text()).toEqual(
         'View all 1 issues'
+      );
+    });
+
+    it('renders open issue and closed issue links if the urls are set', () => {
+      const { wrapper } = setup({
+        issues: [
+          {
+            issue_key: 'issue_key',
+            title: 'title',
+            url: 'http://url',
+            status: 'Open',
+            priority_display_name: 'P2',
+            priority_name: 'Major',
+          },
+        ],
+        total: 1,
+        openCount: 1,
+        allIssuesUrl: 'url',
+        openIssuesUrl: 'url',
+        closedIssuesUrl: 'url',
+      });
+      expect(wrapper.find('.table-issue-more-issues').first().text()).toEqual(
+        'View 1 open issues'
+      );
+      expect(wrapper.find('.table-issue-more-issues').at(1).text()).toEqual(
+        'View 0 closed issues'
       );
     });
   });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
@@ -11,7 +11,11 @@ import { getIssues } from 'ducks/issue/reducer';
 import { GetIssuesRequest } from 'ducks/issue/types';
 import { logClick } from 'utils/analytics';
 import ReportTableIssue from '../ReportTableIssue';
-import { ISSUES_TITLE, NO_DATA_ISSUES_TEXT, CREATE_ISSUE_ERROR_TEXT } from './constants';
+import {
+  ISSUES_TITLE,
+  NO_DATA_ISSUES_TEXT,
+  CREATE_ISSUE_ERROR_TEXT,
+} from './constants';
 import './styles.scss';
 
 export interface StateFromProps {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
@@ -113,8 +113,8 @@ export class TableIssues extends React.Component<TableIssueProps> {
       total,
       openCount,
     } = this.props;
-    const totalCount = total ? total : 0;
-    const openIssueCount = openCount ? openCount : 0;
+    const totalCount = total || 0;
+    const openIssueCount = openCount || 0;
     const closedIssueCount = totalCount - openIssueCount;
     const hasIssues = issues.length !== 0 || totalCount > 0;
 
@@ -127,6 +127,7 @@ export class TableIssues extends React.Component<TableIssueProps> {
     if (!hasIssues) {
       return reportIssueLink;
     }
+
     if (openIssuesUrl && closedIssuesUrl) {
       return (
         <span className="table-more-issues" key="more-issue-link">
@@ -154,23 +155,23 @@ export class TableIssues extends React.Component<TableIssueProps> {
           |{reportIssueLink}
         </span>
       );
-    } else {
-      return (
-        <span className="table-more-issues" key="more-issue-link">
-          <a
-            id="more-issues-link"
-            className="table-issue-more-issues"
-            target="_blank"
-            rel="noreferrer"
-            href={allIssuesUrl}
-            onClick={logClick}
-          >
-            View all {total} issues
-          </a>
-          |{reportIssueLink}
-        </span>
-      );
     }
+
+    return (
+      <span className="table-more-issues" key="more-issue-link">
+        <a
+          id="more-issues-link"
+          className="table-issue-more-issues"
+          target="_blank"
+          rel="noreferrer"
+          href={allIssuesUrl}
+          onClick={logClick}
+        >
+          View all {total} issues
+        </a>
+        |{reportIssueLink}
+      </span>
+    );
   };
 
   render() {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
@@ -11,7 +11,7 @@ import { getIssues } from 'ducks/issue/reducer';
 import { GetIssuesRequest } from 'ducks/issue/types';
 import { logClick } from 'utils/analytics';
 import ReportTableIssue from '../ReportTableIssue';
-import { NO_DATA_ISSUES_TEXT } from './constants';
+import { ISSUES_TITLE, NO_DATA_ISSUES_TEXT, CREATE_ISSUE_ERROR_TEXT } from './constants';
 import './styles.scss';
 
 export interface StateFromProps {
@@ -78,8 +78,8 @@ export class TableIssues extends React.Component<TableIssueProps> {
     const { createIssueFailure } = this.props;
 
     const createIssueErrorMsg = createIssueFailure ? (
-      <span className="section-title title-3 create-issue-error">
-        Could not create issue!
+      <span className="section-title create-issue-error">
+        {CREATE_ISSUE_ERROR_TEXT}
       </span>
     ) : (
       ''
@@ -87,7 +87,7 @@ export class TableIssues extends React.Component<TableIssueProps> {
 
     return (
       <div className="table-issues-header">
-        <span className="section-title title-3">Issues</span>
+        <span className="section-title">{ISSUES_TITLE}</span>
         {createIssueErrorMsg}
       </div>
     );
@@ -119,7 +119,7 @@ export class TableIssues extends React.Component<TableIssueProps> {
     const hasIssues = issues.length !== 0 || totalCount > 0;
 
     const reportIssueLink = (
-      <div className={`table-report-new-issue ${hasIssues ? 'ml-1' : ''}`}>
+      <div className={`table-report-new-issue ${hasIssues ? 'last-item' : ''}`}>
         <ReportTableIssue tableKey={tableKey} tableName={tableName} />
       </div>
     );
@@ -144,7 +144,7 @@ export class TableIssues extends React.Component<TableIssueProps> {
           |
           <a
             id="closed-issues-link"
-            className="table-issue-more-issues ml-1"
+            className="table-issue-more-issues last-item"
             target="_blank"
             rel="noreferrer"
             href={closedIssuesUrl}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
@@ -12,7 +12,7 @@ $shimmer-loader-lines: 1, 2;
   justify-content: space-between;
 
   .create-issue-error {
-    color: $rose80 !important;
+    color: $priority-bg-color !important;
   }
 }
 

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
@@ -108,7 +108,7 @@ $shimmer-loader-lines: 1, 2;
   margin-bottom: $spacer-1;
   margin-right: $spacer-1;
 
-  &.ml-1 {
+  &.last-item {
     margin-left: $spacer-1;
   }
 }
@@ -121,7 +121,7 @@ $shimmer-loader-lines: 1, 2;
 .table-report-new-issue {
   margin-bottom: $spacer-1;
 
-  &.ml-1 {
+  &.last-item {
     margin-left: $spacer-1;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/styles.scss
@@ -7,6 +7,15 @@ $issue-banner-height: 40px;
 $shimmer-line-height: 16px;
 $shimmer-loader-lines: 1, 2;
 
+.table-issues-header {
+  display: flex;
+  justify-content: space-between;
+
+  .create-issue-error {
+    color: $rose80 !important;
+  }
+}
+
 .table-issues {
   margin-bottom: $spacer-1;
 
@@ -98,6 +107,10 @@ $shimmer-loader-lines: 1, 2;
 .table-issue-more-issues {
   margin-bottom: $spacer-1;
   margin-right: $spacer-1;
+
+  &.ml-1 {
+    margin-left: $spacer-1;
+  }
 }
 
 .table-more-issues {

--- a/frontend/docs/application_config.md
+++ b/frontend/docs/application_config.md
@@ -316,5 +316,12 @@ _TODO: Please add doc\*_
 
 ## Issue Tracking Features
 
-In order to enable Issue Tracking set `IssueTrackingConfig.enabled` to `true` to see UI features. If you wish to prepopulate the issue description text field with a template to suggest more detailed information to be provided by the user when an issue is reported, set `IssueTrackingConfig.issueDescriptionTemplate` with the desired string. Further configuration
-is required to fully enable the feature, please see this [entry](flask_config.md#issue-tracking-integration-features).
+In order to enable Issue Tracking, set `IssueTrackingConfig.enabled` to `true` to see UI features. Further configuration is required to fully enable the feature, please see this [entry](flask_config.md#issue-tracking-integration-features).
+
+To prepopulate the issue description text field with a template to suggest more detailed information to be provided by the user when an issue is reported, set `IssueTrackingConfig.issueDescriptionTemplate` with the desired string.
+
+A default project ID to specify where issues will be created is set in the flask configuration, but to allow users to override this value and choose which project their issue is created in, set `IssueTrackingConfig.projectSelection.enabled` 
+to `true`. This will add an extra input field in the `Report an issue` modal that will accept a Jira project key, but if no input is entered, it will use the value that is set in the flask configuration. This feature is currently only 
+implemented for use with Jira issue tracking.
+* Set `IssueTrackingConfig.projectSelection.title` to add a title to the input field, for example `Jira project key (optional)`, to let users know what to enter in the text field.
+* An optional config `IssueTrackingConfig.projectSelection.inputHint` can be set to show a hint in the input field, which can be helpful to show users an example that conveys the expected format of the project key.

--- a/frontend/tests/unit/api/issue/test_issue.py
+++ b/frontend/tests/unit/api/issue/test_issue.py
@@ -35,7 +35,10 @@ class IssueTest(unittest.TestCase):
                                              priority=Priority.P2)
         self.expected_issues = IssueResults(issues=[self.mock_data_issue],
                                             total=0,
-                                            all_issues_url="http://moredata")
+                                            open_count=0,
+                                            all_issues_url="http://moredata",
+                                            open_issues_url="http://moredata",
+                                            closed_issues_url="http://moredata")
 
     # ----- Jira API Tests ---- #
 
@@ -86,8 +89,14 @@ class IssueTest(unittest.TestCase):
                              self.expected_issues.issues[0].issue_key)
             self.assertEqual(data['issues']['total'],
                              self.expected_issues.total)
+            self.assertEqual(data['issues']['open_count'],
+                             self.expected_issues.open_count)
             self.assertEqual(data['issues']['all_issues_url'],
                              self.expected_issues.all_issues_url)
+            self.assertEqual(data['issues']['open_issues_url'],
+                             self.expected_issues.open_issues_url)
+            self.assertEqual(data['issues']['closed_issues_url'],
+                             self.expected_issues.closed_issues_url)
             mock_issue_tracker_client.return_value.get_issues.assert_called_with('table_key')
 
     def test_create_issue_not_enabled(self) -> None:
@@ -102,6 +111,7 @@ class IssueTest(unittest.TestCase):
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'title': 'test title',
                 'key': 'key',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
@@ -122,6 +132,7 @@ class IssueTest(unittest.TestCase):
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'title': 'test title',
                 'key': 'key',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
@@ -138,6 +149,7 @@ class IssueTest(unittest.TestCase):
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'key': 'table_key',
                 'title': 'test title',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
@@ -155,6 +167,7 @@ class IssueTest(unittest.TestCase):
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'title': 'test title',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
             })
@@ -171,6 +184,7 @@ class IssueTest(unittest.TestCase):
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'key': 'table_key',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
             })
@@ -187,6 +201,7 @@ class IssueTest(unittest.TestCase):
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'title': 'test title',
                 'key': 'key'
             })
@@ -202,6 +217,7 @@ class IssueTest(unittest.TestCase):
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
+                'project_key': 'test project',
                 'title': 'test title',
                 'key': 'key',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
@@ -218,6 +234,7 @@ class IssueTest(unittest.TestCase):
                 'description': 'test description',
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
+                'project_key': 'test project',
                 'title': 'test title',
                 'key': 'key',
                 'resource_path': '/table_detail/cluster/database/schema/table_name'
@@ -233,6 +250,24 @@ class IssueTest(unittest.TestCase):
             response = test.post('/api/issue/issue', data={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
+                'priority_level': 'P2',
+                'project_key': 'test project',
+                'title': 'test title',
+                'key': 'key',
+                'resource_path': '/table_detail/cluster/database/schema/table_name'
+            })
+            self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    def test_create_jira_issue_no_project_key(self) -> None:
+        """
+         Test request failure if project key is missing
+         :return:
+         """
+        with local_app.test_client() as test:
+            response = test.post('/api/issue/issue', data={
+                'description': 'test description',
+                'owner_ids': ['user1@email.com', 'user2@email.com'],
+                'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
                 'title': 'test title',
                 'key': 'key',
@@ -256,6 +291,7 @@ class IssueTest(unittest.TestCase):
                                      'owner_ids': ['user1@email.com', 'user2@email.com'],
                                      'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                                      'priority_level': 'P2',
+                                     'project_key': 'test project',
                                      'title': 'title',
                                      'key': 'key',
                                      'resource_path': '/table_detail/cluster/database/schema/table_name'

--- a/frontend/tests/unit/api/issue/test_issue.py
+++ b/frontend/tests/unit/api/issue/test_issue.py
@@ -35,10 +35,10 @@ class IssueTest(unittest.TestCase):
                                              priority=Priority.P2)
         self.expected_issues = IssueResults(issues=[self.mock_data_issue],
                                             total=0,
-                                            open_count=0,
                                             all_issues_url="http://moredata",
                                             open_issues_url="http://moredata",
-                                            closed_issues_url="http://moredata")
+                                            closed_issues_url="http://moredata",
+                                            open_count=0)
 
     # ----- Jira API Tests ---- #
 
@@ -89,14 +89,14 @@ class IssueTest(unittest.TestCase):
                              self.expected_issues.issues[0].issue_key)
             self.assertEqual(data['issues']['total'],
                              self.expected_issues.total)
-            self.assertEqual(data['issues']['open_count'],
-                             self.expected_issues.open_count)
             self.assertEqual(data['issues']['all_issues_url'],
                              self.expected_issues.all_issues_url)
             self.assertEqual(data['issues']['open_issues_url'],
                              self.expected_issues.open_issues_url)
             self.assertEqual(data['issues']['closed_issues_url'],
                              self.expected_issues.closed_issues_url)
+            self.assertEqual(data['issues']['open_count'],
+                             self.expected_issues.open_count)
             mock_issue_tracker_client.return_value.get_issues.assert_called_with('table_key')
 
     def test_create_issue_not_enabled(self) -> None:

--- a/frontend/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/frontend/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -1,17 +1,19 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import flask
 import unittest
 from amundsen_application.proxy.issue_tracker_clients.issue_exceptions import IssueConfigurationException
-from amundsen_application.proxy.issue_tracker_clients.jira_client import JiraClient, SEARCH_STUB_ALL_ISSUES
+from amundsen_application.proxy.issue_tracker_clients.jira_client import (JiraClient,
+                                                                          SEARCH_STUB_ALL_ISSUES,
+                                                                          SEARCH_STUB_OPEN_ISSUES)
 from amundsen_application.models.data_issue import DataIssue, Priority
 from amundsen_common.models.user import User
 from jira import JIRAError
 from types import SimpleNamespace
-from typing import Dict, List
+from typing import Dict
 
 app = flask.Flask(__name__)
 app.config.from_object('amundsen_application.config.TestConfig')
@@ -76,7 +78,7 @@ class JiraClientTest(unittest.TestCase):
 
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.JIRA')
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.'
-                         'JiraClient._generate_all_issues_url')
+                         'JiraClient._generate_issues_url')
     def test_get_issues_returns_JIRAError(self, mock_remaining_issues: Mock, mock_JIRA_client: Mock) -> None:
         mock_JIRA_client.return_value.get_issues.side_effect = JIRAError('Some exception')
         mock_remaining_issues.return_value = 0
@@ -97,7 +99,7 @@ class JiraClientTest(unittest.TestCase):
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.'
                          'JiraClient._get_issue_properties')
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.'
-                         'jira_client.JiraClient._generate_all_issues_url')
+                         'jira_client.JiraClient._generate_issues_url')
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.'
                          'jira_client.JiraClient._sort_issues')
     def test_get_issues_returns_issues(self,
@@ -120,13 +122,14 @@ class JiraClientTest(unittest.TestCase):
             mock_JIRA_client.assert_called()
             self.assertEqual(results.issues[0], self.mock_issue)
             self.assertEqual(results.total, self.mock_jira_issues.total)
-            mock_JIRA_client.return_value.search_issues.assert_called_with(
-                SEARCH_STUB_ALL_ISSUES.format(table_key="key"),
-                maxResults=3)
+            mock_JIRA_client.return_value.search_issues.assert_has_calls([
+                call(SEARCH_STUB_ALL_ISSUES.format(table_key="key"), maxResults=3),
+                call(SEARCH_STUB_OPEN_ISSUES.format(table_key="key"), maxResults=1)
+            ])
 
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.JIRA')
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.urllib.parse.quote')
-    def test__generate_all_issues_url(self, mock_url_lib: Mock, mock_JIRA_client: Mock) -> None:
+    def test__generate_issues_url(self, mock_url_lib: Mock, mock_JIRA_client: Mock) -> None:
         mock_url_lib.return_value = 'test'
         with app.test_request_context():
             jira_client = JiraClient(issue_labels=[],
@@ -135,12 +138,11 @@ class JiraClientTest(unittest.TestCase):
                                      issue_tracker_password=app.config['ISSUE_TRACKER_PASSWORD'],
                                      issue_tracker_project_id=app.config['ISSUE_TRACKER_PROJECT_ID'],
                                      issue_tracker_max_results=app.config['ISSUE_TRACKER_MAX_RESULTS'])
-            issues = [DataIssue(issue_key='key', title='title', url='url', status='open', priority=Priority.P2)]
-            url = jira_client._generate_all_issues_url(table_uri="table", issues=issues)
+            url = jira_client._generate_issues_url(search_stub="search", table_uri="table", issueCount=1)
             self.assertEqual(url, 'test_url/issues/?jql=test')
 
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.JIRA')
-    def test__generate_all_issues_url_no_issues(self, mock_JIRA_client: Mock) -> None:
+    def test__generate_issues_url_no_issues(self, mock_JIRA_client: Mock) -> None:
         with app.test_request_context():
             jira_client = JiraClient(issue_labels=[],
                                      issue_tracker_url=app.config['ISSUE_TRACKER_URL'],
@@ -148,9 +150,7 @@ class JiraClientTest(unittest.TestCase):
                                      issue_tracker_password=app.config['ISSUE_TRACKER_PASSWORD'],
                                      issue_tracker_project_id=app.config['ISSUE_TRACKER_PROJECT_ID'],
                                      issue_tracker_max_results=app.config['ISSUE_TRACKER_MAX_RESULTS'])
-            issues: List[DataIssue]
-            issues = []
-            url = jira_client._generate_all_issues_url(table_uri="table", issues=issues)
+            url = jira_client._generate_issues_url(search_stub="search", table_uri="table", issueCount=0)
             self.assertEqual(url, '')
 
     @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.JIRA')
@@ -171,6 +171,7 @@ class JiraClientTest(unittest.TestCase):
                                          owner_ids=['test_email'],
                                          frequent_user_ids=['test_email'],
                                          priority_level='P2',
+                                         project_key='',
                                          table_uri='key',
                                          title='title',
                                          table_url='http://table')
@@ -199,6 +200,7 @@ class JiraClientTest(unittest.TestCase):
                                                owner_ids=['test@email.com'],
                                                frequent_user_ids=['test@email.com'],
                                                priority_level='P2',
+                                               project_key='',
                                                table_uri='key',
                                                title='title',
                                                table_url='http://table')
@@ -247,6 +249,7 @@ class JiraClientTest(unittest.TestCase):
                                                owner_ids=['inactive@email.com'],
                                                frequent_user_ids=['inactive@email.com'],
                                                priority_level='P2',
+                                               project_key='',
                                                table_uri='key',
                                                title='title',
                                                table_url='http://table')
@@ -294,6 +297,7 @@ class JiraClientTest(unittest.TestCase):
                                      owner_ids=['inactive@email.com'],
                                      frequent_user_ids=['inactive@email.com'],
                                      priority_level='P2',
+                                     project_key='',
                                      table_uri='key',
                                      title='title',
                                      table_url='http://table')
@@ -323,9 +327,49 @@ class JiraClientTest(unittest.TestCase):
                                      owner_ids=['test@email.com'],
                                      frequent_user_ids=[],
                                      priority_level='P2',
+                                     project_key='',
                                      table_uri='key',
                                      title='title',
                                      table_url='http://table')
             mock_JIRA_client.return_value.add_watcher.assert_called_with(
                 issue=self.mock_issue.key,
                 watcher='test')
+
+    @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.JIRA')
+    @unittest.mock.patch('amundsen_application.proxy.issue_tracker_clients.jira_client.'
+                         'JiraClient._get_issue_properties')
+    def test_create_issue_with_project_key(self, mock_get_issue_properties: Mock, mock_JIRA_client: Mock) -> None:
+        mock_JIRA_client.return_value.create_issue.return_value = self.mock_issue
+        mock_get_issue_properties.return_value = self.mock_issue_instance
+        mock_labels = ['mock-label']
+        with app.test_request_context():
+            jira_client = JiraClient(issue_labels=mock_labels,
+                                     issue_tracker_url=app.config['ISSUE_TRACKER_URL'],
+                                     issue_tracker_user=app.config['ISSUE_TRACKER_USER'],
+                                     issue_tracker_password=app.config['ISSUE_TRACKER_PASSWORD'],
+                                     issue_tracker_project_id=app.config['ISSUE_TRACKER_PROJECT_ID'],
+                                     issue_tracker_max_results=app.config['ISSUE_TRACKER_MAX_RESULTS'])
+            results = jira_client.create_issue(description='desc',
+                                               owner_ids=[],
+                                               frequent_user_ids=[],
+                                               priority_level='P2',
+                                               project_key='PROJECT',
+                                               table_uri='key',
+                                               title='title',
+                                               table_url='http://table')
+            mock_JIRA_client.assert_called
+            self.assertEqual(results, self.mock_issue_instance)
+            mock_JIRA_client.return_value.create_issue.assert_called_with(fields=dict(project={
+                'key': 'PROJECT'
+            }, issuetype={
+                'id': 1,
+                'name': 'Bug',
+            }, labels=mock_labels,
+                summary='title',
+                description=("desc \n "
+                             "*Reported By:* test@email.com \n "
+                             "*Table Key:* key [PLEASE DO NOT REMOVE] \n "
+                             "*Table URL:* http://table "),
+                priority={
+                    'name': 'Major'
+            }, reporter={'name': 'test'}))


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Currently, only one issue tracking project ID can be specified in the flask config. This change adds a configuration that when enabled, the `Report an issue` modal will include a new text input field that allows the user reporting the issue to specify a different Jira project key where they want the issue created instead.

The second component has to do with sorting of the issues displayed on the page. Before this change, it only showed open issues first, then closed issues, and sorted within those categories by descending created date order. Now, within the open and closed categories it will sort by priority first and then created date, and it will not display closed tickets older than 90 days. In addition, instead of linking to view all issues associated with the table, there are now two links to show all open issues and all closed issues so that users can more easily access open issues without requiring extra filtering.

These changes are only implemented to work with the Jira client and will keep the current behavior for other issue tracking clients.

### Tests

On the JS side, the new config values are handled in the tests, and the new project key field and open/closed issue links are tested. `test_jira_client.py` tests the creation of an issue with a new project key.

### Documentation

`frontend/docs/application_config.md` was updated to describe the new configs that can be used to enable project selection.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
