### PR TITLE
Feat: Further generalize applications

### DIFF
--- a/databuilder/databuilder/models/application.py
+++ b/databuilder/databuilder/models/application.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterator, Union, Optional
+from typing import (
+    Iterator, Optional, Union,
+)
 
 from amundsen_common.utils.atlas import (
     AtlasCommonParams, AtlasCommonTypes, AtlasTableTypes,

--- a/databuilder/databuilder/models/application.py
+++ b/databuilder/databuilder/models/application.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterator, Union
+from typing import Iterator, Union, Optional
 
 from amundsen_common.utils.atlas import (
     AtlasCommonParams, AtlasCommonTypes, AtlasTableTypes,
@@ -21,88 +21,51 @@ from databuilder.serializers.atlas_serializer import get_entity_attrs
 from databuilder.utils.atlas import AtlasRelationshipTypes, AtlasSerializedEntityOperation
 
 
-class Application(GraphSerializable, TableSerializable, AtlasSerializable):
+class GenericApplication(GraphSerializable, TableSerializable, AtlasSerializable):
     """
-    Application-table matching model
-
-    Application represent the applications that generate tables
+    An Application that generates or consumes a resource.
     """
 
-    APPLICATION_LABEL = 'Application'
+    LABEL = 'Application'
+    DEFAULT_KEY_FORMAT = 'application://{application_type}/{application_id}'
 
-    APPLICATION_KEY_FORMAT = 'application://{application_type}/{database}/{table}'
-    APPLICATION_ID_FORMAT = '{application_type}.{database}.{table}'
-    APPLICATION_DESCRIPTION_FORMAT = '{application_type} application for {database}.{table}'
+    APP_URL = 'application_url'
+    APP_NAME = 'name'
+    APP_ID = 'id'
+    APP_DESCRIPTION = 'description'
 
-    # Hardcode Airflow configuration values for backwards compatibility
-    AIRFLOW_APPLICATION_KEY_FORMAT = 'application://{cluster}.airflow/{dag}/{task}'
-    AIRFLOW_APPLICATION_ID_FORMAT = '{dag}/{task}'
-    AIRFLOW_APPLICATION_DESCRIPTION_FORMAT = 'Airflow with id {id}'
+    GENERATES_REL_TYPE = 'GENERATES'
+    DERIVED_FROM_REL_TYPE = 'DERIVED_FROM'
+    CONSUMES_REL_TYPE = 'CONSUMES'
+    CONSUMED_BY_REL_TYPE = 'CONSUMED_BY'
 
-    APPLICATION_URL_NAME = 'application_url'
-    APPLICATION_NAME = 'name'
-    APPLICATION_ID = 'id'
-    APPLICATION_DESCRIPTION = 'description'
-    APPLICATION_TABLE_RELATION_TYPE = 'GENERATES'
-    TABLE_APPLICATION_RELATION_TYPE = 'DERIVED_FROM'
+    LABELS_PERMITTED_TO_HAVE_USAGE = ['Table']
 
     def __init__(self,
-                 task_id: str,
-                 dag_id: str,
-                 application_url_template: str,
-                 db_name: str = 'hive',
-                 cluster: str = 'gold',
-                 schema: str = '',
-                 table_name: str = '',
-                 application_type: str = 'Airflow',
-                 exec_date: str = '',
+                 start_label: str,
+                 start_key: str,
+                 application_type: str,
+                 application_id: str,
+                 application_url: str,
+                 application_description: Optional[str] = None,
+                 app_key_override: Optional[str] = None,  # for bw-compatibility only
+                 generates_resource: bool = True,
                  ) -> None:
-        # todo: need to modify this hack
-        self.application_url = application_url_template.format(dag_id=dag_id)
-        self.database = db_name
-        self.cluster = cluster
-        self.schema = schema
-        self.table = table_name
-        self.dag = dag_id
+
+        if start_label not in GenericApplication.LABELS_PERMITTED_TO_HAVE_USAGE:
+            raise Exception(f'applications associated with {start_label} are not supported')
+
+        self.start_label = start_label
+        self.start_key = start_key
         self.application_type = application_type
-        self.task = task_id
-
-        application_id_format = Application.APPLICATION_ID_FORMAT
-        application_key_format = Application.APPLICATION_KEY_FORMAT
-        application_description_format = Application.APPLICATION_DESCRIPTION_FORMAT
-
-        # The Application model was originally designed to only be compatible with Airflow
-        # If the type is Airflow we must use the hardcoded Airflow constants for backwards compatibility
-        if self.application_type.lower() == 'airflow':
-            application_id_format = Application.AIRFLOW_APPLICATION_ID_FORMAT
-            application_key_format = Application.AIRFLOW_APPLICATION_KEY_FORMAT
-            application_description_format = Application.AIRFLOW_APPLICATION_DESCRIPTION_FORMAT
-
-        self.application_id = application_id_format.format(
-            dag=self.dag,
-            task=self.task,
-            table=self.table,
-            database=self.database,
+        self.application_id = application_id
+        self.application_url = application_url
+        self.application_description = application_description
+        self.application_key = app_key_override or GenericApplication.DEFAULT_KEY_FORMAT.format(
             application_type=self.application_type,
+            application_id=self.application_id,
         )
-        self.application_key = application_key_format.format(
-            dag=self.dag,
-            task=self.task,
-            table=self.table,
-            database=self.database,
-            cluster=self.cluster,
-            application_type=self.application_type,
-        )
-
-        self.application_description = application_description_format.format(
-            dag=self.dag,
-            task=self.task,
-            table=self.table,
-            database=self.database,
-            cluster=self.cluster,
-            id=self.application_id,
-            application_type=self.application_type,
-        )
+        self.generates_resource = generates_resource
 
         self._node_iter = self._create_node_iterator()
         self._relation_iter = self._create_relation_iterator()
@@ -129,29 +92,24 @@ class Application(GraphSerializable, TableSerializable, AtlasSerializable):
         except StopIteration:
             return None
 
-    def get_table_model_key(self) -> str:
-        # returns formatted string for table name
-        return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,
-                                                     schema=self.schema,
-                                                     tbl=self.table,
-                                                     cluster=self.cluster)
-
     def _create_node_iterator(self) -> Iterator[GraphNode]:
         """
         Create an application node
         :return:
         """
-        application_node = GraphNode(
+        attrs = {
+            GenericApplication.APP_NAME: self.application_type,
+            GenericApplication.APP_ID: self.application_id,
+            GenericApplication.APP_URL: self.application_url,
+        }
+        if self.application_description:
+            attrs[GenericApplication.APP_DESCRIPTION] = self.application_description
+
+        yield GraphNode(
             key=self.application_key,
-            label=Application.APPLICATION_LABEL,
-            attributes={
-                Application.APPLICATION_URL_NAME: self.application_url,
-                Application.APPLICATION_NAME: self.application_type,
-                Application.APPLICATION_DESCRIPTION: self.application_description,
-                Application.APPLICATION_ID: self.application_id
-            }
+            label=GenericApplication.LABEL,
+            attributes=attrs,
         )
-        yield application_node
 
     def _create_relation_iterator(self) -> Iterator[GraphRelationship]:
         """
@@ -159,31 +117,32 @@ class Application(GraphSerializable, TableSerializable, AtlasSerializable):
         :return:
         """
         graph_relationship = GraphRelationship(
-            start_key=self.get_table_model_key(),
-            start_label=TableMetadata.TABLE_NODE_LABEL,
+            start_key=self.start_key,
+            start_label=self.start_label,
             end_key=self.application_key,
-            end_label=Application.APPLICATION_LABEL,
-            type=Application.TABLE_APPLICATION_RELATION_TYPE,
-            reverse_type=Application.APPLICATION_TABLE_RELATION_TYPE,
+            end_label=GenericApplication.LABEL,
+            type=(GenericApplication.DERIVED_FROM_REL_TYPE if self.generates_resource
+                  else GenericApplication.CONSUMED_BY_REL_TYPE),
+            reverse_type=(GenericApplication.GENERATES_REL_TYPE if self.generates_resource
+                          else GenericApplication.CONSUMES_REL_TYPE),
             attributes={}
         )
         yield graph_relationship
 
+    # TODO: support consuming/producing relationships and multiple apps per resource
     def _create_record_iterator(self) -> Iterator[RDSModel]:
-        application_record = RDSApplication(
+        yield RDSApplication(
             rk=self.application_key,
             application_url=self.application_url,
             name=self.application_type,
             id=self.application_id,
-            description=self.application_description
+            description=self.application_description or '',
         )
-        yield application_record
 
-        application_table_record = RDSApplicationTable(
-            rk=self.get_table_model_key(),
+        yield RDSApplicationTable(
+            rk=self.start_key,
             application_rk=self.application_key,
         )
-        yield application_table_record
 
     def create_next_atlas_entity(self) -> Union[AtlasEntity, None]:
         try:
@@ -196,7 +155,7 @@ class Application(GraphSerializable, TableSerializable, AtlasSerializable):
             (AtlasCommonParams.qualified_name, self.application_key),
             ('name', self.application_type),
             ('id', self.application_id),
-            ('description', self.application_description),
+            ('description', self.application_description or ''),
             ('application_url', self.application_url)
         ]
 
@@ -217,14 +176,65 @@ class Application(GraphSerializable, TableSerializable, AtlasSerializable):
         except StopIteration:
             return None
 
+    # TODO: support consuming/producing relationships and multiple apps per resource
     def _create_atlas_relation_iterator(self) -> Iterator[AtlasRelationship]:
-        relationship = AtlasRelationship(
+        yield AtlasRelationship(
             relationshipType=AtlasRelationshipTypes.table_application,
             entityType1=AtlasTableTypes.table,
-            entityQualifiedName1=self.get_table_model_key(),
+            entityQualifiedName1=self.start_key,
             entityType2=AtlasCommonTypes.application,
             entityQualifiedName2=self.application_key,
             attributes={}
         )
 
-        yield relationship
+
+class AirflowApplication(GenericApplication):
+
+    ID_FORMAT = '{dag}/{task}'
+    KEY_FORMAT = 'application://{cluster}.airflow/{id}'
+    DESCRIPTION_FORMAT = 'Airflow with id {id}'
+
+    def __init__(self,
+                 task_id: str,
+                 dag_id: str,
+                 application_url_template: str,
+                 db_name: str = 'hive',
+                 cluster: str = 'gold',
+                 schema: str = '',
+                 table_name: str = '',
+                 application_type: str = 'Airflow',
+                 exec_date: str = '',
+                 generates_table: bool = True,
+                 ) -> None:
+
+        self.database = db_name
+        self.cluster = cluster
+        self.schema = schema
+        self.table = table_name
+        self.dag = dag_id
+        self.task = task_id
+
+        airflow_app_id = AirflowApplication.ID_FORMAT.format(dag=dag_id, task=task_id)
+        GenericApplication.__init__(
+            self,
+            start_label=TableMetadata.TABLE_NODE_LABEL,
+            start_key=self.get_table_model_key(),
+            application_type=application_type,
+            application_id=airflow_app_id,
+            application_url=application_url_template.format(dag_id=dag_id),
+            application_description=AirflowApplication.DESCRIPTION_FORMAT.format(id=airflow_app_id),
+            app_key_override=AirflowApplication.KEY_FORMAT.format(cluster=cluster, id=airflow_app_id),
+            generates_resource=generates_table,
+        )
+
+    def get_table_model_key(self) -> str:
+        return TableMetadata.TABLE_KEY_FORMAT.format(
+            db=self.database,
+            cluster=self.cluster,
+            schema=self.schema,
+            tbl=self.table,
+        )
+
+
+# Alias for backwards compatibility
+Application = AirflowApplication

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.3.1'
+__version__ = '6.4.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/tests/unit/models/test_application.py
+++ b/databuilder/tests/unit/models/test_application.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from collections import namedtuple
+
 from dataclasses import dataclass
 from typing import Dict, List
 from unittest.mock import ANY
 
-from databuilder.models.application import Application
+from databuilder.models.application import Application, GenericApplication
 from databuilder.models.graph_serializable import (
     NODE_KEY, NODE_LABEL, RELATION_END_KEY, RELATION_END_LABEL, RELATION_REVERSE_TYPE, RELATION_START_KEY,
     RELATION_START_LABEL, RELATION_TYPE,
@@ -26,7 +28,7 @@ from databuilder.serializers.neptune_serializer import (
 
 @dataclass
 class ApplicationTestCase:
-    application: Application
+    application: GenericApplication
     expected_node_results: List[Dict]
     expected_relation_results: List[Dict]
     expected_records: List[Dict]
@@ -93,21 +95,35 @@ class TestApplication(unittest.TestCase):
             ),
         )
 
-        # Test several different potential application types
-        for application_type in ['Databricks', 'Snowflake', 'EMR']:
+        # Test several non-airflow applications
+        AppTestCase = namedtuple('AppTestCase', ['name', 'generates_table'])
+        non_airflow_cases = [
+            AppTestCase(name='Databricks', generates_table=False),
+            AppTestCase(name='Snowflake', generates_table=True),
+            AppTestCase(name='EMR', generates_table=False),
+        ]
+
+        for case in non_airflow_cases:
+            application_type = case.name
             url = f'https://{application_type.lower()}.com/job/1234'
             id = f'{application_type}.hive.test_table'
             description = f'{application_type} application for hive.test_table'
-
-            # task_id and dag_id are irrelevant for non Airflow applcations for for backwards
-            # compatibility we do not want to remove the init arguements
-            application = Application(
-                task_id='',
-                dag_id='',
+            table_key = TableMetadata.TABLE_KEY_FORMAT.format(
+                db='hive',
+                cluster='gold',
                 schema='default',
-                table_name='test_table',
-                application_url_template=url,
+                tbl='test_table',
+            )
+
+            application = GenericApplication(
+                start_label=TableMetadata.TABLE_NODE_LABEL,
+                start_key=table_key,
                 application_type=application_type,
+                application_id=id,
+                application_url=url,
+                application_description=description,
+                app_key_override=f'application://{application_type}/hive/test_table',
+                generates_resource=case.generates_table,
             )
 
             expected_node_results = [{
@@ -124,8 +140,10 @@ class TestApplication(unittest.TestCase):
                 RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
                 RELATION_END_KEY: f'application://{application_type}/hive/test_table',
                 RELATION_END_LABEL: 'Application',
-                RELATION_TYPE: 'DERIVED_FROM',
-                RELATION_REVERSE_TYPE: 'GENERATES'
+                RELATION_TYPE: (GenericApplication.DERIVED_FROM_REL_TYPE if case.generates_table
+                                else GenericApplication.CONSUMED_BY_REL_TYPE),
+                RELATION_REVERSE_TYPE: (GenericApplication.GENERATES_REL_TYPE if case.generates_table
+                                        else GenericApplication.CONSUMES_REL_TYPE),
             }]
 
             expected_application_record = {
@@ -154,11 +172,6 @@ class TestApplication(unittest.TestCase):
                     expected_records,
                 ),
             )
-
-    def test_get_table_model_key(self) -> None:
-        for tc in self.test_cases:
-            table = tc.application.get_table_model_key()
-            self.assertEqual(table, 'hive://gold.default/test_table')
 
     def test_get_application_model_key(self) -> None:
         for tc in self.test_cases:
@@ -218,16 +231,16 @@ class TestApplication(unittest.TestCase):
                 NEPTUNE_HEADER_ID: "{label}:{from_vertex_id}_{to_vertex_id}".format(
                     from_vertex_id=table_id,
                     to_vertex_id=application_id,
-                    label='DERIVED_FROM'
+                    label=tc.expected_relation_results[0][RELATION_TYPE],
                 ),
                 METADATA_KEY_PROPERTY_NAME_BULK_LOADER_FORMAT: "{label}:{from_vertex_id}_{to_vertex_id}".format(
                     from_vertex_id=table_id,
                     to_vertex_id=application_id,
-                    label='DERIVED_FROM'
+                    label=tc.expected_relation_results[0][RELATION_TYPE],
                 ),
                 NEPTUNE_RELATIONSHIP_HEADER_FROM: table_id,
                 NEPTUNE_RELATIONSHIP_HEADER_TO: application_id,
-                NEPTUNE_HEADER_LABEL: 'DERIVED_FROM',
+                NEPTUNE_HEADER_LABEL: tc.expected_relation_results[0][RELATION_TYPE],
                 NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
                 NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
             }
@@ -236,16 +249,16 @@ class TestApplication(unittest.TestCase):
                 NEPTUNE_HEADER_ID: "{label}:{from_vertex_id}_{to_vertex_id}".format(
                     from_vertex_id=application_id,
                     to_vertex_id=table_id,
-                    label='GENERATES'
+                    label=tc.expected_relation_results[0][RELATION_REVERSE_TYPE],
                 ),
                 METADATA_KEY_PROPERTY_NAME_BULK_LOADER_FORMAT: "{label}:{from_vertex_id}_{to_vertex_id}".format(
                     from_vertex_id=application_id,
                     to_vertex_id=table_id,
-                    label='GENERATES'
+                    label=tc.expected_relation_results[0][RELATION_REVERSE_TYPE],
                 ),
                 NEPTUNE_RELATIONSHIP_HEADER_FROM: application_id,
                 NEPTUNE_RELATIONSHIP_HEADER_TO: table_id,
-                NEPTUNE_HEADER_LABEL: 'GENERATES',
+                NEPTUNE_HEADER_LABEL: tc.expected_relation_results[0][RELATION_REVERSE_TYPE],
                 NEPTUNE_LAST_EXTRACTED_AT_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: ANY,
                 NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT: NEPTUNE_CREATION_TYPE_JOB
             }

--- a/databuilder/tests/unit/models/test_application.py
+++ b/databuilder/tests/unit/models/test_application.py
@@ -3,7 +3,6 @@
 
 import unittest
 from collections import namedtuple
-
 from dataclasses import dataclass
 from typing import Dict, List
 from unittest.mock import ANY

--- a/metadata/metadata_service/api/swagger_doc/template.yml
+++ b/metadata/metadata_service/api/swagger_doc/template.yml
@@ -201,7 +201,7 @@ components:
         create_time:
           type: string
           description: 'Create time'
-    TableWriterFields:
+    ApplicationFields:
       type: object
       properties:
         application_url:
@@ -209,13 +209,16 @@ components:
           description: 'Application url'
         name:
           type: string
-          description: 'Table writer name'
+          description: 'Application name'
         id:
           type: string
-          description: 'Table writer id'
+          description: 'Application id'
+        kind:
+          type: string
+          description: 'Whether the app is a producer or consumer'
         description:
           type: string
-          description: 'Table writer description'
+          description: 'Application description'
     SourceFields:
       type: object
       properties:
@@ -276,7 +279,11 @@ components:
             items:
               $ref: '#/components/schemas/WatermarkFields'
           table_writer:
-            $ref: '#/components/schemas/TableWriterFields'
+            $ref: '#/components/schemas/ApplicationFields'
+          table_apps:
+            type: array
+            description: 'Supersedes table_writer by allowing multiple applications which may be consumers or producers of a table'
+            $ref: '#/components/schemas/ApplicationFields'
           last_updated_timestamp:
             type: integer
             description: 'Epoch timestamp of when it was last updated'
@@ -485,11 +492,6 @@ components:
           description: '[DEPRECATED] Chart names associated with the Dashboard'
           items:
             type: string
-        frequent_users:
-          type: array
-          description: 'List of queries used by this Dashboard'
-          items:
-            $ref: '#/components/schemas/UserDetailFields'
         tables:
           type: array
           description: 'Tables that is used in Dashboard'

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -301,8 +301,8 @@ class Neo4jProxy(BaseProxy):
 
         resource_reports = self._extract_resource_reports_from_query(table_records.get('resource_reports', []))
 
-        return wmk_results, table_writer, table_apps, timestamp_value, owner_record, tags, src, badges, prog_descriptions, \
-            resource_reports
+        return wmk_results, table_writer, table_apps, timestamp_value, owner_record,\
+            tags, src, badges, prog_descriptions, resource_reports
 
     @timer_with_counter
     def _exec_table_query_query(self, table_uri: str) -> Tuple:

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.10.0'
+__version__ = '3.11.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-from collections import namedtuple
-
 import textwrap
 import unittest
+from collections import namedtuple
 from typing import Any, Dict  # noqa: F401
 from unittest.mock import MagicMock, patch
 

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -1463,8 +1463,8 @@ class TestNeo4jProxyHelpers:
     CreateAppsTestCase = namedtuple('CreateAppsTestCase',
                                     ['input_producing', 'input_consuming', 'table_writer', 'table_apps'])
 
-    def test_create_apps(self):
-        def _get_test_record(app_id):
+    def test_create_apps(self) -> None:
+        def _get_test_record(app_id: str) -> dict:
             return {'name': 'SomeApp', 'application_url': 'https://foo.bar', 'id': app_id}
 
         test_cases = [

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.20.0
+amundsen-common>=0.22.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
Continuing the work started in https://github.com/amundsen-io/amundsen/pull/1569. To recap, we'd like to generalize `Application` to support multiple apps per resource and add "consumes" as a new possible relationship type in addition to "generates". See design in the earlier PR. 

Here we have generalized the databuilder model and updated the neo4j proxy. Other proxies will keep their current behavior of fetching and returning one app as the `table_writer`.

This PR takes advantage of the fact that the Application model had [an unused field](https://github.com/amundsen-io/amundsen/blob/main/common/amundsen_common/models/table.py#L78) named `kind` which we're using to specify the relationship (consuming or producing).

Note about bw-compatibility:
**Most** of this PR is fully backwards-compatible: `table_apps` is an optional field and `table_writer` continues to be set as before. The refactor of `Application` into a subclass of `GenericApplication` should be fully transparent. 

However, because we doubled down on extending `Application` beyond Airflow, this unfortunately is incompatible with the earlier changes made in that same direction by @jroof88: https://github.com/amundsen-io/amundsen/pull/1398. Those who have started using `Application` for ingesting non-Airflow apps will have a one-time migration cost to `GenericApplication`. The benefit is in not having to forever work around Airflow specifics like `dag_id` etc. 

Signed-off-by: Dmitriy Kunitskiy <dkunitskiy@lyft.com>
