### PR TITLE
fix: Tableau dashboard extractor to ignore dashboards of insufficient privileges

### DIFF
--- a/databuilder/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
@@ -41,6 +41,10 @@ class TableauGraphQLDashboardTableExtractor(TableauGraphQLApiExtractor):
                           self._conf.get_list(TableauGraphQLDashboardTableExtractor.EXCLUDED_PROJECTS, [])]
 
         for workbook in workbooks_data:
+            if None in (workbook['projectName'], workbook['name']):
+                LOGGER.warning(f'Ignoring workbook (ID:{workbook["vizportalUrlId"]}) ' +
+                               f'in project (ID:{workbook["projectVizportalUrlId"]}) because of a lack of permission')
+                continue
             data = {
                 'dashboard_group_id': workbook['projectName'],
                 'dashboard_id': TableauDashboardUtils.sanitize_workbook_name(workbook['name']),
@@ -49,7 +53,10 @@ class TableauGraphQLDashboardTableExtractor(TableauGraphQLApiExtractor):
             }
 
             for table in workbook['upstreamTables']:
-
+                if table['name'] is None:
+                    LOGGER.warning(f'Ignoring a table in workbook (ID:{workbook["name"]}) ' +
+                                   f'in project (ID:{workbook["projectName"]}) because of a lack of permission')
+                    continue
                 # external tables have no schema, so they must be parsed differently
                 # see TableauExternalTableExtractor for more specifics
                 if table['schema'] != '':
@@ -111,6 +118,8 @@ class TableauDashboardTableExtractor(Extractor):
           workbooks {
             name
             projectName
+            projectVizportalUrlId
+            vizportalUrlId
             upstreamTables {
               name
               schema

--- a/databuilder/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_table_extractor.py
+++ b/databuilder/tests/unit/extractor/dashboard/tableau/test_tableau_dashboard_table_extractor.py
@@ -41,6 +41,28 @@ def mock_query(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
                         }
                     }
                 ]
+            },
+            {
+                'name': 'Test Workbook',
+                'projectName': 'Test Project',
+                'upstreamTables': [
+                    {
+                        'name': 'test_table_1',
+                        'schema': 'test_schema_1',
+                        'database': {
+                            'name': 'test_database_1',
+                            'connectionType': 'redshift'
+                        }
+                    },
+                    {
+                        'name': None,
+                        'schema': 'test_schema_2',
+                        'database': {
+                            'name': 'test_database_2',
+                            'connectionType': 'redshift'
+                        }
+                    }
+                ]
             }
         ]
     }
@@ -83,6 +105,15 @@ class TestTableauDashboardTable(unittest.TestCase):
         self.assertEqual(record._table_ids, [
             'tableau_dashboard_database://tableau_dashboard_cluster.test_schema_1/test_table_1',
             'tableau_dashboard_database://tableau_dashboard_cluster.test_schema_2/test_table_2'])
+
+        record = extractor.extract()
+
+        self.assertEqual(record._dashboard_id, 'Test Workbook')
+        self.assertEqual(record._dashboard_group_id, 'Test Project')
+        self.assertEqual(record._product, 'tableau')
+        self.assertEqual(record._cluster, 'tableau_dashboard_cluster')
+        self.assertEqual(record._table_ids, [
+            'tableau_dashboard_database://tableau_dashboard_cluster.test_schema_1/test_table_1'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

Tableau API returns null for dashboard name or project name when the user token does not have access privilege for the dashboard or the project.
If these names are None, we would ignore them and shows some warnings.

Related: #911, amundsen-io/amundsendatabuilder/pull/442

<!-- Include a summary of changes -->

### Tests

Add tests for the case of None table name
<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
