### PR TITLE
fix: Search filtering behavior fix

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -480,7 +480,7 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:1474434691": [
+    "js/config/config-default.ts:3603164347": [
       [342, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
       [343, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
@@ -528,13 +528,13 @@ exports[`eslint`] = {
     "js/ducks/search/filters/reducer.ts:2963377860": [
       [58, 6, 56, "Unexpected lexical declaration in case block.", "1729617587"]
     ],
-    "js/ducks/search/reducer.ts:4060029949": [
-      [202, 2, 12, "\'submitSearch\' is already declared in the upper scope.", "30183583"],
-      [304, 6, 27, "Unexpected lexical declaration in case block.", "3336779920"],
-      [328, 6, 53, "Unexpected lexical declaration in case block.", "2684420572"],
-      [348, 6, 66, "Unexpected lexical declaration in case block.", "2160263677"],
-      [361, 6, 123, "Unexpected lexical declaration in case block.", "2271601490"],
-      [375, 6, 61, "Unexpected lexical declaration in case block.", "2053236172"]
+    "js/ducks/search/reducer.ts:572539093": [
+      [203, 2, 12, "\'submitSearch\' is already declared in the upper scope.", "30183583"],
+      [306, 6, 27, "Unexpected lexical declaration in case block.", "3336779920"],
+      [331, 6, 53, "Unexpected lexical declaration in case block.", "2684420572"],
+      [352, 6, 66, "Unexpected lexical declaration in case block.", "2160263677"],
+      [366, 6, 123, "Unexpected lexical declaration in case block.", "2271601490"],
+      [380, 6, 61, "Unexpected lexical declaration in case block.", "2053236172"]
     ],
     "js/ducks/search/tests/sagas.spec.ts:1084062070": [
       [313, 6, 31, "Use object destructuring.", "3735531535"]
@@ -585,7 +585,7 @@ exports[`eslint`] = {
       [105, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
       [123, 16, 20, "Must use destructuring state assignment", "2976153148"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:1134041346": [
+    "js/features/ColumnList/ColumnType/parser.ts:4274243564": [
       [58, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
       [59, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [81, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
@@ -593,14 +593,13 @@ exports[`eslint`] = {
       [126, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
       [127, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"],
-      [216, 8, 11, "Assignment to function parameter \'nestedLevel\'.", "3385509726"]
+      [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ColumnList/index.spec.tsx:1172488593": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
     ],
-    "js/features/ColumnList/index.tsx:632462402": [
-      [201, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:562234816": [
+      [203, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -762,13 +761,13 @@ exports[`eslint`] = {
       [101, 15, 16, "Must use destructuring props assignment", "1927755215"],
       [109, 15, 19, "Must use destructuring props assignment", "4761610"]
     ],
-    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx:1903041510": [
-      [74, 23, 7, "\'removed\' is assigned a value but never used.", "1396037287"]
+    "js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx:2551202718": [
+      [73, 23, 7, "\'removed\' is assigned a value but never used.", "1396037287"]
     ],
-    "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:1857548883": [
-      [29, 29, -857, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:221029136": [
+      [28, 29, -806, "Expected to return a value at the end of arrow function.", "5381"]
     ],
-    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:761986486": [
+    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:3421937441": [
       [50, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/pages/SearchPage/SearchPanel/tests/index.spec.tsx:3928473928": [

--- a/frontend/amundsen_application/static/js/ducks/search/reducer.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/reducer.spec.ts
@@ -324,6 +324,7 @@ describe('search reducer', () => {
         ...initialState,
         ...expectedSearchAllResults,
         filters: testState.filters,
+        didSearch: true,
         inlineResults: {
           dashboards: expectedSearchAllResults.dashboards,
           features: expectedSearchAllResults.features,
@@ -360,6 +361,7 @@ describe('search reducer', () => {
         ...testState,
         ...expectedSearchResults,
         isLoading: false,
+        didSearch: true,
       });
     });
 

--- a/frontend/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/reducer.ts
@@ -58,6 +58,7 @@ export interface SearchReducerState {
     features: FeatureSearchResults;
   };
   filters: FilterReducerState;
+  didSearch: boolean;
 }
 
 /* ACTIONS */
@@ -280,6 +281,7 @@ export const initialState: SearchReducerState = {
     total_results: 0,
   },
   filters: initialFilterState,
+  didSearch: false,
   inlineResults: initialInlineResultsState,
 };
 
@@ -307,6 +309,7 @@ export default function reducer(
         ...state,
         filters: payload.filters || state.filters,
         resource: payload.resource || state.resource,
+        didSearch: false,
       };
     case UpdateSearchState.RESET:
       return initialState;
@@ -336,6 +339,7 @@ export default function reducer(
         ...initialState,
         ...newState,
         filters: state.filters,
+        didSearch: true,
         inlineResults: {
           dashboards: newState.dashboards,
           features: newState.features,
@@ -351,6 +355,7 @@ export default function reducer(
         ...state,
         ...resourceNewState,
         isLoading: false,
+        didSearch: true,
       };
     case SearchAll.FAILURE:
     case SearchResource.FAILURE:

--- a/frontend/amundsen_application/static/js/fixtures/globalState.ts
+++ b/frontend/amundsen_application/static/js/fixtures/globalState.ts
@@ -225,6 +225,7 @@ const globalState: GlobalState = {
       },
     },
     filters: defaultEmptyFilters,
+    didSearch: false,
   },
   tableMetadata: {
     isLoading: true,

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.spec.tsx
@@ -36,7 +36,6 @@ describe('CheckBoxFilter', () => {
         hive: true,
       },
       updateFilter: jest.fn(),
-      setDidApplyFilters: jest.fn(),
       ...propOverrides,
     };
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -87,11 +86,9 @@ describe('CheckBoxFilter', () => {
     let mockEvent;
 
     let updateFilterSpy;
-    let setDidApplyFiltersSpy;
     beforeAll(() => {
       ({ props, wrapper } = setup());
       updateFilterSpy = jest.spyOn(props, 'updateFilter');
-      setDidApplyFiltersSpy = jest.spyOn(props, 'setDidApplyFilters');
     });
 
     it('calls props.updateFilter if no items will be checked', () => {
@@ -117,7 +114,6 @@ describe('CheckBoxFilter', () => {
         mockCategoryId,
         expectedCheckedValues
       );
-      expect(setDidApplyFiltersSpy).toHaveBeenCalledWith(true);
     });
   });
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx
@@ -22,7 +22,6 @@ export interface CheckboxFilterProperties {
 interface OwnProps {
   categoryId: string;
   checkboxProperties: CheckboxFilterProperties[];
-  setDidApplyFilters: (didApply: boolean) => void;
 }
 
 interface StateFromProps {
@@ -61,7 +60,7 @@ export class CheckBoxFilter extends React.Component<CheckBoxFilterProps> {
 
   onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let { checkedValues } = this.props;
-    const { updateFilter, setDidApplyFilters } = this.props;
+    const { updateFilter } = this.props;
     const { value } = e.target;
     const categoryId = e.target.name;
 
@@ -80,7 +79,6 @@ export class CheckBoxFilter extends React.Component<CheckBoxFilterProps> {
       updateFilter(categoryId, undefined);
     } else {
       updateFilter(categoryId, checkedValues);
-      setDidApplyFilters(true);
     }
   };
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx
@@ -19,7 +19,6 @@ const setup = (propOverrides?: Partial<FilterSectionProps>) => {
     hasValue: true,
     title: 'Category',
     type: FilterType.INPUT_SELECT,
-    setDidApplyFilters: jest.fn(),
     ...propOverrides,
   };
   // eslint-disable-next-line react/jsx-props-no-spreading

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.tsx
@@ -17,7 +17,6 @@ export interface OwnProps {
   title: string;
   type: FilterType;
   options?: CheckboxFilterProperties[];
-  setDidApplyFilters: (didApply: boolean) => void;
 }
 
 export interface StateFromProps {
@@ -28,7 +27,7 @@ export type FilterSectionProps = OwnProps & StateFromProps;
 
 export class FilterSection extends React.Component<FilterSectionProps> {
   renderFilterComponent = () => {
-    const { categoryId, options, type, setDidApplyFilters } = this.props;
+    const { categoryId, options, type } = this.props;
 
     if (type === FilterType.INPUT_SELECT) {
       return <InputFilter categoryId={categoryId} />;
@@ -38,7 +37,6 @@ export class FilterSection extends React.Component<FilterSectionProps> {
         <CheckBoxFilter
           categoryId={categoryId}
           checkboxProperties={options || []}
-          setDidApplyFilters={setDidApplyFilters}
         />
       );
     }

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx
@@ -104,8 +104,14 @@ describe('InputFilter', () => {
       const mockEvent = { target: { value: mockValue } };
       wrapper.instance().onInputChange(mockEvent);
 
-      props.filterState[props.resourceType][props.categoryId] = mockValue;
-      expect(updateFilterStateSpy).toHaveBeenCalledWith(props.filterState);
+      const newFilters = {
+        ...props.filterState,
+        [props.resourceType]: {
+          ...props.filterState[props.resourceType],
+          [props.categoryId]: mockValue.toLowerCase(),
+        },
+      };
+      expect(updateFilterStateSpy).toHaveBeenCalledWith(newFilters);
     });
   });
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
@@ -63,8 +63,11 @@ export class InputFilter extends React.Component<
 
     this.setState({ value: newValue });
 
-    filterState[resourceType][categoryId] = newValue;
-    updateFilterState(filterState);
+    const newFilters = {
+      ...filterState,
+      [resourceType]: { ...filterState[resourceType], [categoryId]: newValue },
+    };
+    updateFilterState(newFilters);
   };
 
   render = () => {

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.spec.tsx
@@ -68,7 +68,6 @@ describe('SearchFilter', () => {
         },
       ],
       updateFilter: jest.fn(),
-      setDidApplyFilters: jest.fn(),
       ...propOverrides,
     };
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -83,12 +82,10 @@ describe('SearchFilter', () => {
     let props;
     let wrapper;
     let updateFilterSpy;
-    let setDidApplyFiltersSpy;
 
     beforeAll(() => {
       ({ props, wrapper } = setup());
       updateFilterSpy = jest.spyOn(props, 'updateFilter');
-      setDidApplyFiltersSpy = jest.spyOn(props, 'setDidApplyFilters');
     });
 
     it('calls props.updateFilter with schema categoryId', () => {
@@ -100,7 +97,6 @@ describe('SearchFilter', () => {
           value: 'schema',
         },
       ]);
-      expect(setDidApplyFiltersSpy).toHaveBeenCalledWith(true);
     });
   });
 
@@ -108,12 +104,10 @@ describe('SearchFilter', () => {
     let props;
     let wrapper;
     let updateFilterSpy;
-    let setDidApplyFiltersSpy;
 
     beforeAll(() => {
       ({ props, wrapper } = setup());
       updateFilterSpy = jest.spyOn(props, 'updateFilter');
-      setDidApplyFiltersSpy = jest.spyOn(props, 'setDidApplyFilters');
     });
 
     it('calls props.clearFilter with schema categoryId', () => {
@@ -129,7 +123,6 @@ describe('SearchFilter', () => {
           value: undefined,
         },
       ]);
-      expect(setDidApplyFiltersSpy).toHaveBeenCalledWith(false);
     });
   });
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.tsx
@@ -30,10 +30,6 @@ export interface CheckboxFilterSection extends FilterSectionItem {
   options: CheckboxFilterProperties[];
 }
 
-interface OwnProps {
-  setDidApplyFilters: (didApply: boolean) => void;
-}
-
 export interface StateFromProps {
   filterSections: FilterSectionItem[];
 }
@@ -42,7 +38,7 @@ interface DispatchFromProps {
   updateFilter: (searchFilters: SearchFilterInput[]) => UpdateFilterRequest;
 }
 
-export type SearchFilterProps = StateFromProps & DispatchFromProps & OwnProps;
+export type SearchFilterProps = StateFromProps & DispatchFromProps;
 
 export class SearchFilter extends React.Component<SearchFilterProps> {
   onApplyChanges = (event: React.FormEvent<HTMLFormElement>) => {
@@ -53,7 +49,7 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
     ) as HTMLFormElement;
     const formData = new FormData(form);
 
-    const { filterSections, updateFilter, setDidApplyFilters } = this.props;
+    const { filterSections, updateFilter } = this.props;
     const filters = filterSections
       .filter(
         (section) =>
@@ -65,24 +61,21 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
         value: formData.get(section.categoryId) as string,
       }));
     updateFilter(filters);
-    setDidApplyFilters(true);
   };
 
   onClearFilter = () => {
-    const { filterSections, updateFilter, setDidApplyFilters } = this.props;
+    const { filterSections, updateFilter } = this.props;
     const filters = filterSections.map((section) => ({
       categoryId: section.categoryId,
       value: undefined,
     }));
     updateFilter(filters);
-    setDidApplyFilters(false);
   };
 
   createFilterSection = (
     key: string,
     section: FilterSectionItem | CheckboxFilterSection
   ) => {
-    const { setDidApplyFilters } = this.props;
     const { categoryId, helpText, title, type } = section;
     const options = (section as CheckboxFilterSection).options
       ? (section as CheckboxFilterSection).options
@@ -95,7 +88,6 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
         title={title}
         type={type}
         options={options}
-        setDidApplyFilters={setDidApplyFilters}
       />
     );
   };
@@ -177,7 +169,7 @@ export const mapDispatchToProps = (dispatch: any) =>
     dispatch
   );
 
-export default connect<StateFromProps, DispatchFromProps, OwnProps>(
+export default connect<StateFromProps, DispatchFromProps>(
   mapStateToProps,
   mapDispatchToProps
 )(SearchFilter);

--- a/frontend/amundsen_application/static/js/pages/SearchPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/index.spec.tsx
@@ -52,6 +52,7 @@ const setup = (
     features: globalState.search.features,
     tables: globalState.search.tables,
     users: globalState.search.users,
+    didSearch: false,
     setPageIndex: jest.fn(),
     urlDidUpdate: jest.fn(),
     ...routerProps,
@@ -159,10 +160,13 @@ describe('SearchPage', () => {
       });
     });
 
-    describe('if there are filters that have not been applied yet', () => {
+    describe('if there are filters but no search action taken', () => {
       it('renders default search page message', () => {
-        const { wrapper } = setup({ searchTerm: '', hasFilters: true });
-        wrapper.setState({ didApplyFilters: false });
+        const { wrapper } = setup({
+          searchTerm: '',
+          hasFilters: true,
+          didSearch: false,
+        });
         content = shallow(
           wrapper.instance().getTabContent(
             {
@@ -195,9 +199,12 @@ describe('SearchPage', () => {
         expect(content.children().at(0).text()).toEqual(message);
       });
 
-      it('if no searchTerm but there are filters active that have been applied', () => {
-        const { wrapper } = setup({ searchTerm: '', hasFilters: true });
-        wrapper.setState({ didApplyFilters: true });
+      it('if no searchTerm but there are filters and a search action has been taken', () => {
+        const { wrapper } = setup({
+          searchTerm: '',
+          hasFilters: true,
+          didSearch: true,
+        });
         content = shallow(
           wrapper.instance().getTabContent(testResults, ResourceType.table)
         );

--- a/frontend/amundsen_application/static/js/pages/SearchPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/index.tsx
@@ -119,11 +119,10 @@ export class SearchPage extends React.Component<SearchPageProps> {
     const startIndex = RESULTS_PER_PAGE * page_index + 1;
     const tabLabel = this.generateTabLabel(tab);
 
-    // No search input and search action has not been taken
-    if (
+    const hasNoSearchInputOrAction =
       searchTerm.length === 0 &&
-      (!hasFilters || (!didSearch && total_results === 0))
-    ) {
+      (!hasFilters || (!didSearch && total_results === 0));
+    if (hasNoSearchInputOrAction) {
       return (
         <div className="search-list-container">
           <div className="search-error body-placeholder">
@@ -133,8 +132,9 @@ export class SearchPage extends React.Component<SearchPageProps> {
       );
     }
 
-    // Check no results
-    if (total_results === 0 && (searchTerm.length > 0 || hasFilters)) {
+    const hasNoResults =
+      total_results === 0 && (searchTerm.length > 0 || hasFilters);
+    if (hasNoResults) {
       return (
         <div className="search-list-container">
           <div className="search-error body-placeholder">
@@ -146,8 +146,8 @@ export class SearchPage extends React.Component<SearchPageProps> {
       );
     }
 
-    // Check page_index bounds
-    if (page_index < 0 || startIndex > total_results) {
+    const hasIndexOutOfBounds = page_index < 0 || startIndex > total_results;
+    if (hasIndexOutOfBounds) {
       return (
         <div className="search-list-container">
           <div className="search-error body-placeholder">

--- a/frontend/amundsen_application/static/js/pages/SearchPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/index.tsx
@@ -55,6 +55,7 @@ export interface StateFromProps {
   dashboards: DashboardSearchResults;
   features: FeatureSearchResults;
   users: UserSearchResults;
+  didSearch: boolean;
 }
 
 export interface DispatchFromProps {
@@ -66,23 +67,8 @@ export type SearchPageProps = StateFromProps &
   DispatchFromProps &
   RouteComponentProps<any>;
 
-export interface SearchPageState {
-  didApplyFilters: boolean;
-}
-
-export class SearchPage extends React.Component<
-  SearchPageProps,
-  SearchPageState
-> {
+export class SearchPage extends React.Component<SearchPageProps> {
   public static defaultProps: Partial<SearchPageProps> = {};
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      didApplyFilters: false,
-    };
-  }
 
   componentDidMount() {
     const { location, urlDidUpdate: updateUrl } = this.props;
@@ -95,10 +81,6 @@ export class SearchPage extends React.Component<
       updateUrl(location.search);
     }
   }
-
-  setDidApplyFilters = (didApply: boolean) => {
-    this.setState({ didApplyFilters: didApply });
-  };
 
   renderSearchResults = () => {
     const { resource, tables, users, dashboards, features } = this.props;
@@ -132,14 +114,16 @@ export class SearchPage extends React.Component<
   };
 
   getTabContent = (results: SearchResults<Resource>, tab: ResourceType) => {
-    const { didApplyFilters } = this.state;
-    const { hasFilters, searchTerm, setPageIndex } = this.props;
+    const { hasFilters, searchTerm, setPageIndex, didSearch } = this.props;
     const { page_index, total_results } = results;
     const startIndex = RESULTS_PER_PAGE * page_index + 1;
     const tabLabel = this.generateTabLabel(tab);
 
-    // No search input
-    if (searchTerm.length === 0 && (!hasFilters || !didApplyFilters)) {
+    // No search input and search action has not been taken
+    if (
+      searchTerm.length === 0 &&
+      (!hasFilters || (!didSearch && total_results === 0))
+    ) {
       return (
         <div className="search-list-container">
           <div className="search-error body-placeholder">
@@ -207,7 +191,7 @@ export class SearchPage extends React.Component<
       <div className="search-page">
         <SearchPanel>
           <ResourceSelector />
-          <SearchFilter setDidApplyFilters={this.setDidApplyFilters} />
+          <SearchFilter />
         </SearchPanel>
         <main className="search-results">
           <h1 className="sr-only">{SEARCHPAGE_TITLE}</h1>
@@ -237,6 +221,7 @@ export const mapStateToProps = (state: GlobalState) => {
     users: state.search.users,
     dashboards: state.search.dashboards,
     features: state.search.features,
+    didSearch: state.search.didSearch,
   };
 };
 


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Fixes related to recent changes to search filtering here: https://github.com/amundsen-io/amundsen/pull/1605
- The original change checked whether the `Apply filters` button had been clicked to know if a search had occurred to provide the correct messaging to the user on the page. This didn't account for searches done from other locations, such as clicking on a tag on the home page, and this resulted in an unintended effect where the results were retrieved but not displayed. This update instead sets a boolean state value in the reducer that will tell if a search action has been taken, compared to an update to the global state without a search action (such as updating the filters).
- When the filters global state was updated on any input field changes, the original change was unintentionally updating the global state object reference, causing the filters to not be reset when they should have been. This change properly copies the existing state to a new object and appends the updated filter.

### Tests

Small changes to existing tests to account for the changes noted in the summary above.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
