### PR TITLE
fix: use strtobool to help csv_extractor handle bool fields

### DIFF
--- a/databuilder/databuilder/extractor/csv_extractor.py
+++ b/databuilder/databuilder/extractor/csv_extractor.py
@@ -4,6 +4,7 @@
 import csv
 import importlib
 from collections import defaultdict
+from distutils.util import strtobool
 from typing import Any, List
 
 from pyhocon import ConfigTree
@@ -234,9 +235,7 @@ class CsvTableColumnExtractor(Extractor):
                                   name=table_dict['name'],
                                   description=table_dict['description'],
                                   columns=columns,
-                                  # TODO: this possibly should parse stringified booleans;
-                                  # right now it only will be false for empty strings
-                                  is_view=bool(table_dict['is_view']),
+                                  is_view=bool(strtobool(table_dict['is_view'])),
                                   tags=table_dict['tags']
                                   )
             results.append(table)

--- a/databuilder/databuilder/models/application.py
+++ b/databuilder/databuilder/models/application.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from distutils.util import strtobool
 from typing import (
     Iterator, Optional, Union,
 )
@@ -67,7 +68,7 @@ class GenericApplication(GraphSerializable, TableSerializable, AtlasSerializable
             application_type=self.application_type,
             application_id=self.application_id,
         )
-        self.generates_resource = generates_resource
+        self.generates_resource = bool(strtobool(generates_resource))
 
         self._node_iter = self._create_node_iterator()
         self._relation_iter = self._create_relation_iterator()

--- a/databuilder/databuilder/models/dashboard/dashboard_usage.py
+++ b/databuilder/databuilder/models/dashboard/dashboard_usage.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from distutils.util import strtobool
 from typing import (
     Any, Optional, Union,
 )
