### PR TITLE
fix: add region parameter to glue extractor boto3 client instantiation

### DIFF
--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -165,7 +165,7 @@ job = DefaultJob(
 job.launch()
 ```
 
-If using the filters option here is the input format
+If using the filters option here is the input format. For more information on filters visit [link](https://docs.aws.amazon.com/glue/latest/webapi/API_PropertyPredicate.html)
 ```
 [
   {
@@ -177,6 +177,20 @@ If using the filters option here is the input format
 ]
 ```
 
+Example filtering on database and table. Note that Comparator can only apply to time fields.
+
+```
+[
+  {
+    "Key": "DatabaseName",
+    "Value": "my_database"
+  },
+  {
+    "Key": "Name",
+    "Value": "my_table"
+  }
+]
+```
 #### [Delta-Lake-MetadataExtractor](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py)
 An extractor that runs on a spark cluster and obtains delta-lake metadata using spark sql commands.
 This custom solution is currently necessary because the hive metastore does not contain all metadata information for delta-lake tables.

--- a/databuilder/databuilder/extractor/glue_extractor.py
+++ b/databuilder/databuilder/extractor/glue_extractor.py
@@ -21,11 +21,13 @@ class GlueExtractor(Extractor):
     FILTER_KEY = 'filters'
     MAX_RESULTS_KEY = 'max_results'
     RESOURCE_SHARE_TYPE = 'resource_share_type'
+    REGION_NAME_KEY = "region"
     DEFAULT_CONFIG = ConfigFactory.from_dict({
         CLUSTER_KEY: 'gold',
         FILTER_KEY: None,
         MAX_RESULTS_KEY: 500,
-        RESOURCE_SHARE_TYPE: "ALL"
+        RESOURCE_SHARE_TYPE: "ALL",
+        REGION_NAME_KEY: None
     })
 
     def init(self, conf: ConfigTree) -> None:
@@ -34,7 +36,11 @@ class GlueExtractor(Extractor):
         self._filters = conf.get(GlueExtractor.FILTER_KEY)
         self._max_results = conf.get(GlueExtractor.MAX_RESULTS_KEY)
         self._resource_share_type = conf.get(GlueExtractor.RESOURCE_SHARE_TYPE)
-        self._glue = boto3.client('glue')
+        self._region_name = conf.get(GlueExtractor.REGION_NAME_KEY)
+        if self._region_name is not None:
+            self._glue = boto3.client('glue', region_name=self._region_name)
+        else:
+            self._glue = boto3.client('glue')
         self._extract_iter: Union[None, Iterator] = None
 
     def extract(self) -> Union[TableMetadata, None]:


### PR DESCRIPTION
**glue extractor** does not get `region_name` argument. It might be needed in different scenarios. For example, while using **Databricks** for extracting data from AWS Glue, it gives `NoRegionError: You must specify a region.`

You might be questioning why cant we use aws configuration and set region with **.aws/config** $HOME directory. Databricks is using instance profile for associating cluster with AWS IAM role. It is not a good practice to install aws cli to databricks cluster and configure aws credentials. So, typically, there is no **.aws/config** file stored in databricks cluster, and it is not needed.

In a nutshell, it might be better to have an option to provide `region_name` parameter while creating glue extractor.

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
