### PR TITLE
feat: Add column statistics indicator for columns with TableColumnStats available

### DIFF
--- a/frontend/amundsen_application/static/js/components/SVGIcons/GraphIcon.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/GraphIcon.tsx
@@ -1,0 +1,40 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IconSizes } from 'interfaces';
+import { IconProps } from './types';
+import { DEFAULT_CIRCLE_FILL_COLOR } from './constants';
+
+export const GraphIcon: React.FC<IconProps> = ({
+  size = IconSizes.REGULAR,
+  fill = DEFAULT_CIRCLE_FILL_COLOR,
+}: IconProps) => {
+  const id = `graph_icon_${uuidv4()}`;
+
+  return (
+    <svg viewBox="0 0 25 25" height={size} width={size}>
+      <defs>
+        <path
+          d="M12,0.259C5.516,0.259,0.258,5.516,0.258,12c0,6.486,5.258,11.74,11.742,11.74S23.742,18.486,23.742,12
+            C23.742,5.516,18.484,0.259,12,0.259z M18.896,10.467c-0.137,0-0.268,0-0.383-0.054l-2.735,2.736
+            c0.053,0.115,0.053,0.244,0.053,0.383c0,0.846-0.684,1.533-1.531,1.533s-1.531-0.688-1.531-1.533l0.053-0.383l-1.97-1.97
+            c-0.245,0.054-0.521,0.054-0.766,0l-3.501,3.501l0.054,0.385c0,0.846-0.686,1.531-1.533,1.531s-1.533-0.686-1.533-1.531
+            c0-0.848,0.686-1.533,1.533-1.533l0.383,0.055l3.502-3.503C8.851,9.586,8.981,9.019,9.387,8.62c0.598-0.605,1.564-0.605,2.161,0
+            c0.407,0.398,0.536,0.966,0.398,1.463l1.97,1.969l0.383-0.054c0.137,0,0.268,0,0.383,0.054l2.734-2.735
+            c-0.053-0.115-0.053-0.245-0.053-0.383c0-0.847,0.688-1.532,1.532-1.532c0.848,0,1.532,0.686,1.532,1.532
+            S19.743,10.467,18.896,10.467z"
+          id={id}
+        />
+      </defs>
+      <g fill="none" fillRule="evenodd">
+        <mask id="prefix__b" fill="#fff">
+          <use xlinkHref={`#${id}`} />
+        </mask>
+        <use fill={fill} xlinkHref={`#${id}`} />
+      </g>
+    </svg>
+  );
+};

--- a/frontend/amundsen_application/static/js/components/SVGIcons/constants.ts
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/constants.ts
@@ -1,3 +1,5 @@
 export const DEFAULT_FILL_COLOR = '#9191A8'; // gray40
 export const FAILURE_FILL_COLOR = '#FF9E87'; // sunset20
 export const SUCCESS_FILL_COLOR = '#4AE3AE'; // mint20
+
+export const DEFAULT_CIRCLE_FILL_COLOR = '#523be4'; // indigo80

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -250,6 +250,15 @@ describe('ColumnList', () => {
 
         expect(actual).toEqual(expected);
       });
