### PR TITLE
feat: Adding single apply and clear buttons to apply to all search filters

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -762,17 +762,6 @@ exports[`eslint`] = {
       [101, 15, 16, "Must use destructuring props assignment", "1927755215"],
       [109, 15, 19, "Must use destructuring props assignment", "4761610"]
     ],
-    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx:3245208470": [
-      [58, 6, 25, "Use object destructuring.", "354229464"],
-      [59, 6, 29, "Use object destructuring.", "2645724888"],
-      [60, 6, 44, "Use array destructuring.", "3197678167"],
-      [94, 6, 25, "Use object destructuring.", "354229464"],
-      [95, 6, 29, "Use object destructuring.", "2645724888"],
-      [134, 6, 25, "Use object destructuring.", "354229464"],
-      [135, 6, 29, "Use object destructuring.", "2645724888"],
-      [199, 14, 5, "\'props\' is already declared in the upper scope.", "187023499"],
-      [209, 14, 5, "\'props\' is assigned a value but never used.", "187023499"]
-    ],
     "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx:1903041510": [
       [74, 23, 7, "\'removed\' is assigned a value but never used.", "1396037287"]
     ],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -525,8 +525,8 @@ exports[`eslint`] = {
       [111, 6, 191, "Unexpected lexical declaration in case block.", "1433271452"],
       [117, 6, 59, "Unexpected lexical declaration in case block.", "3993269111"]
     ],
-    "js/ducks/search/filters/reducer.ts:4089663982": [
-      [63, 6, 56, "Unexpected lexical declaration in case block.", "1729617587"]
+    "js/ducks/search/filters/reducer.ts:2963377860": [
+      [58, 6, 56, "Unexpected lexical declaration in case block.", "1729617587"]
     ],
     "js/ducks/search/reducer.ts:4060029949": [
       [202, 2, 12, "\'submitSearch\' is already declared in the upper scope.", "30183583"],
@@ -762,99 +762,31 @@ exports[`eslint`] = {
       [101, 15, 16, "Must use destructuring props assignment", "1927755215"],
       [109, 15, 19, "Must use destructuring props assignment", "4761610"]
     ],
-    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx:464014135": [
-      [57, 6, 25, "Use object destructuring.", "354229464"],
-      [58, 6, 29, "Use object destructuring.", "2645724888"],
-      [59, 6, 44, "Use array destructuring.", "3197678167"],
-      [92, 6, 25, "Use object destructuring.", "354229464"],
-      [93, 6, 29, "Use object destructuring.", "2645724888"],
-      [130, 6, 25, "Use object destructuring.", "354229464"],
-      [131, 6, 29, "Use object destructuring.", "2645724888"],
-      [195, 14, 5, "\'props\' is already declared in the upper scope.", "187023499"],
-      [205, 14, 5, "\'props\' is assigned a value but never used.", "187023499"]
+    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx:3245208470": [
+      [58, 6, 25, "Use object destructuring.", "354229464"],
+      [59, 6, 29, "Use object destructuring.", "2645724888"],
+      [60, 6, 44, "Use array destructuring.", "3197678167"],
+      [94, 6, 25, "Use object destructuring.", "354229464"],
+      [95, 6, 29, "Use object destructuring.", "2645724888"],
+      [134, 6, 25, "Use object destructuring.", "354229464"],
+      [135, 6, 29, "Use object destructuring.", "2645724888"],
+      [199, 14, 5, "\'props\' is already declared in the upper scope.", "187023499"],
+      [209, 14, 5, "\'props\' is assigned a value but never used.", "187023499"]
     ],
-    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx:764455976": [
-      [49, 17, 24, "Must use destructuring props assignment", "4001263474"],
-      [66, 11, 24, "Must use destructuring props assignment", "4001263474"],
-      [72, 17, 7, "\'removed\' is assigned a value but never used.", "1396037287"],
-      [74, 10, 24, "Must use destructuring props assignment", "4001263474"],
-      [79, 6, 23, "Must use destructuring props assignment", "405692188"],
-      [81, 6, 23, "Must use destructuring props assignment", "405692188"]
+    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx:1903041510": [
+      [74, 23, 7, "\'removed\' is assigned a value but never used.", "1396037287"]
     ],
