### PR TITLE
feat: add partition column badge

### DIFF
--- a/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -18,9 +18,9 @@ from pyspark.sql.types import (
 from pyspark.sql.utils import AnalysisException, ParseException
 
 from databuilder.extractor.base_extractor import Extractor
+from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
 from databuilder.models.table_last_updated import TableLastUpdated
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
-from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
 
 TableKey = namedtuple('TableKey', ['schema', 'table_name'])
 
@@ -29,7 +29,8 @@ LOGGER = logging.getLogger(__name__)
 
 # TODO once column tags work properly, consider deprecating this for TableMetadata directly
 class ScrapedColumnMetadata(object):
-    def __init__(self, name: str, data_type: str, description: Optional[str], sort_order: int, badges: Union[List[str], None] = None):
+    def __init__(self, name: str, data_type: str, description: Optional[str], sort_order: int,
+                 badges: Union[List[str], None] = None):
         self.name = name
         self.data_type = data_type
         self.description = description
@@ -385,7 +386,7 @@ class DeltaLakeMetadataExtractor(Extractor):
                                    description=column.description,
                                    col_type=column.data_type,
                                    sort_order=column.sort_order,
-                                   badges = column.badges)
+                                   badges=column.badges)
                 )
         description = table.get_table_description()
         return TableMetadata(self._db,

--- a/databuilder/tests/unit/extractor/test_deltalake_extractor.py
+++ b/databuilder/tests/unit/extractor/test_deltalake_extractor.py
@@ -15,8 +15,8 @@ from databuilder import Scoped
 from databuilder.extractor.delta_lake_metadata_extractor import (
     DeltaLakeMetadataExtractor, ScrapedColumnMetadata, ScrapedTableMetadata,
 )
-from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
+from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
 
 
 class TestDeltaLakeExtractor(unittest.TestCase):

--- a/databuilder/tests/unit/extractor/test_deltalake_extractor.py
+++ b/databuilder/tests/unit/extractor/test_deltalake_extractor.py
@@ -16,6 +16,7 @@ from databuilder.extractor.delta_lake_metadata_extractor import (
     DeltaLakeMetadataExtractor, ScrapedColumnMetadata, ScrapedTableMetadata,
 )
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
+from databuilder.extractor.table_metadata_constants import PARTITION_BADGE
 
 
 class TestDeltaLakeExtractor(unittest.TestCase):
@@ -146,6 +147,7 @@ class TestDeltaLakeExtractor(unittest.TestCase):
         actual = self.dExtractor.fetch_columns("test_schema1", "test_table3")
         partition_column = ScrapedColumnMetadata(name="c", description=None, data_type="boolean", sort_order=0)
         partition_column.set_is_partition(True)
+        partition_column.set_badges([PARTITION_BADGE])
         expected = [partition_column,
                     ScrapedColumnMetadata(name="d", description=None, data_type="float", sort_order=1)]
         for a, b in zip(actual, expected):


### PR DESCRIPTION
### Summary of Changes

delta lake extractor is not able to add badge for the **partition columns**. This change is for extending delta lake extractor  as it detects partition column and add a badge to it.
In a nutshell:
- adding `badges` property to `ScrapedColumnMetadata` class
- setting Partition Column badge when it detects partition column

### Tests

![image](https://user-images.githubusercontent.com/15074091/149378412-8129de49-265c-40ed-a12f-1bfe03f26184.png)

`databuilder/tests/unit/extractor/test_deltalake_extractor.py` is changed. badge is added to `partition_column`.

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