@@ -41,7 +42,7 @@ class DashboardUsage(Usage):
         :param cluster:
         :param kwargs:
         """
-        self._should_create_user_node = bool(should_create_user_node)
+        self._should_create_user_node = bool(strtobool(should_create_user_node))
         Usage.__init__(
             self,
             start_label=DashboardMetadata.DASHBOARD_NODE_LABEL,

--- a/databuilder/databuilder/models/query/query.py
+++ b/databuilder/databuilder/models/query/query.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+from distutils.util import strtobool
 from typing import (
     Iterator, List, Optional,
 )
@@ -67,7 +68,7 @@ class QueryMetadata(QueryBase):
         self.tables = tables
         self.table_keys = [tm._get_table_key() for tm in tables]
         self.user = user
-        self.yield_relation_nodes = yield_relation_nodes
+        self.yield_relation_nodes = bool(strtobool(yield_relation_nodes))
         self._sql_begin = sql[:25] + '...'
         self._node_iter = self._create_next_node()
         self._relation_iter = self._create_relation_iterator()

--- a/databuilder/databuilder/models/query/query_execution.py
+++ b/databuilder/databuilder/models/query/query_execution.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from distutils.util import strtobool
 from typing import (
     Iterator, Optional, Union,
 )
@@ -64,7 +65,7 @@ class QueryExecutionsMetadata(GraphSerializable):
         self.start_time = start_time
         self.execution_count = execution_count
         self.window_duration = window_duration
-        self.yield_relation_nodes = yield_relation_nodes
+        self.yield_relation_nodes = bool(strtobool(yield_relation_nodes))
         self._node_iter = self._create_next_node()
         self._relation_iter = self._create_relation_iterator()
 

--- a/databuilder/databuilder/models/query/query_join.py
+++ b/databuilder/databuilder/models/query/query_join.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from distutils.util import strtobool
 from typing import Iterator, Optional
 
 from databuilder.models.graph_node import GraphNode
@@ -83,7 +84,7 @@ class QueryJoinMetadata(GraphSerializable):
         self.join_operator = join_operator
         self.join_sql = join_sql
         self.query_metadata = query_metadata
-        self.yield_relation_nodes = yield_relation_nodes
+        self.yield_relation_nodes = bool(strtobool(yield_relation_nodes))
         self._node_iter = self._create_next_node()
         self._relation_iter = self._create_relation_iterator()
 

--- a/databuilder/databuilder/models/query/query_where.py
+++ b/databuilder/databuilder/models/query/query_where.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+from distutils.util import strtobool
 from typing import (
     Iterator, List, Optional,
 )
@@ -64,7 +65,7 @@ class QueryWhereMetadata(QueryBase):
         self.left_arg = left_arg
         self.right_arg = right_arg
         self.operator = operator
-        self.yield_relation_nodes = yield_relation_nodes
+        self.yield_relation_nodes = bool(strtobool(yield_relation_nodes))
         self._table_hash = self._get_table_hash(self.tables)
         self._where_hash = self._get_where_hash(self.where_clause)
         self._node_iter = self._create_next_node()

--- a/databuilder/databuilder/models/table_metadata.py
+++ b/databuilder/databuilder/models/table_metadata.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+from distutils.util import strtobool
 from typing import (
     Any, Dict, Iterable, Iterator, List, Optional, Set, Union,
 )
@@ -417,7 +418,7 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
         self.name = name
         self.description = DescriptionMetadata.create_description_metadata(text=description, source=description_source)
         self.columns = columns if columns else []
-        self.is_view = is_view
+        self.is_view = bool(strtobool(is_view))
         self.attrs: Optional[Dict[str, Any]] = None
 
         self.tags = _format_as_list(tags)

--- a/databuilder/databuilder/models/table_stats.py
+++ b/databuilder/databuilder/models/table_stats.py
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
+from distutils.util import strtobool
 from typing import (
     Iterator, Optional, Union,
 )
@@ -50,7 +51,7 @@ class TableStats(GraphSerializable, TableSerializable):
         self.stat_val = str(stat_val)
         # metrics are about the table, stats are about the data in a table
         # ex: table usage is a metric
-        self.is_metric = is_metric
+        self.is_metric = bool(strtobool(is_metric))
         self._node_iter = self._create_node_iterator()
         self._relation_iter = self._create_relation_iterator()
         self._record_iter = self._create_record_iterator()

--- a/databuilder/databuilder/models/user.py
+++ b/databuilder/databuilder/models/user.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+from distutils.util import strtobool
 from typing import (
     Any, Iterator, Optional, Union,
 )
@@ -94,11 +95,11 @@ class User(GraphSerializable, TableSerializable, AtlasSerializable):
         self.employee_type = employee_type
         # this attr not available in team service, either update team service, update with FE
         self.slack_id = slack_id
-        self.is_active = is_active
+        self.is_active = bool(strtobool(is_active))
         self.profile_url = profile_url
         self.updated_at = updated_at
         self.role_name = role_name
-        self.do_not_update_empty_attribute = do_not_update_empty_attribute
+        self.do_not_update_empty_attribute = bool(strtobool(do_not_update_empty_attribute))
         self.attrs = None
         if kwargs:
             self.attrs = copy.deepcopy(kwargs)

--- a/databuilder/databuilder/models/user_elasticsearch_document.py
+++ b/databuilder/databuilder/models/user_elasticsearch_document.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from distutils.util import strtobool
+
 from databuilder.models.elasticsearch_document import ElasticsearchDocument
 
 
@@ -35,7 +37,7 @@ class UserESDocument(ElasticsearchDocument):
         self.manager_email = manager_email
         self.slack_id = slack_id
         self.role_name = role_name
-        self.is_active = is_active
+        self.is_active = bool(strtobool(is_active))
         self.total_read = total_read
         self.total_own = total_own
         self.total_follow = total_follow

--- a/databuilder/example/sample_data/sample_application.csv
+++ b/databuilder/example/sample_data/sample_application.csv
@@ -1,2 +1,3 @@
-task_id,dag_id,application_url_template,db_name,schema,table_name,cluster
-hive.test_schema.test_table1,event_test,"https://airflow_host.net/admin/airflow/tree?dag_id={dag_id}",hive,test_schema,test_table1,gold
+task_id,dag_id,application_url_template,db_name,schema,table_name,cluster,generates_table
+hive.test_schema.test_table1,event_test,"https://airflow_host.net/admin/airflow/tree?dag_id={dag_id}",hive,test_schema,test_table1,gold,false
+dynamo.test_schema.test_table2,event_test2,"https://airflow_host.net/admin/airflow/tree?dag_id={dag_id}",dynamo,test_schema,test_table2,gold,true


### PR DESCRIPTION
When introducing sample applications on CONSUMES relation,
it's found hard to add generates_table w/o introducing
separated extractor for it to handle it as bool correctly,
for example, the is_view under table_metadata cannot parse
False correctly, too.

I consider this makes sense and introduced no surprising
corner cases but only handle str like False, NO, no, false
as bool(False), although, it's an implicit implementation.

### Summary of Changes

- Added sample data for applications with awareness of boolean field: generates_resource
- Now boolean fields in `dataloader.models` can handle string typed data in a more expected fashion

### Tests

> I mark this approach as WIP if it's agreed to do so(after all it's an implicit approach).
> If the team are not against it, I will add some tests.

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does

Thank you all Amundsen team, I really appreciate it!