### PR TITLE
feat: allow multiple applications

### DIFF
--- a/common/amundsen_common/models/table.py
+++ b/common/amundsen_common/models/table.py
@@ -183,6 +183,7 @@ class Table:
     owners: List[User] = []
     watermarks: List[Watermark] = []
     table_writer: Optional[Application] = None
+    table_apps: Optional[List[Application]] = None
     resource_reports: Optional[List[ResourceReport]] = None
     last_updated_timestamp: Optional[int] = None
     source: Optional[Source] = None

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.21.0'
+__version__ = '0.22.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/frontend/tests/unit/api/metadata/test_v0.py
+++ b/frontend/tests/unit/api/metadata/test_v0.py
@@ -151,6 +151,7 @@ class MetadataTest(unittest.TestCase):
                 'id': 'test_id',
                 'description': 'This is a test'
             },
+            'table_apps': None,
             'watermarks': [
                 {'watermark_type': 'low_watermark', 'partition_key': 'ds', 'partition_value': '', 'create_time': ''},
                 {'watermark_type': 'high_watermark', 'partition_key': 'ds', 'partition_value': '', 'create_time': ''}


### PR DESCRIPTION
We'd like to support associating multiple applications per table. The databuilder model already permits this (Tables to Applications relationship is many-to-many), but the rest of Amundsen does not. 

Here's the design we're working on (i.e. if there's multiple Applications, they'd get a dropdown, grouped per application name).  
<img width="479" alt="Screen Shot 2021-11-05 at 4 54 16 PM" src="https://user-images.githubusercontent.com/3423366/140590507-5fe70c65-4e3a-4126-8d44-b2083868b2a4.png">

We will make this work for generic applications, following https://github.com/amundsen-io/amundsen/pull/1398. 
