### PR TITLE
fix: Added support in helm chart for air-gapped deployment

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -106,6 +106,7 @@ Note we updated from elasticsearch 6 to elasticsearch 7
 | neo4j.resources | object | `{}` | See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) |
 | neo4j.serviceType | string | `"ClusterIP"` | The neo4j service type. See service types [ref](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | neo4j.tolerations | list | `[]` | neo4j specific tolerations. |
+| neo4j.version | string | `"3.3.0"` | **DEPRECATED - Now using the neo4j.imageTag** The neo4j application version used by amundsen. |
 | nodeSelector | object | `{}` | amundsen application wide configuration of nodeSelector. This applies to search, metadata, frontend and neo4j. Elasticsearch has it's own configuation properties for this. [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) |
 | oidc.configs.FLASK_OIDC_CONFIG_URL | string | `"https://accounts.google.com/.well-known/openid-configuration"` |  |
 | oidc.configs.FLASK_OIDC_PROVIDER_NAME | string | `"google"` |  |

--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -95,13 +95,17 @@ Note we updated from elasticsearch 6 to elasticsearch 7
 | neo4j.config.dbms.heap_max_size | string | `"2G"` | the max java heap for neo4j |
 | neo4j.config.dbms.pagecache_size | string | `"2G"` | the page cache size for neo4j |
 | neo4j.enabled | bool | `true` | If neo4j is enabled as part of this chart, or not. Set this to false if you want to provide your own version. |
+| neo4j.image | string | `"neo4j"` | The image of the neo4j container. |
+| neo4j.imageTag | string | `"3.3.0"` | The image tag of the neo4j container. |
+| neo4j.initPluginsContainer.image | string | `"appropriate/curl"` | The image of the init neo4j plugins container. |
+| neo4j.initPluginsContainer.imageTag | string | `"latest"` | The image tag of the init neo4j plugins container. |
+| neo4j.initPluginsContainer.command | list | _See values.yaml_ | The command to execute in the init neo4j plugins container. |
 | neo4j.nodeSelector | object | `{}` | neo4j specific nodeSelector. |
 | neo4j.persistence | object | `{}` | Neo4j persistence. Turn this on to keep your data between pod crashes, etc. This is also needed for backups. |
 | neo4j.podAnnotations | object | `{}` | neo4j pod specific annotations. |
 | neo4j.resources | object | `{}` | See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) |
 | neo4j.serviceType | string | `"ClusterIP"` | The neo4j service type. See service types [ref](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | neo4j.tolerations | list | `[]` | neo4j specific tolerations. |
-| neo4j.version | string | `"3.3.0"` | The neo4j application version used by amundsen. |
 | nodeSelector | object | `{}` | amundsen application wide configuration of nodeSelector. This applies to search, metadata, frontend and neo4j. Elasticsearch has it's own configuation properties for this. [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) |
 | oidc.configs.FLASK_OIDC_CONFIG_URL | string | `"https://accounts.google.com/.well-known/openid-configuration"` |  |
 | oidc.configs.FLASK_OIDC_PROVIDER_NAME | string | `"google"` |  |

--- a/amundsen-kube-helm/templates/helm/templates/deployment-neo4j.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/deployment-neo4j.yaml
@@ -41,27 +41,16 @@ spec:
       {{- end }}
       initContainers:
         - name: init-neo4j-plugins
-          image: "appropriate/curl:latest"
+          image: {{ .Values.neo4j.initPluginsContainer.image }}:{{ .Values.neo4j.initPluginsContainer.imageTag }}
           imagePullPolicy: "IfNotPresent"
           command:
-            - "/bin/sh"
-            - "-c"
-            - |
-              curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.3.0.4/apoc-3.3.0.4-all.jar -O
-              curl -L https://github.com/neo4j-contrib/neo4j-graph-algorithms/releases/download/3.3.5.0/graph-algorithms-algo-3.3.5.0.jar -O
-              curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.250/aws-java-sdk-core-1.11.250.jar -O
-              curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.250/aws-java-sdk-s3-1.11.250.jar -O
-              curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.4/httpclient-4.5.4.jar -O
-              curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.8/httpcore-4.4.8.jar -O
-              curl -L https://repo1.maven.org/maven2/joda-time/joda-time/2.9.9/joda-time-2.9.9.jar -O
-              chmod 755 *.jar
-              mv *.jar /var/lib/neo4j/plugins
+            {{- .Values.neo4j.initPluginsContainer.command | toYaml | nindent 12 }}
           volumeMounts:
             - name: plugins
               mountPath: /var/lib/neo4j/plugins
       containers:
       - name: neo4j
-        image: neo4j:{{ .Values.neo4j.version }}
+        image: {{ .Values.neo4j.image }}:{{ .Values.neo4j.imageTag }}
         ports:
         - containerPort: 7474
         - containerPort: 7687

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -280,8 +280,34 @@ neo4j:
   # neo4j.enabled -- If neo4j is enabled as part of this chart, or not. Set this to false if you want to provide your own version.
   enabled: true
 
-  # neo4j.version -- The neo4j application version used by amundsen.
-  version: 3.3.0
+  # neo4j.image -- The image of the neo4j container.
+  image: neo4j
+
+  # neo4j.imageTag -- The image tag of the neo4j container.
+  imageTag: 3.3.0
+
+  # neo4j.initPluginsContainer -- The image used to install plugins used by neo4j.
+  initPluginsContainer:
+
+    # neo4j.initContainer.image -- The image of the neo4j init container.
+    image: appropriate/curl
+
+    # neo4j.initContainer.imageTag -- The image tag of the neo4j init container.
+    imageTag: latest
+
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.3.0.4/apoc-3.3.0.4-all.jar -O
+        curl -L https://github.com/neo4j-contrib/neo4j-graph-algorithms/releases/download/3.3.5.0/graph-algorithms-algo-3.3.5.0.jar -O
+        curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.250/aws-java-sdk-core-1.11.250.jar -O
+        curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.250/aws-java-sdk-s3-1.11.250.jar -O
+        curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.4/httpclient-4.5.4.jar -O
+        curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.8/httpcore-4.4.8.jar -O
+        curl -L https://repo1.maven.org/maven2/joda-time/joda-time/2.9.9/joda-time-2.9.9.jar -O
+        chmod 755 *.jar
+        mv *.jar /var/lib/neo4j/plugins
 
   # neo4j.resources -- See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
   resources: {}


### PR DESCRIPTION
### Summary of Changes

The current helm chart does not support air-gapped deployment when the k8s cluster being deployed on has no Internet connectivity.  Most of the components support specifying which image registry to use, but the `neo4j` deployment did not.  Not only it didn't support customizing the docker registry, but the initialization of plugins was hard-coded.

This PR adds support to customize the neo4j docker image registry.  It also provides a way to change how the neo4j plugins are injected (or initialized) in the neo4j container.  

### Tests

### Documentation

By default, the same commands will be executed in the neo4j init container:
```
        - "/bin/sh"
        - "-c"
        - |
          curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.3.0.4/apoc-3.3.0.4-all.jar -O
          curl -L https://github.com/neo4j-contrib/neo4j-graph-algorithms/releases/download/3.3.5.0/graph-algorithms-algo-3.3.5.0.jar -O
          curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.250/aws-java-sdk-core-1.11.250.jar -O
          curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.250/aws-java-sdk-s3-1.11.250.jar -O
          curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.4/httpclient-4.5.4.jar -O
          curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.8/httpcore-4.4.8.jar -O
          curl -L https://repo1.maven.org/maven2/joda-time/joda-time/2.9.9/joda-time-2.9.9.jar -O
          chmod 755 *.jar
          mv *.jar /var/lib/neo4j/plugins
```

But with this PR, you could change this to leverage another container that already contains the jar archives:
```
    initPluginsContainer:
      image: my.private.registry.com/amundsen-neo4j-plugins
      imageTag: 3.3.0
      command:
        - "/bin/sh"
        - "-c"
        - |
          cp *.jar /var/lib/neo4j/plugins
```
where `my.private.registry.com/amundsen-neo4j-plugins:3.3.0` was built using the following Dockerfile:
```
FROM appropriate/curl:latest
WORKDIR /app/neo4j_plugins

RUN curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.3.0.4/apoc-3.3.0.4-all.jar -O && \
    curl -L https://github.com/neo4j-contrib/neo4j-graph-algorithms/releases/download/3.3.5.0/graph-algorithms-algo-3.3.5.0.jar -O && \
    curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.250/aws-java-sdk-core-1.11.250.jar -O && \
    curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.250/aws-java-sdk-s3-1.11.250.jar -O && \
    curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.4/httpclient-4.5.4.jar -O && \
    curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.8/httpcore-4.4.8.jar -O && \
    curl -L https://repo1.maven.org/maven2/joda-time/joda-time/2.9.9/joda-time-2.9.9.jar -O && \
    chmod 755 *.jar
```

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