+
+      it('should show column statistics icon', () => {
+        const { wrapper } = setup({ columns });
+
+        const expected = 1;
+        const actual = wrapper.find('GraphIcon').length;
+
+        expect(actual).toEqual(expected);
+      });
     });
 
     describe('when columns with several stats including usage are passed', () => {

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -17,6 +17,7 @@ import ColumnType from './ColumnType';
 import { EMPTY_MESSAGE } from './constants';
 
 import TestDataBuilder from './testDataBuilder';
+import {GraphIcon} from "components/SVGIcons/GraphIcon";
 
 jest.mock('config/config-utils');
 
@@ -228,6 +229,15 @@ describe('ColumnList', () => {
 
         expect(actual).toEqual(expected);
       });
+
+      it('should not show column statistics icon', () => {
+        const { wrapper } = setup({ columns });
+
+        const expected = 0;
+        const actual = wrapper.find('GraphIcon').length;
+
+        expect(actual).toEqual(expected);
+      });
     });
 
     describe('when columns with one usage data entry are passed', () => {
@@ -249,6 +259,15 @@ describe('ColumnList', () => {
         const { wrapper } = setup({ columns });
         const expected = columns.length;
         const actual = wrapper.find('.table-detail-table .usage-value').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should show column statistics icon', () => {
+        const { wrapper } = setup({ columns });
+
+        const expected = columns.length;
+        const actual = wrapper.find('GraphIcon').length;
 
         expect(actual).toEqual(expected);
       });

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -12,7 +12,6 @@ import { BadgeStyle } from 'config/config-types';
 import * as ConfigUtils from 'config/config-utils';
 
 import globalState from 'fixtures/globalState';
-import { GraphIcon } from 'components/SVGIcons/GraphIcon';
 import ColumnList, { ColumnListProps } from '.';
 import ColumnType from './ColumnType';
 import { EMPTY_MESSAGE } from './constants';

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -17,7 +17,7 @@ import ColumnType from './ColumnType';
 import { EMPTY_MESSAGE } from './constants';
 
 import TestDataBuilder from './testDataBuilder';
-import {GraphIcon} from "components/SVGIcons/GraphIcon";
+import { GraphIcon } from 'components/SVGIcons/GraphIcon';
 
 jest.mock('config/config-utils');
 

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -12,12 +12,12 @@ import { BadgeStyle } from 'config/config-types';
 import * as ConfigUtils from 'config/config-utils';
 
 import globalState from 'fixtures/globalState';
+import { GraphIcon } from 'components/SVGIcons/GraphIcon';
 import ColumnList, { ColumnListProps } from '.';
 import ColumnType from './ColumnType';
 import { EMPTY_MESSAGE } from './constants';
 
 import TestDataBuilder from './testDataBuilder';
-import { GraphIcon } from 'components/SVGIcons/GraphIcon';
 
 jest.mock('config/config-utils');
 

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -85,7 +85,6 @@ type ContentType = {
   title: string;
   description: string;
   nestedLevel: number;
-  stats: boolean;
 };
 
 type DatatypeType = {
@@ -253,7 +252,6 @@ const ColumnList: React.FC<ColumnListProps> = ({
         title: item.name,
         description: item.description,
         nestedLevel: item.nested_level || 0,
-        stats: hasItemStats,
       },
       type: {
         type: item.col_type,
@@ -328,7 +326,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
     {
       title: 'Name',
       field: 'content',
-      component: ({ title, description, nestedLevel, stats }: ContentType) => (
+      component: ({ title, description, nestedLevel }: ContentType) => (
         <>
           {nestedLevel > 0 && (
             <>

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -43,6 +43,8 @@ import { logAction } from 'utils/analytics';
 import { buildTableKey, TablePageParams } from 'utils/navigationUtils';
 import { getUniqueValues, filterOutUniqueValues } from 'utils/stats';
 
+import { GraphIcon } from 'components/SVGIcons/GraphIcon';
+
 import ColumnType from './ColumnType';
 import ColumnDescEditableText from './ColumnDescEditableText';
 import ColumnStats from './ColumnStats';
@@ -83,6 +85,7 @@ type ContentType = {
   title: string;
   description: string;
   nestedLevel: number;
+  stats: boolean;
 };
 
 type DatatypeType = {
@@ -245,10 +248,12 @@ const ColumnList: React.FC<ColumnListProps> = ({
   const formatColumnData = (item, index) => {
     const hasItemStats = !!item.stats.length;
     return {
+      stats: hasItemStats ? item.stats : null,
       content: {
         title: item.name,
         description: item.description,
         nestedLevel: item.nested_level || 0,
+        stats: hasItemStats,
       },
       type: {
         type: item.col_type,
@@ -259,7 +264,6 @@ const ColumnList: React.FC<ColumnListProps> = ({
       children: item.children,
       sort_order: item.sort_order,
       usage: getUsageStat(item),
-      stats: hasItemStats ? item.stats : null,
       badges: hasColumnBadges ? item.badges : [],
       action: {
         name: item.name,
@@ -310,9 +314,21 @@ const ColumnList: React.FC<ColumnListProps> = ({
 
   let formattedColumns: ReusableTableColumn[] = [
     {
+      title: '',
+      field: 'stats',
+      width: 24,
+      horAlign: TextAlignmentValues.left,
+      component: (stats) => {
+        if (stats != null && stats.length > 0) {
+          return <GraphIcon />;
+        }
+        return null;
+      },
+    },
+    {
       title: 'Name',
       field: 'content',
-      component: ({ title, description, nestedLevel }: ContentType) => (
+      component: ({ title, description, nestedLevel, stats }: ContentType) => (
         <>
           {nestedLevel > 0 && (
             <>

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -304,6 +304,8 @@ const ColumnList: React.FC<ColumnListProps> = ({
     ? orderedData
     : flattenData(orderedData);
 
+  const STATS_COLUMN_WIDTH = 24;
+
   flattenedData.forEach((item, index) => {
     if (item.name === selectedColumn) {
       selectedIndex = index;
@@ -314,7 +316,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
     {
       title: '',
       field: 'stats',
-      width: 24,
+      width: STATS_COLUMN_WIDTH,
       horAlign: TextAlignmentValues.left,
       component: (stats) => {
         if (stats != null && stats.length > 0) {

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -45,7 +45,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-__version__ = '4.0.1'
+__version__ = '4.1.0'
 
 jira = ['jira==3.0.1']
 asana = ['asana==0.10.3']


### PR DESCRIPTION
### Summary of Changes

Currently there is no indication if there is a need to expand the column details to see whether column has column stats available or not. Users need to expand details even if there is nothing there.

This PR introduces an icon which indicates that a given column has statistics available. I am not strongly opinionated towards icon or placement choice but I think such indicator is a must to improve user experience.

This is how it looks like after this initial implementation:
![image](https://user-images.githubusercontent.com/5680655/151964237-715d0c39-9f3c-46c1-ac44-7d45d35ce35a.png)

### Tests

tbd

### Documentation

tbd

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
