### PR TITLE
feat: Add config to prevent neo4j staleness removal task from removing data with missing publisher metadata

### DIFF
--- a/databuilder/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/databuilder/task/neo4j_staleness_removal_task.py
@@ -169,18 +169,18 @@ class Neo4jStalenessRemovalTask(Task):
         :return:
         """
         if self.ms_to_expire:
-            condition = f"""(target.publisher_last_updated_epoch_ms < (timestamp() - ${MARKER_VAR_NAME})"""
+            condition = f"""target.publisher_last_updated_epoch_ms < (timestamp() - ${MARKER_VAR_NAME})"""
             if not self.retain_data_with_no_publisher_metadata:
                 null_check = "EXISTS(target.publisher_last_updated_epoch_ms)"
                 condition = f"""{condition}\nOR NOT {null_check}"""
-            condition += ")"
+            condition = f"""({condition})"""
             return statement.format(staleness_condition=condition)
 
-        condition = f"""(target.published_tag < ${MARKER_VAR_NAME}"""
+        condition = f"""target.published_tag < ${MARKER_VAR_NAME}"""
         if not self.retain_data_with_no_publisher_metadata:
             null_check = "EXISTS(target.published_tag)"
             condition = f"""{condition}\nOR NOT {null_check}"""
-        condition += ")"
+        condition = f"""({condition})"""
         return statement.format(staleness_condition=condition)
 
     def _delete_stale_relations(self) -> None:

--- a/databuilder/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/databuilder/task/neo4j_staleness_removal_task.py
@@ -37,6 +37,7 @@ STALENESS_PCT_MAX_DICT = "staleness_max_pct_dict"
 # Using this milliseconds and published timestamp to determine staleness
 MS_TO_EXPIRE = "milliseconds_to_expire"
 MIN_MS_TO_EXPIRE = "minimum_milliseconds_to_expire"
+RETAIN_DATA_WITH_NO_PUBLISHER_METADATA = "retain_data_with_no_publisher_metadata"
 
 DEFAULT_CONFIG = ConfigFactory.from_dict({BATCH_SIZE: 100,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50,
@@ -47,6 +48,7 @@ DEFAULT_CONFIG = ConfigFactory.from_dict({BATCH_SIZE: 100,
                                           TARGET_RELATIONS: [],
                                           STALENESS_PCT_MAX_DICT: {},
                                           MIN_MS_TO_EXPIRE: 86400000,
+                                          RETAIN_DATA_WITH_NO_PUBLISHER_METADATA: False,
                                           DRY_RUN: False})
 
 LOGGER = logging.getLogger(__name__)
@@ -111,6 +113,7 @@ class Neo4jStalenessRemovalTask(Task):
         self.dry_run = conf.get_bool(DRY_RUN)
         self.staleness_pct = conf.get_int(STALENESS_MAX_PCT)
         self.staleness_pct_dict = conf.get(STALENESS_PCT_MAX_DICT)
+        self.retain_data_with_no_publisher_metadata = conf.get_bool(RETAIN_DATA_WITH_NO_PUBLISHER_METADATA)
 
         if JOB_PUBLISH_TAG in conf and MS_TO_EXPIRE in conf:
             raise Exception(f'Cannot have both {JOB_PUBLISH_TAG} and {MS_TO_EXPIRE} in job config')
@@ -166,13 +169,17 @@ class Neo4jStalenessRemovalTask(Task):
         :return:
         """
         if self.ms_to_expire:
-            return statement.format(staleness_condition=textwrap.dedent(f"""\
-            (target.publisher_last_updated_epoch_ms < (timestamp() - ${MARKER_VAR_NAME})
-            OR NOT EXISTS(target.publisher_last_updated_epoch_ms))"""))
+            condition = f"""(target.publisher_last_updated_epoch_ms < (timestamp() - ${MARKER_VAR_NAME})"""
+            condition = (condition + ")"
+                         if self.retain_data_with_no_publisher_metadata
+                         else condition + "\nOR NOT EXISTS(target.publisher_last_updated_epoch_ms))")
+            return statement.format(staleness_condition=condition)
 
-        return statement.format(staleness_condition=textwrap.dedent(f"""\
-        (target.published_tag <> ${MARKER_VAR_NAME}
-        OR NOT EXISTS(target.published_tag))"""))
+        condition = f"""(target.published_tag <> ${MARKER_VAR_NAME}"""
+        condition = (condition + ")"
+                     if self.retain_data_with_no_publisher_metadata
+                     else condition + "\nOR NOT EXISTS(target.published_tag))")
+        return statement.format(staleness_condition=condition)
 
     def _delete_stale_relations(self) -> None:
         self._batch_delete(statement=self._decorate_staleness(self.delete_stale_relations_statement),

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.4.4'
+__version__ = '6.4.6'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.4.3'
+__version__ = '6.4.4'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -156,6 +156,39 @@ class TestRemoveStaleData(unittest.TestCase):
             RETURN count(*) as count
             """))
 
+    def test_validation_statement_publish_tag_retain_data_with_no_publisher_metadata(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
+                as mock_execute:
+            task = Neo4jStalenessRemovalTask()
+            job_config = ConfigFactory.from_dict({
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.RETAIN_DATA_WITH_NO_PUBLISHER_METADATA}': True
+            })
+
+            task.init(job_config)
+            task._validate_node_staleness_pct()
+            mock_execute.assert_any_call(param_dict={'marker': u'foo'},
+                                         statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            WHERE (target.published_tag <> $marker)
+            RETURN count(*) as count
+            """))
+
+            task._validate_relation_staleness_pct()
+            mock_execute.assert_any_call(param_dict={'marker': u'foo'},
+                                         statement=textwrap.dedent("""
+            MATCH (start_node)-[target:BAR]-(end_node)
+            WHERE (target.published_tag <> $marker)
+            RETURN count(*) as count
+            """))
+
     def test_validation_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
                 as mock_execute:
@@ -195,6 +228,39 @@ class TestRemoveStaleData(unittest.TestCase):
             MATCH (start_node)-[target:BAR]-(end_node)
             WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(target.publisher_last_updated_epoch_ms))