-    "js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx:1370878703": [
-      [19, 0, 46, "\`../constants\` import should occur before import of \`.\`", "1852737997"],
-      [98, 14, 7, "\'wrapper\' is already declared in the upper scope.", "990908086"],
-      [106, 14, 7, "\'wrapper\' is already declared in the upper scope.", "990908086"]
+    "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:1857548883": [
+      [29, 29, -857, "Expected to return a value at the end of arrow function.", "5381"]
     ],
-    "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:259327291": [
-      [40, 4, 22, "Must use destructuring props assignment", "1282914580"],
-      [40, 27, 21, "Must use destructuring props assignment", "1640009072"],
-      [43, 29, -1198, "Expected to return a value at the end of arrow function.", "5381"]
-    ],
-    "js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx:2360649383": [
-      [10, 9, 10, "\'FilterType\' is defined but never used.", "2796081021"],
-      [41, 6, 45, "Use object destructuring.", "1240672346"],
-      [53, 6, 25, "Use object destructuring.", "354229464"],
-      [54, 6, 29, "Use object destructuring.", "2645724888"],
-      [91, 6, 25, "Use object destructuring.", "354229464"],
-      [92, 6, 29, "Use object destructuring.", "2645724888"],
-      [117, 6, 25, "Use object destructuring.", "354229464"],
-      [117, 6, 5, "\'props\' is assigned a value but never used.", "187023499"],
-      [118, 6, 29, "Use object destructuring.", "2645724888"],
-      [137, 6, 25, "Use object destructuring.", "354229464"],
-      [138, 6, 29, "Use object destructuring.", "2645724888"],
-      [205, 14, 5, "\'props\' is already declared in the upper scope.", "187023499"],
-      [215, 14, 5, "\'props\' is assigned a value but never used.", "187023499"]
-    ],
-    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:1127269209": [
-      [49, 21, 16, "Must use destructuring props assignment", "1934035558"],
-      [51, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [57, 8, 16, "Must use destructuring state assignment", "3998965439"],
-      [58, 6, 23, "Must use destructuring props assignment", "405692188"],
-      [58, 30, 21, "Must use destructuring props assignment", "1640009072"],
-      [58, 53, 16, "Must use destructuring state assignment", "3998965439"],
-      [60, 6, 23, "Must use destructuring props assignment", "405692188"],
-      [60, 30, 21, "Must use destructuring props assignment", "1640009072"],
-      [75, 8, 203, "A control must be associated with a text label.", "4138944353"],
-      [81, 17, 16, "Must use destructuring state assignment", "3998965439"]
-    ],
-    "js/pages/SearchPage/SearchFilter/index.spec.tsx:3995988813": [
-      [67, 6, 25, "Use object destructuring.", "354229464"],
-      [68, 6, 29, "Use object destructuring.", "2645724888"],
-      [69, 6, 48, "Use array destructuring.", "1915473085"],
-      [70, 6, 45, "Use array destructuring.", "1487312825"],
-      [104, 14, 7, "\'content\' is already declared in the upper scope.", "3716929964"],
-      [119, 6, 25, "Use object destructuring.", "354229464"],
-      [120, 6, 29, "Use object destructuring.", "2645724888"],
-      [144, 6, 29, "Use object destructuring.", "2645724888"]
+    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:761986486": [
+      [50, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/pages/SearchPage/SearchPanel/tests/index.spec.tsx:3928473928": [
       [25, 6, 25, "Use object destructuring.", "1230260048"]
     ],
     "js/pages/SearchPage/constants.ts:2540603999": [
       [14, 2, 112, "Multiline support is limited to browsers supporting ES5 only.", "2645164555"]
-    ],
-    "js/pages/SearchPage/index.spec.tsx:901773677": [
-      [146, 16, 5, "\'props\' is assigned a value but never used.", "187023499"],
-      [213, 8, 25, "Use object destructuring.", "354229464"],
-      [214, 8, 29, "Use object destructuring.", "2645724888"],
-      [215, 8, 27, "\'generateInfoTextMockResults\' is assigned a value but never used.", "4193504909"],
-      [222, 16, 5, "\'props\' is already declared in the upper scope.", "187023499"],
-      [222, 23, 7, "\'wrapper\' is already declared in the upper scope.", "990908086"]
-    ],
-    "js/pages/SearchPage/index.tsx:558952138": [
-      [72, 4, 23, "Must use destructuring props assignment", "2469865886"],
-      [72, 28, 19, "Must use destructuring props assignment", "1779396464"],
-      [76, 8, 19, "Must use destructuring props assignment", "1779396464"],
-      [77, 6, 23, "Must use destructuring props assignment", "2469865886"],
-      [77, 30, 19, "Must use destructuring props assignment", "1779396464"],
-      [82, 12, 19, "Must use destructuring props assignment", "3960624135"],
-      [84, 34, 17, "Must use destructuring props assignment", "3767383680"],
-      [86, 34, 16, "Must use destructuring props assignment", "1927755215"],
-      [89, 10, 21, "Must use destructuring props assignment", "1352381626"],
-      [93, 34, 19, "Must use destructuring props assignment", "4761610"],
-      [164, 24, 23, "Must use destructuring props assignment", "1307307490"],
-      [175, 8, 20, "Must use destructuring props assignment", "2826313809"]
     ],
     "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1422860355": [
       [89, 4, 25, "Must use destructuring props assignment", "1403663841"],

--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.spec.ts
@@ -15,13 +15,17 @@ describe('filters reducer', () => {
       const testCategory = 'column';
       const testValue = 'column_name';
       const action = updateFilterByCategory({
-        categoryId: testCategory,
-        value: testValue,
+        searchFilters: [
+          {
+            categoryId: testCategory,
+            value: testValue,
+          },
+        ],
       });
       const { payload } = action;
       expect(action.type).toBe(UpdateSearchFilter.REQUEST);
-      expect(payload.categoryId).toBe(testCategory);
-      expect(payload.value).toBe(testValue);
+      expect(payload.searchFilters[0].categoryId).toBe(testCategory);
+      expect(payload.searchFilters[0].value).toBe(testValue);
     });
   });
 

--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
@@ -2,15 +2,14 @@ import {
   SubmitSearchResource,
   SubmitSearchResourceRequest,
 } from 'ducks/search/types';
-import { ResourceType } from 'interfaces';
+import { FilterOptions, ResourceType, SearchFilterInput } from 'interfaces';
 
 /* ACTION TYPES */
 export enum UpdateSearchFilter {
   REQUEST = 'amundsen/search/filter/UPDATE_SEARCH_FILTER_REQUEST',
 }
 export type UpdateFilterPayload = {
-  categoryId: string;
-  value: string | FilterOptions | undefined;
+  searchFilters: SearchFilterInput[];
 };
 export interface UpdateFilterRequest {
   payload: UpdateFilterPayload;
@@ -19,21 +18,17 @@ export interface UpdateFilterRequest {
 
 /* ACTIONS */
 export function updateFilterByCategory({
-  categoryId,
-  value,
+  searchFilters,
 }: UpdateFilterPayload): UpdateFilterRequest {
   return {
     payload: {
-      categoryId,
-      value,
+      searchFilters,
     },
     type: UpdateSearchFilter.REQUEST,
   };
 }
 
 /* REDUCER TYPES */
-export type FilterOptions = { [id: string]: boolean };
-
 export interface FilterReducerState {
   [ResourceType.dashboard]?: ResourceFilterReducerState;
   [ResourceType.table]?: ResourceFilterReducerState;

--- a/frontend/amundsen_application/static/js/ducks/search/filters/sagas.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/sagas.spec.ts
@@ -52,7 +52,9 @@ describe('filter sagas', () => {
       const testValue = { hive: true };
       testSaga(
         Sagas.filterWorker,
-        updateFilterByCategory({ categoryId: testCategoryId, value: testValue })
+        updateFilterByCategory({
+          searchFilters: [{ categoryId: testCategoryId, value: testValue }],
+        })
       )
         .next()
         .select(SearchUtils.getSearchState)

--- a/frontend/amundsen_application/static/js/ducks/search/filters/sagas.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/sagas.ts
@@ -14,18 +14,20 @@ import { UpdateSearchFilter, UpdateFilterRequest } from './reducer';
  * Then executes a search on current resource based with new filters and current search state values.
  */
 export function* filterWorker(action: UpdateFilterRequest): SagaIterator {
-  const { categoryId, value } = action.payload;
+  const { searchFilters } = action.payload;
   const state = yield select(getSearchState);
   const { search_term, resource, filters } = state;
   let resourceFilters = {
     ...filters[resource],
   };
 
-  if (value === undefined) {
-    resourceFilters = filterFromObj(resourceFilters, [categoryId]);
-  } else {
-    resourceFilters[categoryId] = value;
-  }
+  searchFilters.forEach((filter) => {
+    if (filter.value === undefined) {
+      resourceFilters = filterFromObj(resourceFilters, [filter.categoryId]);
+    } else {
+      resourceFilters[filter.categoryId] = filter.value;
+    }
+  });
 
   yield put(
     submitSearchResource({

--- a/frontend/amundsen_application/static/js/interfaces/SearchFilterInput.ts
+++ b/frontend/amundsen_application/static/js/interfaces/SearchFilterInput.ts
@@ -1,0 +1,9 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface SearchFilterInput {
+  categoryId: string;
+  value: string | FilterOptions | undefined;
+}
+
+export type FilterOptions = { [id: string]: boolean };

--- a/frontend/amundsen_application/static/js/interfaces/index.ts
+++ b/frontend/amundsen_application/static/js/interfaces/index.ts
@@ -8,6 +8,7 @@ export * from './Issue';
 export * from './Notifications';
 export * from './PreviewData';
 export * from './Resources';
+export * from './SearchFilterInput';
 export * from './TableMetadata';
 export * from './Tags';
 export * from './User';

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
@@ -191,7 +191,9 @@ describe('CheckBoxFilter', () => {
     });
 
     it('sets checkedValues to empty object if no filters exist for the given category', () => {
-      const { props: fakeCategoryProps } = setup({ categoryId: 'fakeCategory' });
+      const { props: fakeCategoryProps } = setup({
+        categoryId: 'fakeCategory',
+      });
       result = mapStateToProps(mockStateWithFilters, fakeCategoryProps);
       expect(result.checkedValues).toEqual({});
     });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
@@ -36,6 +36,7 @@ describe('CheckBoxFilter', () => {
         hive: true,
       },
       updateFilter: jest.fn(),
+      setDidApplyFilters: jest.fn(),
       ...propOverrides,
     };
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -88,11 +89,13 @@ describe('CheckBoxFilter', () => {
     let mockEvent;
 
     let updateFilterSpy;
+    let setDidApplyFiltersSpy;
     beforeAll(() => {
       const setupResult = setup();
       props = setupResult.props;
       wrapper = setupResult.wrapper;
       updateFilterSpy = jest.spyOn(props, 'updateFilter');
+      setDidApplyFiltersSpy = jest.spyOn(props, 'setDidApplyFilters');
     });
 
     it('calls props.updateFilter if no items will be checked', () => {
@@ -118,6 +121,7 @@ describe('CheckBoxFilter', () => {
         mockCategoryId,
         expectedCheckedValues
       );
+      expect(setDidApplyFiltersSpy).toHaveBeenCalledWith(true);
     });
   });
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
@@ -55,10 +55,8 @@ describe('CheckBoxFilter', () => {
     let checkBoxItem;
     let mockProperties;
     beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
-      mockProperties = props.checkboxProperties[0];
+      ({ props, wrapper } = setup());
+      [mockProperties] = props.checkboxProperties;
       const content = wrapper
         .instance()
         .createCheckBoxItem(mockCategoryId, 'testKey', mockProperties);
@@ -91,9 +89,7 @@ describe('CheckBoxFilter', () => {
     let updateFilterSpy;
     let setDidApplyFiltersSpy;
     beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
+      ({ props, wrapper } = setup());
       updateFilterSpy = jest.spyOn(props, 'updateFilter');
       setDidApplyFiltersSpy = jest.spyOn(props, 'setDidApplyFilters');
     });
@@ -131,9 +127,7 @@ describe('CheckBoxFilter', () => {
     let createCheckBoxItemSpy;
 
     beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
+      ({ props, wrapper } = setup());
       createCheckBoxItemSpy = jest.spyOn(
         wrapper.instance(),
         'createCheckBoxItem'
@@ -197,8 +191,8 @@ describe('CheckBoxFilter', () => {
     });
 
     it('sets checkedValues to empty object if no filters exist for the given category', () => {
-      const { props } = setup({ categoryId: 'fakeCategory' });
-      result = mapStateToProps(mockStateWithFilters, props);
+      const { props: fakeCategoryProps } = setup({ categoryId: 'fakeCategory' });
+      result = mapStateToProps(mockStateWithFilters, fakeCategoryProps);
       expect(result.checkedValues).toEqual({});
     });
   });
@@ -207,7 +201,6 @@ describe('CheckBoxFilter', () => {
     let dispatch;
     let result;
     beforeAll(() => {
-      const { props } = setup();
       dispatch = jest.fn(() => Promise.resolve());
       result = mapDispatchToProps(dispatch);
     });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx
@@ -9,10 +9,10 @@ import { GlobalState } from 'ducks/rootReducer';
 import {
   updateFilterByCategory,
   UpdateFilterRequest,
-  FilterOptions,
 } from 'ducks/search/filters/reducer';
 
 import CheckBoxItem from 'components/Inputs/CheckBoxItem';
+import { FilterOptions } from 'interfaces/SearchFilterInput';
 
 export interface CheckboxFilterProperties {
   label: string;
@@ -22,6 +22,7 @@ export interface CheckboxFilterProperties {
 interface OwnProps {
   categoryId: string;
   checkboxProperties: CheckboxFilterProperties[];
+  setDidApplyFilters: (didApply: boolean) => void;
 }
 
 interface StateFromProps {
@@ -43,11 +44,12 @@ export class CheckBoxFilter extends React.Component<CheckBoxFilterProps> {
     key: string,
     item: CheckboxFilterProperties
   ) => {
+    const { checkedValues } = this.props;
     const { label, value } = item;
     return (
       <CheckBoxItem
         key={key}
-        checked={this.props.checkedValues[value]}
+        checked={checkedValues[value]}
         name={categoryId}
         value={value}
         onChange={this.onCheckboxChange}
@@ -59,27 +61,26 @@ export class CheckBoxFilter extends React.Component<CheckBoxFilterProps> {
 
   onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let { checkedValues } = this.props;
+    const { updateFilter, setDidApplyFilters } = this.props;
     const { value } = e.target;
     const categoryId = e.target.name;
 
     if (e.target.checked) {
       checkedValues = {
-        ...this.props.checkedValues,
+        ...checkedValues,
         [value]: true,
       };
     } else {
       /* Removing an object key with object destructuring */
-      const {
-        [value]: removed,
-        ...newCheckedValues
-      } = this.props.checkedValues;
+      const { [value]: removed, ...newCheckedValues } = checkedValues;
       checkedValues = newCheckedValues;
     }
 
     if (Object.keys(checkedValues).length === 0) {
-      this.props.updateFilter(categoryId, undefined);
+      updateFilter(categoryId, undefined);
     } else {
-      this.props.updateFilter(categoryId, checkedValues);
+      updateFilter(categoryId, checkedValues);
+      setDidApplyFilters(true);
     }
   };
 
@@ -119,7 +120,10 @@ export const mapDispatchToProps = (dispatch: any) =>
       updateFilter: (
         categoryId: string,
         checkedValues: FilterOptions | undefined
-      ) => updateFilterByCategory({ categoryId, value: checkedValues }),
+      ) =>
+        updateFilterByCategory({
+          searchFilters: [{ categoryId, value: checkedValues }],
+        }),
     },
     dispatch
   );

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx
@@ -11,21 +11,15 @@ import globalState from 'fixtures/globalState';
 import { FilterType, ResourceType } from 'interfaces';
 
 import InfoButton from 'components/InfoButton';
-import {
-  FilterSection,
-  FilterSectionProps,
-  mapDispatchToProps,
-  mapStateToProps,
-} from '.';
-import { CLEAR_BTN_TEXT } from '../constants';
+import { FilterSection, FilterSectionProps, mapStateToProps } from '.';
 
 const setup = (propOverrides?: Partial<FilterSectionProps>) => {
   const props: FilterSectionProps = {
     categoryId: 'testId',
     hasValue: true,
     title: 'Category',
-    clearFilter: jest.fn(),
     type: FilterType.INPUT_SELECT,
+    setDidApplyFilters: jest.fn(),
     ...propOverrides,
   };
   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -37,23 +31,6 @@ const setup = (propOverrides?: Partial<FilterSectionProps>) => {
 };
 
 describe('FilterSection', () => {
-  describe('onClearFilter', () => {
-    let props;
-    let wrapper;
-    let clearFilterSpy;
-
-    beforeAll(() => {
-      ({ props, wrapper } = setup());
-      clearFilterSpy = jest.spyOn(props, 'clearFilter');
-    });
-
-    it('calls props.clearFilter with props.categoryId', () => {
-      wrapper.instance().onClearFilter();
-
-      expect(clearFilterSpy).toHaveBeenCalledWith(props.categoryId);
-    });
-  });
-
   describe('renderFilterComponent', () => {
     it('returns an InputFilter w/ correct props if props.type == FilterType.INPUT_SELECT', () => {
       const { props, wrapper } = setup({ type: FilterType.INPUT_SELECT });
@@ -96,22 +73,13 @@ describe('FilterSection', () => {
 
     it('renders InfoButton with correct props if props.helpText exists', () => {
       const mockHelpText = 'Help me';
-      const { wrapper } = setup({ helpText: mockHelpText });
-      const infoButton = wrapper.find(InfoButton);
+      const { wrapper: wrapperWithHelpText } = setup({
+        helpText: mockHelpText,
+      });
+      const infoButton = wrapperWithHelpText.find(InfoButton);
 
       expect(infoButton.exists()).toBe(true);
       expect(infoButton.props().infoText).toBe(mockHelpText);
-    });
-
-    it('renders button to clear category if props.hasValue', () => {
-      const { wrapper } = setup({ hasValue: true });
-      const clearButton = wrapper.find('button');
-
-      expect(clearButton.exists()).toBe(true);
-      expect(clearButton.props().onClick).toBe(
-        wrapper.instance().onClearFilter
-      );
-      expect(clearButton.text()).toEqual(CLEAR_BTN_TEXT);
     });
 
     it('calls renderFilterComponent()', () => {
@@ -192,21 +160,6 @@ describe('FilterSection', () => {
         result = mapStateToProps(mockStateWithFilters, props);
         expect(result.hasValue).toEqual(false);
       });
-    });
-  });
-
-  describe('mapDispatchToProps', () => {
-    let dispatch;
-    let result;
-
-    beforeAll(() => {
-      setup();
-      dispatch = jest.fn(() => Promise.resolve());
-      result = mapDispatchToProps(dispatch);
-    });
-
-    it('sets clearFilter on the props', () => {
-      expect(result.clearFilter).toBeInstanceOf(Function);
     });
   });
 });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.tsx
@@ -2,18 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-
-import {
-  updateFilterByCategory,
-  UpdateFilterRequest,
-} from 'ducks/search/filters/reducer';
 
 import { GlobalState } from 'ducks/rootReducer';
 import { FilterType, IconSizes } from 'interfaces';
 import InfoButton from 'components/InfoButton';
-import { CLEAR_BTN_TEXT } from '../constants';
 
 import CheckBoxFilter, { CheckboxFilterProperties } from '../CheckBoxFilter';
 import InputFilter from '../InputFilter';
@@ -24,25 +17,18 @@ export interface OwnProps {
   title: string;
   type: FilterType;
   options?: CheckboxFilterProperties[];
+  setDidApplyFilters: (didApply: boolean) => void;
 }
 
 export interface StateFromProps {
   hasValue: boolean;
 }
 
-export interface DispatchFromProps {
-  clearFilter: (categoryId: string) => UpdateFilterRequest;
-}
-
-export type FilterSectionProps = OwnProps & DispatchFromProps & StateFromProps;
+export type FilterSectionProps = OwnProps & StateFromProps;
 
 export class FilterSection extends React.Component<FilterSectionProps> {
-  onClearFilter = () => {
-    this.props.clearFilter(this.props.categoryId);
-  };
-
   renderFilterComponent = () => {
-    const { categoryId, options, type } = this.props;
+    const { categoryId, options, type, setDidApplyFilters } = this.props;
 
     if (type === FilterType.INPUT_SELECT) {
       return <InputFilter categoryId={categoryId} />;
@@ -52,13 +38,14 @@ export class FilterSection extends React.Component<FilterSectionProps> {
         <CheckBoxFilter
           categoryId={categoryId}
           checkboxProperties={options || []}
+          setDidApplyFilters={setDidApplyFilters}
         />
       );
     }
   };
 
   render = () => {
-    const { categoryId, hasValue, helpText, title } = this.props;
+    const { categoryId, helpText, title } = this.props;
 
     return (
       <div className="search-filter-section">
@@ -78,15 +65,6 @@ export class FilterSection extends React.Component<FilterSectionProps> {
               />
             )}
           </div>
-          {hasValue && (
-            <button
-              onClick={this.onClearFilter}
-              className="btn btn-link clear-button"
-              type="button"
-            >
-              {CLEAR_BTN_TEXT}
-            </button>
-          )}
         </div>
         {this.renderFilterComponent()}
       </div>
@@ -115,16 +93,6 @@ export const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
   };
 };
 
-export const mapDispatchToProps = (dispatch: any) =>
-  bindActionCreators(
-    {
-      clearFilter: (categoryId: string) =>
-        updateFilterByCategory({ categoryId, value: undefined }),
-    },
-    dispatch
-  );
-
-export default connect<StateFromProps, DispatchFromProps, OwnProps>(
-  mapStateToProps,
-  mapDispatchToProps
-)(FilterSection);
+export default connect<StateFromProps, OwnProps>(mapStateToProps)(
+  FilterSection
+);

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx
@@ -8,8 +8,7 @@ import { GlobalState } from 'ducks/rootReducer';
 
 import globalState from 'fixtures/globalState';
 
-import { FilterType, ResourceType } from 'interfaces';
-import { APPLY_BTN_TEXT } from '../constants';
+import { ResourceType } from 'interfaces';
 import {
   InputFilter,
   InputFilterProps,
@@ -24,7 +23,9 @@ describe('InputFilter', () => {
     const props: InputFilterProps = {
       categoryId: 'schema',
       value: 'schema_name',
-      updateFilter: jest.fn(),
+      filterState: { dashboard: { name: 'name' }, table: { column: 'column' } },
+      resourceType: ResourceType.table,
+      updateFilterState: jest.fn(),
       ...propOverrides,
     };
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -39,7 +40,7 @@ describe('InputFilter', () => {
     const testValue = 'test';
     let wrapper;
     beforeAll(() => {
-      wrapper = setup({ value: testValue }).wrapper;
+      ({ wrapper } = setup({ value: testValue }));
     });
     it('sets the value state from props', () => {
       expect(wrapper.state().value).toEqual(testValue);
@@ -50,9 +51,7 @@ describe('InputFilter', () => {
     let props;
     let wrapper;
     beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
+      ({ props, wrapper } = setup());
     });
     it('sets the value state to props.value if the property has changed', () => {
       setStateSpy.mockClear();
@@ -82,41 +81,13 @@ describe('InputFilter', () => {
     });
   });
 
-  describe('onApplyChanges', () => {
-    let props;
-    let wrapper;
-
-    let updateFilterSpy;
-    beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
-      updateFilterSpy = jest.spyOn(props, 'updateFilter');
-    });
-
-    it('calls props.updateFilter if state.value is falsy', () => {
-      updateFilterSpy.mockClear();
-      wrapper.setState({ value: '' });
-      wrapper.instance().onApplyChanges({ preventDefault: jest.fn() });
-      expect(updateFilterSpy).toHaveBeenCalledWith(props.categoryId, undefined);
-    });
-
-    it('calls props.updateFilter if state.value has a truthy value', () => {
-      updateFilterSpy.mockClear();
-      const mockValue = 'hello';
-      wrapper.setState({ value: mockValue });
-      wrapper.instance().onApplyChanges({ preventDefault: jest.fn() });
-      expect(updateFilterSpy).toHaveBeenCalledWith(props.categoryId, mockValue);
-    });
-  });
-
   describe('onInputChange', () => {
     let props;
     let wrapper;
+    let updateFilterStateSpy;
     beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
+      ({ props, wrapper } = setup());
+      updateFilterStateSpy = jest.spyOn(props, 'updateFilterState');
     });
     it('sets the value state to e.target.value', () => {
       setStateSpy.mockClear();
@@ -126,6 +97,16 @@ describe('InputFilter', () => {
       wrapper.instance().onInputChange(mockEvent);
       expect(setStateSpy).toHaveBeenCalledWith({ value: expectedValue });
     });
+
+    it('updates the global filter state', () => {
+      updateFilterStateSpy.mockClear();
+      const mockValue = 'mockValue';
+      const mockEvent = { target: { value: mockValue } };
+      wrapper.instance().onInputChange(mockEvent);
+
+      props.filterState[props.resourceType][props.categoryId] = mockValue;
+      expect(updateFilterStateSpy).toHaveBeenCalledWith(props.filterState);
+    });
   });
 
   describe('render', () => {
@@ -134,15 +115,8 @@ describe('InputFilter', () => {
     let element;
 
     beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
+      ({ props, wrapper } = setup());
       wrapper.instance().render();
-    });
-
-    it('renders a form with correct onSubmit property', () => {
-      element = wrapper.find('form');
-      expect(element.props().onSubmit).toBe(wrapper.instance().onApplyChanges);
     });
 
     it('renders and input text with correct properties', () => {
@@ -151,17 +125,12 @@ describe('InputFilter', () => {
       expect(element.props().onChange).toBe(wrapper.instance().onInputChange);
       expect(element.props().value).toBe(wrapper.state().value);
     });
-
-    it('renders a button with correct properties', () => {
-      element = wrapper.find('button');
-      expect(element.props().name).toBe(props.categoryId);
-      expect(element.text()).toEqual(APPLY_BTN_TEXT);
-    });
   });
 
   describe('mapStateToProps', () => {
+    let props;
     const mockCategoryId = 'schema';
-    const { props } = setup({ categoryId: mockCategoryId });
+    ({ props } = setup({ categoryId: mockCategoryId }));
     const mockFilters = 'schema_name';
 
     const mockStateWithFilters: GlobalState = {
@@ -203,7 +172,7 @@ describe('InputFilter', () => {
     });
 
     it('sets value to empty string if no filters exist for the given category', () => {
-      const { props } = setup({ categoryId: 'fakeCategory' });
+      ({ props } = setup({ categoryId: 'fakeCategory' }));
       result = mapStateToProps(mockStateWithFilters, props);
       expect(result.value).toEqual('');
     });
@@ -213,13 +182,12 @@ describe('InputFilter', () => {
     let dispatch;
     let result;
     beforeAll(() => {
-      const { props } = setup();
       dispatch = jest.fn(() => Promise.resolve());
       result = mapDispatchToProps(dispatch);
     });
 
-    it('sets updateFilter on the props', () => {
-      expect(result.updateFilter).toBeInstanceOf(Function);
+    it('sets updateFilterState on the props', () => {
+      expect(result.updateFilterState).toBeInstanceOf(Function);
     });
   });
 });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
@@ -5,13 +5,11 @@ import * as React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import {
-  updateFilterByCategory,
-  UpdateFilterRequest,
-} from 'ducks/search/filters/reducer';
-
 import { GlobalState } from 'ducks/rootReducer';
-import { APPLY_BTN_TEXT } from '../constants';
+import { updateSearchState } from 'ducks/search/reducer';
+import { ResourceType } from 'interfaces/Resources';
+import { UpdateSearchStateRequest } from 'ducks/search/types';
+import { FilterReducerState } from 'ducks/search/filters/reducer';
 
 interface OwnProps {
   categoryId: string;
@@ -19,13 +17,14 @@ interface OwnProps {
 
 interface StateFromProps {
   value: string;
+  filterState: FilterReducerState;
+  resourceType: ResourceType;
 }
 
-interface DispatchFromProps {
-  updateFilter: (
-    categoryId: string,
-    value: string | undefined
-  ) => UpdateFilterRequest;
+export interface DispatchFromProps {
+  updateFilterState: (
+    newFilterState: FilterReducerState
+  ) => UpdateSearchStateRequest;
 }
 
 export type InputFilterProps = StateFromProps & DispatchFromProps & OwnProps;
@@ -47,44 +46,41 @@ export class InputFilter extends React.Component<
   }
 
   componentDidUpdate = (prevProps: StateFromProps) => {
-    const newValue = this.props.value;
+    const { value: newValue } = this.props;
     if (prevProps.value !== newValue) {
       this.setState({ value: newValue || '' });
     }
   };
 
-  onApplyChanges = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (this.state.value) {
-      this.props.updateFilter(this.props.categoryId, this.state.value);
-    } else {
-      this.props.updateFilter(this.props.categoryId, undefined);
-    }
-  };
-
   onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ value: e.target.value.toLowerCase() });
+    const {
+      filterState,
+      resourceType,
+      categoryId,
+      updateFilterState,
+    } = this.props;
+    const newValue = e.target.value.toLowerCase();
+
+    this.setState({ value: newValue });
+
+    filterState[resourceType][categoryId] = newValue;
+    updateFilterState(filterState);
   };
 
   render = () => {
+    const { value } = this.state;
     const { categoryId } = this.props;
+    const ariaLabel = categoryId + ' filter input';
     return (
-      <form
-        className="input-section-content form-group"
-        onSubmit={this.onApplyChanges}
-      >
-        <input
-          type="text"
-          className="form-control"
-          name={categoryId}
-          id={categoryId}
-          onChange={this.onInputChange}
-          value={this.state.value}
-        />
-        <button name={categoryId} className="btn btn-default" type="submit">
-          {APPLY_BTN_TEXT}
-        </button>
-      </form>
+      <input
+        type="text"
+        className="form-control"
+        name={categoryId}
+        id={categoryId}
+        onChange={this.onInputChange}
+        value={value}
+        aria-label={ariaLabel}
+      />
     );
   };
 }
@@ -96,14 +92,21 @@ export const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
     : '';
   return {
     value: value || '',
+    filterState: state.search.filters,
+    resourceType: state.search.resource,
   };
 };
 
 export const mapDispatchToProps = (dispatch: any) =>
   bindActionCreators(
     {
-      updateFilter: (categoryId: string, value: string | undefined) =>
-        updateFilterByCategory({ categoryId, value }),
+      updateFilterState: (newFilterState: FilterReducerState) =>
+        updateSearchState({
+          filters: {
+            ...newFilterState,
+          },
+          submitSearch: false,
+        }),
     },
     dispatch
   );

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/constants.ts
@@ -1,3 +1,3 @@
-export const APPLY_BTN_TEXT = 'Apply';
+export const APPLY_BTN_TEXT = 'Apply filters';
 
-export const CLEAR_BTN_TEXT = 'Clear';
+export const CLEAR_BTN_TEXT = 'Clear all';

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/styles.scss
@@ -27,18 +27,16 @@
 
   .input-section-content {
     display: flex;
-
-    button,
-    input[type='text'] {
-      margin-top: $spacer-1;
-    }
-
-    button {
-      margin-left: $spacer-1;
-    }
+    flex-direction: column;
 
     input {
       min-width: 0;
     }
+  }
+
+  .input-section-buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-top: $spacer-3;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/SearchPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/index.spec.tsx
@@ -144,7 +144,25 @@ describe('SearchPage', () => {
     let content;
     describe('if no search input (no term or filters)', () => {
       it('renders default search page message', () => {
-        const { props, wrapper } = setup({ searchTerm: '', hasFilters: false });
+        const { wrapper } = setup({ searchTerm: '', hasFilters: false });
+        content = shallow(
+          wrapper.instance().getTabContent(
+            {
+              page_index: 0,
+              results: [],
+              total_results: 0,
+            },
+            ResourceType.table
+          )
+        );
+        expect(content.children().at(0).text()).toEqual(SEARCH_DEFAULT_MESSAGE);
+      });
+    });
+
+    describe('if there are filters that have not been applied yet', () => {
+      it('renders default search page message', () => {
+        const { wrapper } = setup({ searchTerm: '', hasFilters: true });
+        wrapper.setState({ didApplyFilters: false });
         content = shallow(
           wrapper.instance().getTabContent(
             {
@@ -177,8 +195,9 @@ describe('SearchPage', () => {
         expect(content.children().at(0).text()).toEqual(message);
       });
 
-      it('if no searchTerm but there are filters active', () => {
+      it('if no searchTerm but there are filters active that have been applied', () => {
         const { wrapper } = setup({ searchTerm: '', hasFilters: true });
+        wrapper.setState({ didApplyFilters: true });
         content = shallow(
           wrapper.instance().getTabContent(testResults, ResourceType.table)
         );
@@ -207,20 +226,16 @@ describe('SearchPage', () => {
     describe('if searchTerm and search results exist', () => {
       let props;
       let wrapper;
-      let generateInfoTextMockResults;
 
       beforeAll(() => {
-        const setupResult = setup({ searchTerm: '' });
-        props = setupResult.props;
-        wrapper = setupResult.wrapper;
-        generateInfoTextMockResults = 'test info text';
+        ({ props, wrapper } = setup({ searchTerm: '' }));
         content = shallow(
           wrapper.instance().getTabContent(props.tables, ResourceType.table)
         );
       });
 
       it('renders PaginatedApiResourceList with correct props', () => {
-        const { props, wrapper } = setup();
+        ({ props, wrapper } = setup());
         const testResults = {
           page_index: 0,
           results: [],

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/constants.ts
@@ -1,3 +1,5 @@
 export const ISSUES_TITLE = 'Issues';
-export const NO_DATA_ISSUES_TEXT = 'No associated issues';
+export const NO_DATA_ISSUES_TEXT = 'No open issues';
 export const CREATE_ISSUE_ERROR_TEXT = 'Could not create issue!';
+export const SINGLE_ISSUE = 'issue';
+export const MULTIPLE_ISSUES = 'issues';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.spec.tsx
@@ -104,11 +104,11 @@ describe('TableIssues', () => {
         total: 1,
         openCount: 1,
         allIssuesUrl: 'url',
-        openIssuesUrl: undefined,
+        openIssuesUrl: 'url',
         closedIssuesUrl: undefined,
       });
       expect(wrapper.find('.table-issue-more-issues').text()).toEqual(
-        'View all 1 issues'
+        'View 1 open issue'
       );
     });
 
@@ -131,7 +131,7 @@ describe('TableIssues', () => {
         closedIssuesUrl: 'url',
       });
       expect(wrapper.find('.table-issue-more-issues').first().text()).toEqual(
-        'View 1 open issues'
+        'View 1 open issue'
       );
       expect(wrapper.find('.table-issue-more-issues').at(1).text()).toEqual(
         'View 0 closed issues'

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
@@ -15,6 +15,8 @@ import {
   ISSUES_TITLE,
   NO_DATA_ISSUES_TEXT,
   CREATE_ISSUE_ERROR_TEXT,
+  SINGLE_ISSUE,
+  MULTIPLE_ISSUES,
 } from './constants';
 import './styles.scss';
 
@@ -111,7 +113,6 @@ export class TableIssues extends React.Component<TableIssueProps> {
       issues,
       tableKey,
       tableName,
-      allIssuesUrl,
       openIssuesUrl,
       closedIssuesUrl,
       total,
@@ -120,6 +121,12 @@ export class TableIssues extends React.Component<TableIssueProps> {
     const totalCount = total || 0;
     const openIssueCount = openCount || 0;
     const closedIssueCount = totalCount - openIssueCount;
+
+    const openIssuesText =
+      openIssueCount === 1 ? SINGLE_ISSUE : MULTIPLE_ISSUES;
+    const closedIssuesText =
+      closedIssueCount === 1 ? SINGLE_ISSUE : MULTIPLE_ISSUES;
+
     const hasIssues = issues.length !== 0 || totalCount > 0;
 
     const reportIssueLink = (
@@ -132,9 +139,9 @@ export class TableIssues extends React.Component<TableIssueProps> {
       return reportIssueLink;
     }
 
-    if (openIssuesUrl && closedIssuesUrl) {
-      return (
-        <span className="table-more-issues" key="more-issue-link">
+    return (
+      <span className="table-more-issues" key="more-issue-link">
+        {openIssuesUrl && (
           <a
             id="open-issues-link"
             className="table-issue-more-issues"
@@ -143,36 +150,24 @@ export class TableIssues extends React.Component<TableIssueProps> {
             href={openIssuesUrl}
             onClick={logClick}
           >
-            View {openIssueCount} open issues
+            View {openIssueCount} open {openIssuesText}
           </a>
-          |
+        )}
+        {openIssuesUrl && closedIssuesUrl ? '|' : ''}
+        {closedIssuesUrl && (
           <a
             id="closed-issues-link"
-            className="table-issue-more-issues last-item"
+            className={`table-issue-more-issues ${
+              openIssuesUrl ? 'last-item' : ''
+            }`}
             target="_blank"
             rel="noreferrer"
             href={closedIssuesUrl}
             onClick={logClick}
           >
-            View {closedIssueCount} closed issues
+            View {closedIssueCount} closed {closedIssuesText}
           </a>
-          |{reportIssueLink}
-        </span>
-      );
-    }
-
-    return (
-      <span className="table-more-issues" key="more-issue-link">
-        <a
-          id="more-issues-link"
-          className="table-issue-more-issues"
-          target="_blank"
-          rel="noreferrer"
-          href={allIssuesUrl}
-          onClick={logClick}
-        >
-          View all {total} issues
-        </a>
+        )}
         |{reportIssueLink}
       </span>
     );


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Currently when filtering on the search page, there are `Apply` and `Clear` buttons for every filter section. Only one filter category/value pair could be passed at a time to the search API due to frontend constraints. This change adds just one `Apply filters` button and one `Clear all` button at the bottom of the filters side panel which allows multiple filters to be passed to the API at the same time.

Another change that was made is related to the `Clear all` behavior. The global state was not aware of the filters in the input text fields until they were applied, so with the new UI changes the single clear button did not work at first if the filters had been typed in but not applied. Now the global state is updated whenever anything is typed into the input fields so that the `Clear all` button will work at any time.

### Tests

Since the `Apply filters` and `Clear all` buttons were moved to a higher level component than they were previously a part of, some tests for those were moved to `SearchFilter` where they are now rendered. A test was also added to ensure the filters global state is updated on any input changes.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
