### PR TITLE
docs: Fix deprecated variable name, dockerfile formatting

### DIFF
--- a/docs/authentication/oidc.md
+++ b/docs/authentication/oidc.md
@@ -167,11 +167,11 @@ You can take alook at the public.Dockerfile as a reference.
 
 ```dockerfile
 RUN pip3 install .[oidc]
-ENV FRONTEND_SVC_CONFIG_MODULE_CLASS amundsen_application.oidc_config.OidcConfig
-ENV APP_WRAPPER flaskoidc
-ENV APP_WRAPPER_CLASS FlaskOIDC
-ENV FLASK_OIDC_WHITELISTED_ENDPOINTS status,healthcheck,health
-ENV SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
+ENV FRONTEND_SVC_CONFIG_MODULE_CLASS=amundsen_application.oidc_config.OidcConfig
+ENV FLASK_APP_MODULE_NAME=flaskoidc
+ENV FLASK_APP_CLASS_NAME=FlaskOIDC
+ENV FLASK_OIDC_WHITELISTED_ENDPOINTS=status,healthcheck,health
+ENV SQLALCHEMY_DATABASE_URI=sqlite:///sessions.db
 ```
 
 Please also take a look at this blog [post](https://nirav-langaliya.medium.com/setup-oidc-authentication-with-lyft-amundsen-via-okta-eb0b89d724d3) for more detail.


### PR DESCRIPTION
oidc.md - fix deprecated variable name, fix dockerfile formatting

### Summary of Changes

File:
docs/authentication/oidc.md

1) Deprecated variable name replaced with an actual one:
"APP_WRAPPER" -> "FLASK_APP_MODULE_NAME"
"PP_WRAPPER_CLASS" -> "FLASK_APP_CLASS_NAME"

2) Added the "=" sign in the example Dockerfile ENV statement where it was missing
Reason - omitting of '=' symbol in VAR statements is discouraged as per official doc:
https://docs.docker.com/engine/reference/builder/

### Tests

No tests, docs actualization.

### Documentation

Please see: Summary of Changes

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [+] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [+] PR includes a summary of changes.
- [+] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [+] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
