### PR TITLE
chore: bumped search to 3.0.0

### DIFF
--- a/search/search_service/config.py
+++ b/search/search_service/config.py
@@ -47,7 +47,7 @@ class LocalConfig(Config):
                                         LOCAL_HOST=LOCAL_HOST,
                                         PORT=PROXY_PORT)
                                     )
-    PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'ELASTICSEARCH')]
+    PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'ELASTICSEARCH_V2')]
     PROXY_CLIENT_KEY = os.environ.get('PROXY_CLIENT_KEY')   # type: Optional[Any]
     PROXY_USER = os.environ.get('CREDENTIALS_PROXY_USER', 'elastic')
     PROXY_PASSWORD = os.environ.get('CREDENTIALS_PROXY_PASSWORD', 'elastic')

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '2.11.1'
+__version__ = '3.0.0'
 
 oidc = ['flaskoidc>=1.0.0']
 


### PR DESCRIPTION
This PR bumps the version for amundsen-search to 3.0.0 because new search changes are bw in compatible. 
When bumping make sure to use the following client in config:
`'ELASTICSEARCH_V2': 'search_service.proxy.es_search_proxy.ElasticsearchProxy'`
Major FE release version 4.0.0 is comaptible with the new search service