+            RETURN count(*) as count
+            """))
+
+    def test_validation_statement_ms_to_expire_retain_data_with_no_publisher_metadata(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
+                as mock_execute:
+            task = Neo4jStalenessRemovalTask()
+            job_config = ConfigFactory.from_dict({
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 9876543210,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.RETAIN_DATA_WITH_NO_PUBLISHER_METADATA}': True
+            })
+
+            task.init(job_config)
+            task._validate_node_staleness_pct()
+            mock_execute.assert_any_call(param_dict={'marker': 9876543210},
+                                         statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker))
+            RETURN count(*) as count
+            """))
+
+            task._validate_relation_staleness_pct()
+            mock_execute.assert_any_call(param_dict={'marker': 9876543210},
+                                         statement=textwrap.dedent("""
+            MATCH (start_node)-[target:BAR]-(end_node)
+            WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker))
             RETURN count(*) as count
             """))
 
@@ -312,6 +378,47 @@ class TestRemoveStaleData(unittest.TestCase):
             RETURN count(*) as count
             """))
 
+    def test_delete_statement_publish_tag_retain_data_with_no_publisher_metadata(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
+                as mock_execute:
+            mock_execute.return_value.single.return_value = {'count': 0}
+            task = Neo4jStalenessRemovalTask()
+            job_config = ConfigFactory.from_dict({
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                neo4j_csv_publisher.JOB_PUBLISH_TAG: 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.RETAIN_DATA_WITH_NO_PUBLISHER_METADATA}': True
+            })
+
+            task.init(job_config)
+            task._delete_stale_nodes()
+            task._delete_stale_relations()
+
+            mock_execute.assert_any_call(dry_run=False,
+                                         param_dict={'marker': u'foo', 'batch_size': 100},
+                                         statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            WHERE (target.published_tag <> $marker)
+            WITH target LIMIT $batch_size
+            DETACH DELETE (target)
+            RETURN count(*) as count
+            """))
+
+            mock_execute.assert_any_call(dry_run=False,
+                                         param_dict={'marker': u'foo', 'batch_size': 100},
+                                         statement=textwrap.dedent("""
+            MATCH (start_node)-[target:BAR]-(end_node)
+            WHERE (target.published_tag <> $marker)
+            WITH target LIMIT $batch_size
+            DELETE target
+            RETURN count(*) as count
+            """))
+
     def test_delete_statement_ms_to_expire(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
                 as mock_execute:
@@ -349,6 +456,47 @@ class TestRemoveStaleData(unittest.TestCase):
             MATCH (start_node)-[target:BAR]-(end_node)
             WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker)
             OR NOT EXISTS(target.publisher_last_updated_epoch_ms))
