### PR TITLE
isolate text wrapping for tables only

### DIFF
--- a/frontend/amundsen_application/static/js/components/EditableText/styles.scss
+++ b/frontend/amundsen_application/static/js/components/EditableText/styles.scss
@@ -8,7 +8,6 @@
   .markdown-wrapper {
     font-size: 14px;
     word-break: break-word;
-    white-space: break-spaces;
   }
 
   .edit-link {

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -108,6 +108,10 @@ $row-bottom-border-color: $gray10;
   &:last-child {
     padding-right: $spacer-3;
   }
+
+  .markdown_wrapper {
+    white-space: break-spaces
+  }
 }
 
 .ams-table-expanding-button {


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes
Bug fix:
3 days ago, made a one line change for text wrapping. Reached desired result for table column description wrapping, but had unintended consequence of formatting table descriptions weirdly when there is newline (picture below):
![image](https://user-images.githubusercontent.com/27388371/153972381-92402056-b11f-40cb-be98-46822aa061d2.png)

This new change isolates text wrapping for table column descriptions.

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
