### PR TITLE
fix: bigquery preview with numeric data type - issue #1658

### DIFF
--- a/frontend/amundsen_application/base/base_bigquery_preview_client.py
+++ b/frontend/amundsen_application/base/base_bigquery_preview_client.py
@@ -14,6 +14,9 @@ from flask import Response, make_response, jsonify
 from marshmallow import ValidationError
 from google.cloud import bigquery
 
+import json
+import decimal
+
 
 class BaseBigqueryPreviewClient(BasePreviewClient):
     """
@@ -65,7 +68,7 @@ class BaseBigqueryPreviewClient(BasePreviewClient):
         try:
             data = PreviewDataSchema().dump(preview_data)
             PreviewDataSchema().load(data)  # for validation only
-            payload = jsonify({"preview_data": data})
+            payload = json.dumps({"preview_data": data}, cls=Encoder)
             return make_response(payload, HTTPStatus.OK)
         except ValidationError as err:
             logging.error("PreviewDataSchema serialization error + " + str(err.messages))
@@ -75,3 +78,13 @@ class BaseBigqueryPreviewClient(BasePreviewClient):
 
     def get_feature_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> Response:
         pass
+
+
+class Encoder(json.JSONEncoder):
+    """
+    Customized json encoder class to address the parsing of decimal/numeric data types into float.
+    """
+
+    def default(self, obj):
+        if isinstance(obj, decimal.Decimal):
+            return float(obj)

--- a/frontend/amundsen_application/base/base_bigquery_preview_client.py
+++ b/frontend/amundsen_application/base/base_bigquery_preview_client.py
@@ -3,7 +3,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Dict, List
+from typing import Any, Dict, List
 from amundsen_application.base.base_preview_client import BasePreviewClient
 from amundsen_application.models.preview_data import (
     ColumnItem,
@@ -85,6 +85,6 @@ class Encoder(json.JSONEncoder):
     Customized json encoder class to address the parsing of decimal/numeric data types into float.
     """
 
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         if isinstance(obj, decimal.Decimal):
             return float(obj)


### PR DESCRIPTION
Signed-off-by: Bruno Santos <bsilva89@hotmail.com>

### Summary of Changes

Fixed BaseBigqueryPreviewClient so it can work with numeric data types from BQ tables.

### Tests

No tests added due no new files or features.

### Documentation

N/A.

### Snapshot

![Screenshot from 2022-01-13 08-28-13](https://user-images.githubusercontent.com/42705595/149336235-9ea950b4-959e-4a7f-8017-d395946a5471.png)


### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
