### PR TITLE
fix: update docker environment and image versions for ecs deployment

### DIFF
--- a/docs/installation-aws-ecs/docker-ecs-amundsen.yml
+++ b/docs/installation-aws-ecs/docker-ecs-amundsen.yml
@@ -25,7 +25,9 @@ services:
           awslogs-stream-prefix: amundsen-neo4j
 
   elasticsearch:
-      image: elasticsearch:6.7.0
+      image: elasticsearch:7.13.3
+      environment:
+          - discovery.type=single-node
       ports:
           - 9200:9200
       ulimits:
@@ -40,7 +42,7 @@ services:
           awslogs-stream-prefix: amundsen-elasticsearch
 
   amundsensearch:
-      image: amundsendev/amundsen-search:1.1.1
+      image: amundsendev/amundsen-search:2.11.1
       ports:
         - 5001:5000
       environment:
@@ -55,7 +57,7 @@ services:
           awslogs-stream-prefix: amundsensearch
 
   amundsenmetadata:
-      image: amundsendev/amundsen-metadata:1.0.7
+      image: amundsendev/amundsen-metadata:3.9.0
       ports:
         - 5002:5000
       environment:
@@ -70,12 +72,12 @@ services:
           awslogs-stream-prefix: amundsenmetadata
 
   amundsenfrontend:
-      image: amundsendev/amundsen-frontend:1.0.5
+      image: amundsendev/amundsen-frontend:3.12.0
       ports:
         - 5000:5000
       environment:
-        - SEARCHSERVICE_BASE=http://amundsensearch:5000
-        - METADATASERVICE_BASE=http://amundsenmetadata:5000
+        - SEARCHSERVICE_BASE=http://amundsensearch:5001
+        - METADATASERVICE_BASE=http://amundsenmetadata:5002
       links:
         - amundsensearch:amundsensearch
         - amundsenmetadata:amundsenmetadata


### PR DESCRIPTION
### Summary of Changes

- Point amundsenfrontend environment variables SEARCHSERVICE_BASE and METADATASERVICE_BASE to the correct ports. This resolves the recurring `HTTPConnectionPool(host='amundsenmetadata', port=5000)` exceptions reported in #257 #210.
- Update image versions to match https://github.com/amundsen-io/amundsen/blob/main/docker-amundsen.yml. The updated versions allow users to load data correctly into elasticsearch using the sample_data_loader referenced in the Quick Start Guide (https://www.amundsen.io/amundsen/installation/).

### Tests

N/A - this functionality is not currently tested 

### Documentation

N/A - consistent with existing documentation (https://github.com/amundsen-io/amundsen/blob/master/docs/installation-aws-ecs/aws-ecs-deployment.md)

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
