### PR TITLE
chore: remove gremlin from core dependencies of metadata proxy

### DIFF
--- a/metadata/metadata_service/config.py
+++ b/metadata/metadata_service/config.py
@@ -167,6 +167,6 @@ try:
 
         JANUS_GRAPH_URL = None
 except ImportError:
-    logging.error("""amundsen_gremlin not installed. GremlinConfig and NeptuneConfig classes won't be available!
+    logging.warning("""amundsen_gremlin not installed. GremlinConfig and NeptuneConfig classes won't be available!
     Please install amundsen-metadata[gremlin] if you desire to use those classes.
     """)

--- a/metadata/requirements.txt
+++ b/metadata/requirements.txt
@@ -1,9 +1,6 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-amundsen-gremlin>=0.0.9
-gremlinpython==3.4.3
-gremlinpython==3.4.3
 neo4j==1.7.6
 neotime==1.7.1
 apache_atlas==0.0.11

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -25,8 +25,12 @@ rds = ['amundsen-rds==0.0.6',
        'mysqlclient>=1.3.6,<3',
        'sqlalchemy>=1.3.6,<1.4',
        'alembic>=1.2,<2.0']
-
-all_deps = requirements + requirements_common + requirements_dev + oidc + atlas + rds
+gremlin = [
+    'amundsen-gremlin>=0.0.9',
+    'gremlinpython==3.4.3',
+    'gremlinpython==3.4.3'
+]
+all_deps = requirements + requirements_common + requirements_dev + oidc + atlas + rds + gremlin
 
 setup(
     name='amundsen-metadata',
@@ -44,7 +48,8 @@ setup(
         'dev': requirements_dev,
         'atlas': atlas,
         'oidc': oidc,
-        'rds': rds
+        'rds': rds,
+        'gremlin': gremlin
     },
     python_requires=">=3.7",
     classifiers=[


### PR DESCRIPTION
### Summary of Changes

Removes Gremlin from core dependencies of metadata proxy as it's not a default one. Enforcing installation of amundsen-gremlin along with is redundant and shouldn't happen.

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
