### PR TITLE
fix: set itsdangerous version <= 2.0.1

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -13,6 +13,7 @@ flasgger==0.9.5
 Flask==1.0.2
 Flask-RESTful>=0.3.6
 flask-cors==3.0.8
+itsdangerous<=2.0.1
 Jinja2>=2.10.1
 jsonschema>=3.0.1,<4.0
 marshmallow>=3.0,<=3.6


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->

itsdangerous was released a few hours ago that removed json. https://github.com/pallets/itsdangerous/commit/506ca21d8cc1d16313270c37b6990c9e7762f68e

https://pypi.org/project/itsdangerous/#history

With this newest release, image builds are broken. See this example: https://github.com/youngyjd/amundsen/pull/42
```
[2022-02-18T05:19:20Z] Traceback:
[2022-02-18T05:19:20Z] /usr/local/lib/python3.7/importlib/__init__.py:127: in import_module
[2022-02-18T05:19:20Z]     return _bootstrap._gcd_import(name[level:], package, level)
[2022-02-18T05:19:20Z] /tests/api/brex_lineage/test_graph.py:1: in <module>
[2022-02-18T05:19:20Z]     from amundsen_application.api.brex_lineage.graph import render_attributes
[2022-02-18T05:19:20Z] amundsen_application/__init__.py:11: in <module>
[2022-02-18T05:19:20Z]     from flask import Blueprint, Flask
[2022-02-18T05:19:20Z] venv/lib/python3.7/site-packages/flask/__init__.py:21: in <module>
[2022-02-18T05:19:20Z]     from .app import Flask, Request, Response
[2022-02-18T05:19:20Z] venv/lib/python3.7/site-packages/flask/app.py:25: in <module>
[2022-02-18T05:19:20Z]     from . import cli, json
[2022-02-18T05:19:20Z] venv/lib/python3.7/site-packages/flask/json/__init__.py:21: in <module>
[2022-02-18T05:19:20Z]     from itsdangerous import json as _json
[2022-02-18T05:19:20Z] E   ImportError: cannot import name 'json' from 'itsdangerous' (/app/venv/lib/python3.7/site-packages/itsdangerous/__init__.py)[0m
```

Before we upgrade Flask version, we have to set itsdangerous<=2.0.1 in order for build to pass.

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
