### PR TITLE
feat: remove jira and asana from primary deps in frontend

### DIFF
--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -3,8 +3,6 @@
 
 responses==0.12.1
 SQLAlchemy==1.3.23
-jira==3.0.1
-asana==0.10.3
 retrying>=1.3.3,<2.0
 
 # Backport of PEP 557, Data Classes for Python 3.6.

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -47,10 +47,12 @@ with open(requirements_path) as requirements_file:
 
 __version__ = '4.0.1'
 
+jira = ['jira==3.0.1']
+asana = ['asana==0.10.3']
 oidc = ['flaskoidc>=1.0.0']
 pyarrrow = ['pyarrow==3.0.0']
 bigquery_preview = ['google-cloud-bigquery>=2.13.1,<3.0.0', 'flatten-dict==0.3.0']
-all_deps = requirements + requirements_common + requirements_dev + oidc + pyarrrow + bigquery_preview
+all_deps = requirements + requirements_common + requirements_dev + oidc + pyarrrow + bigquery_preview + jira + asana
 
 setup(
     name='amundsen-frontend',
@@ -69,6 +71,8 @@ setup(
         'dev': requirements_dev,
         'pyarrow': pyarrrow,
         'bigquery_preview': bigquery_preview,
+        'jira': jira,
+        'asana': asana,
         'all': all_deps,
     },
     python_requires=">=3.7",


### PR DESCRIPTION
### Summary of Changes

As neither JIRA nor Asana integrations are default for frontend this PR moves them to dedicated extra sections.

We want avoid having jira dependencies in frontend container as we are not really using jira integration and our security scanners complain about https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22824 which is tied to one of the libraries jira client depends on.

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
