### PR TITLE
docs: Fix broken link to frontend installation

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -75,7 +75,7 @@ rm -rf .local/neo4j
 
 ### Testing Amundsen frontend locally
 
-Amundsen has an instruction regarding local frontend launch [here](/frontend/docs/installation.md)
+Amundsen has an instruction regarding local frontend launch [here](/amundsen/frontend/docs/installation/)
 
 Here are some additional changes you might need for windows (OS Win 10):
 


### PR DESCRIPTION
### Summary of Changes

Fixes a broken link to https://www.amundsen.io/amundsen/frontend/docs/installation/ from https://www.amundsen.io/amundsen/developer_guide/.

The link is going to the local .md file, which gave 404 when clicked online: https://www.amundsen.io/frontend/docs/installation.md

### Tests

Just a docs change

### Documentation

Fixed link

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