+            WITH target LIMIT $batch_size
+            DELETE target
+            RETURN count(*) as count
+            """))
+
+    def test_delete_statement_ms_to_expire_retain_data_with_no_publisher_metadata(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jStalenessRemovalTask, '_execute_cypher_query') \
+                as mock_execute:
+            mock_execute.return_value.single.return_value = {'count': 0}
+            task = Neo4jStalenessRemovalTask()
+            job_config = ConfigFactory.from_dict({
+                f'job.identifier': 'remove_stale_data_job',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_END_POINT_KEY}': 'foobar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_USER}': 'foo',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.NEO4J_PASSWORD}': 'bar',
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.STALENESS_MAX_PCT}': 5,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_NODES}': ['Foo'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.TARGET_RELATIONS}': ['BAR'],
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.MS_TO_EXPIRE}': 9876543210,
+                f'{task.get_scope()}.{neo4j_staleness_removal_task.RETAIN_DATA_WITH_NO_PUBLISHER_METADATA}': True
+            })
+
+            task.init(job_config)
+            task._delete_stale_nodes()
+            task._delete_stale_relations()
+
+            mock_execute.assert_any_call(dry_run=False,
+                                         param_dict={'marker': 9876543210, 'batch_size': 100},
+                                         statement=textwrap.dedent("""
+            MATCH (target:Foo)
+            WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker))
+            WITH target LIMIT $batch_size
+            DETACH DELETE (target)
+            RETURN count(*) as count
+            """))
+
+            mock_execute.assert_any_call(dry_run=False,
+                                         param_dict={'marker': 9876543210, 'batch_size': 100},
+                                         statement=textwrap.dedent("""
+            MATCH (start_node)-[target:BAR]-(end_node)
+            WHERE (target.publisher_last_updated_epoch_ms < (timestamp() - $marker))
             WITH target LIMIT $batch_size
             DELETE target
             RETURN count(*) as count

--- a/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/databuilder/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -142,7 +142,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag))
             RETURN count(*) as count
             """))
@@ -151,7 +151,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (start_node)-[target:BAR]-(end_node)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag))
             RETURN count(*) as count
             """))
@@ -177,7 +177,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target.published_tag <> $marker)
+            WHERE (target.published_tag < $marker)
             RETURN count(*) as count
             """))
 
@@ -185,7 +185,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (start_node)-[target:BAR]-(end_node)
-            WHERE (target.published_tag <> $marker)
+            WHERE (target.published_tag < $marker)
             RETURN count(*) as count
             """))
 
@@ -292,7 +292,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag)) AND (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'
             RETURN count(*) as count
             """))
@@ -301,7 +301,7 @@ class TestRemoveStaleData(unittest.TestCase):
             mock_execute.assert_any_call(param_dict={'marker': u'foo'},
                                          statement=textwrap.dedent("""
             MATCH (start_node)-[target:BAR]-(end_node)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag)) AND (start_node:Foo)-[target]->(end_node:Foo)
             RETURN count(*) as count
             """))
@@ -360,7 +360,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag))
             WITH target LIMIT $batch_size
             DETACH DELETE (target)
@@ -371,7 +371,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (start_node)-[target:BAR]-(end_node)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag))
             WITH target LIMIT $batch_size
             DELETE target
@@ -403,7 +403,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target.published_tag <> $marker)
+            WHERE (target.published_tag < $marker)
             WITH target LIMIT $batch_size
             DETACH DELETE (target)
             RETURN count(*) as count
@@ -413,7 +413,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (start_node)-[target:BAR]-(end_node)
-            WHERE (target.published_tag <> $marker)
+            WHERE (target.published_tag < $marker)
             WITH target LIMIT $batch_size
             DELETE target
             RETURN count(*) as count
@@ -526,7 +526,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (target:Foo)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag)) AND (target)-[:BAR]->(:Foo) AND target.name=\'foo_name\'
             WITH target LIMIT $batch_size
             DETACH DELETE (target)
@@ -537,7 +537,7 @@ class TestRemoveStaleData(unittest.TestCase):
                                          param_dict={'marker': u'foo', 'batch_size': 100},
                                          statement=textwrap.dedent("""
             MATCH (start_node)-[target:BAR]-(end_node)
-            WHERE (target.published_tag <> $marker
+            WHERE (target.published_tag < $marker
             OR NOT EXISTS(target.published_tag)) AND (start_node:Foo)-[target]->(end_node:Foo)
             WITH target LIMIT $batch_size
             DELETE target


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Neo4j data can exist without either attributes "published_tag" or "publisher_last_updated_epoch_ms" if it is created by an Amundsen user rather than by the publisher. In this case you may not want to have these nodes marked as stale and deleted by the Neo4jStalenessRemovalTask. This new config will allow you to keep these nodes by setting `retain_data_with_no_publisher_metadata` to `True`. The default value to keep the original behavior will be `False`, where any data without the publisher metadata will be marked as stale and deleted by this task.

### Tests

Added tests to `test_neo4j_staleness_removal_task.py` to test the Neo4j query format when the config is set to `True`.

### Documentation

Added a note about the config and how it is used in `databuilder/README.md`.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
