### PR TITLE
feat: Updating input placeholder text and hint text for search filters

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -451,9 +451,9 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:3603164347": [
-      [342, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
-      [343, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
+    "js/config/config-default.ts:1383031008": [
+      [354, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
+      [355, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
       [3, 0, 148, "\`.\` import should occur after import of \`./types\`", "4154971894"]
@@ -726,16 +726,16 @@ exports[`eslint`] = {
       [101, 15, 16, "Must use destructuring props assignment", "1927755215"],
       [109, 15, 19, "Must use destructuring props assignment", "4761610"]
     ],
-    "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:2051916132": [
-      [20, 75, -647, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:2252654402": [
+      [26, 2, -669, "Expected to return a value at the end of arrow function.", "5381"]
     ],
-    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:2601908148": [
-      [63, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:1821414929": [
+      [70, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/pages/SearchPage/SearchPanel/tests/index.spec.tsx:3928473928": [
       [25, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/SearchPage/constants.ts:2540603999": [
+    "js/pages/SearchPage/constants.ts:648153442": [
       [14, 2, 112, "Multiline support is limited to browsers supporting ES5 only.", "2645164555"]
     ],
     "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1422860355": [

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -729,7 +729,7 @@ exports[`eslint`] = {
     "js/pages/SearchPage/SearchFilter/FilterSection/index.tsx:2252654402": [
       [26, 2, -669, "Expected to return a value at the end of arrow function.", "5381"]
     ],
-    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:1821414929": [
+    "js/pages/SearchPage/SearchFilter/InputFilter/index.tsx:2399701553": [
       [70, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/pages/SearchPage/SearchPanel/tests/index.spec.tsx:3928473928": [

--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -93,25 +93,29 @@ const configDefault: AppConfig = {
         {
           categoryId: 'product',
           displayName: 'Product',
-          helpText: 'Enter exact product name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact product names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'group_name',
           displayName: 'Group',
-          helpText: 'Enter exact group name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact group names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'name',
           displayName: 'Name',
-          helpText: 'Enter exact dashboard name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact dashboard names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'tag',
           displayName: 'Tag',
-          helpText: 'Enter exact tag name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact tag names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
       ],
@@ -210,31 +214,36 @@ const configDefault: AppConfig = {
         {
           categoryId: 'database',
           displayName: 'Source',
-          helpText: 'Enter exact database name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact database names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'column',
           displayName: 'Column',
-          helpText: 'Enter exact column name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact column names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'schema',
           displayName: 'Schema',
-          helpText: 'Enter exact schema name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact schema names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'table',
           displayName: 'Table',
-          helpText: 'Enter exact table name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact table names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'tag',
           displayName: 'Tag',
-          helpText: 'Enter exact tag name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact tag names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
       ],
@@ -274,26 +283,29 @@ const configDefault: AppConfig = {
         {
           categoryId: 'entity',
           displayName: 'Entity',
-          helpText: 'Enter exact entity name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact entity names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'name',
           displayName: 'Feature Name',
-          helpText: 'Enter exact feature name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact feature names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'group',
           displayName: 'Feature Group',
           helpText:
-            'Enter exact feature group name or a regex wildcard pattern',
+            'Enter one or more comma separated values with exact feature group names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
         {
           categoryId: 'tag',
           displayName: 'Tag',
-          helpText: 'Enter exact tag name or a regex wildcard pattern',
+          helpText:
+            'Enter one or more comma separated values with exact tag names or regex wildcard patterns',
           type: FilterType.INPUT_SELECT,
         },
       ],

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.spec.tsx
@@ -74,15 +74,27 @@ describe('FilterSection', () => {
       expect(wrapper.find('.title-2').text()).toEqual(props.title);
     });
 
-    it('renders InfoButton with correct props if props.helpText exists', () => {
+    it('renders InfoButton with correct props if props.helpText exists and it is a checkbox filter type', () => {
       const mockHelpText = 'Help me';
       const { wrapper: wrapperWithHelpText } = setup({
+        type: FilterType.CHECKBOX_SELECT,
         helpText: mockHelpText,
       });
       const infoButton = wrapperWithHelpText.find(InfoButton);
 
-      expect(infoButton.exists()).toBe(true);
+      expect(infoButton.exists()).toBeTruthy();
       expect(infoButton.props().infoText).toBe(mockHelpText);
+    });
+
+    it('does not render InfoButton if props.helpText exists and it is an input filter type', () => {
+      const mockHelpText = 'Help me';
+      const { wrapper: wrapperWithHelpText } = setup({
+        type: FilterType.INPUT_SELECT,
+        helpText: mockHelpText,
+      });
+      const infoButton = wrapperWithHelpText.find(InfoButton);
+
+      expect(infoButton.exists()).toBeFalsy();
     });
   });
 });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/FilterSection/index.tsx
@@ -18,11 +18,18 @@ export interface FilterSectionProps {
   options?: CheckboxFilterProperties[];
 }
 
-const getFilterComponent = (categoryId, allowableOperation, options, type) => {
+const getFilterComponent = (
+  categoryId,
+  helpText,
+  allowableOperation,
+  options,
+  type
+) => {
   if (type === FilterType.INPUT_SELECT) {
     return (
       <InputFilter
         categoryId={categoryId}
+        helpText={helpText}
         allowableOperation={allowableOperation}
       />
     );
@@ -54,7 +61,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
         >
           {title}
         </label>
-        {helpText && (
+        {helpText && type === FilterType.CHECKBOX_SELECT && (
           <InfoButton
             infoText={helpText}
             placement="top"
@@ -63,7 +70,13 @@ const FilterSection: React.FC<FilterSectionProps> = ({
         )}
       </div>
     </div>
-    {getFilterComponent(categoryId, allowableOperation, options, type)}
+    {getFilterComponent(
+      categoryId,
+      helpText,
+      allowableOperation,
+      options,
+      type
+    )}
   </div>
 );
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.spec.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import SanitizedHTML from 'react-sanitized-html';
 import { shallow } from 'enzyme';
 
 import { GlobalState } from 'ducks/rootReducer';
@@ -248,7 +250,7 @@ describe('InputFilter', () => {
       wrapper.instance().render();
     });
 
-    it('renders and input text with correct properties', () => {
+    it('renders an input text field with correct properties', () => {
       element = wrapper.find('input');
       expect(element.props().name).toBe(props.categoryId);
       expect(element.props().onChange).toBe(wrapper.instance().onInputChange);
@@ -263,6 +265,26 @@ describe('InputFilter', () => {
     it('renders a filter operation selector', () => {
       wrapper.instance().setState({ showFilterOperationToggle: true });
       expect(wrapper.find(FilterOperationSelector).exists()).toBeTruthy();
+    });
+
+    it('does not render an OverlayTrigger', () => {
+      element = wrapper.find(OverlayTrigger);
+      expect(element.exists()).toBeFalsy();
+    });
+
+    it('renders an OverlayTrigger with correct popover', () => {
+      const mockHelpText = 'Help';
+      const expectedPopover = (
+        <Popover id="schema-help-text-popover">
+          <SanitizedHTML html={mockHelpText} />
+        </Popover>
+      );
+
+      ({ wrapper } = setup({ helpText: mockHelpText }));
+      element = wrapper.find(OverlayTrigger);
+
+      expect(element.exists()).toBeTruthy();
+      expect(element.props().overlay).toEqual(expectedPopover);
     });
   });
 

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
@@ -156,7 +156,7 @@ export class InputFilter extends React.Component<
   renderInputField = () => {
     const { value } = this.state;
     const { categoryId } = this.props;
-    const inputAriaLabel = categoryId + 'FilterInput';
+    const inputAriaLabel = categoryId + ' filter input';
     return (
       <input
         type="text"
@@ -193,7 +193,7 @@ export class InputFilter extends React.Component<
     );
 
     return (
-      <div>
+      <>
         {inputField}
         {showFilterOperationToggle && (
           <FilterOperationSelector
@@ -203,7 +203,7 @@ export class InputFilter extends React.Component<
             categoryId={categoryId}
           />
         )}
-      </div>
+      </>
     );
   };
 }

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/InputFilter/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import SanitizedHTML from 'react-sanitized-html';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
@@ -12,10 +14,15 @@ import { ResourceType } from 'interfaces/Resources';
 import { UpdateSearchStateRequest } from 'ducks/search/types';
 import { FilterReducerState } from 'ducks/search/filters/reducer';
 import FilterOperationSelector from '../FilterOperationSelector';
+import {
+  INPUT_FILTER_PLACEHOLDER_MESSAGE,
+  DELAY_SHOW_POPOVER_MS,
+} from '../../constants';
 import '../styles.scss';
 
 interface OwnProps {
   categoryId: string;
+  helpText?: string;
   allowableOperation?: FilterOperationType;
 }
 
@@ -146,21 +153,48 @@ export class InputFilter extends React.Component<
     updateFilterState(newFilters);
   };
 
-  render = () => {
-    const { value, filterOperation, showFilterOperationToggle } = this.state;
-    const { categoryId, allowableOperation } = this.props;
+  renderInputField = () => {
+    const { value } = this.state;
+    const { categoryId } = this.props;
     const inputAriaLabel = categoryId + 'FilterInput';
     return (
+      <input
+        type="text"
+        className="form-control"
+        name={categoryId}
+        id={categoryId}
+        onChange={this.onInputChange}
+        value={value}
+        placeholder={INPUT_FILTER_PLACEHOLDER_MESSAGE}
+        aria-label={inputAriaLabel}
+      />
+    );
+  };
+
+  render = () => {
+    const { filterOperation, showFilterOperationToggle } = this.state;
+    const { categoryId, helpText, allowableOperation } = this.props;
+
+    const inputField = helpText ? (
+      <OverlayTrigger
+        trigger={['hover', 'focus']}
+        placement="top"
+        delayShow={DELAY_SHOW_POPOVER_MS}
+        overlay={
+          <Popover id={categoryId + '-help-text-popover'}>
+            <SanitizedHTML html={helpText} />
+          </Popover>
+        }
+      >
+        {this.renderInputField()}
+      </OverlayTrigger>
+    ) : (
+      this.renderInputField()
+    );
+
+    return (
       <div>
-        <input
-          type="text"
-          className="form-control"
-          name={categoryId}
-          id={categoryId}
-          onChange={this.onInputChange}
-          value={value}
-          aria-label={inputAriaLabel}
-        />
+        {inputField}
         {showFilterOperationToggle && (
           <FilterOperationSelector
             filterOperation={filterOperation}

--- a/frontend/amundsen_application/static/js/pages/SearchPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/constants.ts
@@ -30,3 +30,6 @@ export const USER_RESOURCE_TITLE = getDisplayNameByResource(ResourceType.user);
 export const FEATURE_RESOURCE_TITLE = getDisplayNameByResource(
   ResourceType.feature
 );
+
+export const INPUT_FILTER_PLACEHOLDER_MESSAGE = 'Exact name or *wild card*';
+export const DELAY_SHOW_POPOVER_MS = 300;

--- a/frontend/amundsen_application/static/js/pages/SearchPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/index.tsx
@@ -121,7 +121,8 @@ export class SearchPage extends React.Component<SearchPageProps> {
 
     const hasNoSearchInputOrAction =
       searchTerm.length === 0 &&
-      (!hasFilters || (!didSearch && total_results === 0));
+      (!hasFilters || !didSearch) &&
+      total_results === 0;
     if (hasNoSearchInputOrAction) {
       return (
         <div className="search-list-container">


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This change introduces a few minor adjustments to the way that hint text is displayed for the search filters.
1. Placeholder text is now included on the input filters that reads `Exact name or *wild card*` to make it more immediately clear what the field accepts.
2. The hint text will pop up over the input field itself rather than a separate info icon to ensure users are noticing the hint information provided.
3. Now that the input search filters accept multiple values, include info about that in the hint text. This is included in the default values and will require a change on the side of others if they have custom filters.

<img width="291" alt="Screen Shot 2021-12-23 at 12 32 25 PM" src="https://user-images.githubusercontent.com/6732445/147289311-032aecee-49b7-4d71-aa96-e7d333974d76.png">

### Tests

Added to the `InputFilter` tests to test the new popover on the input text fields.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
