### PR TITLE
chore: remove pyatlasclient version pinning

### DIFF
--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.4.0'
+__version__ = '6.4.1'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:
@@ -70,7 +70,7 @@ feast = [
 ]
 
 atlas = [
-    'pyatlasclient==1.1.2',
+    'pyatlasclient>=1.1.2',
     'apache-atlas>=0.0.11'
 ]
 


### PR DESCRIPTION
Signed-off-by: sinkuladis <sink.vlad@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

Removes hard version pinning of `pyatlasclient` used in databuider.

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
