### PR TITLE
fix: add schema name in node title

### DIFF
--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.ts
@@ -104,10 +104,9 @@ const renderLabels = (
     .attr('class', 'graph-direction-label  upstream-label')
     .attr(
       'transform',
-      `translate(${
-        dimensions.width / 2 -
-        UPSTREAM_LABEL_OFFSET -
-        LINEAGE_SCENE_MARGIN.right
+      `translate(${dimensions.width / 2 -
+      UPSTREAM_LABEL_OFFSET -
+      LINEAGE_SCENE_MARGIN.right
       }, ${LINEAGE_SCENE_MARGIN.top})`
     )
     .html(labels.upstream);
@@ -118,8 +117,7 @@ const renderLabels = (
     .attr('class', 'graph-direction-label downstream-label')
     .attr(
       'transform',
-      `translate(${dimensions.width / 2 + LINEAGE_SCENE_MARGIN.left}, ${
-        LINEAGE_SCENE_MARGIN.top
+      `translate(${dimensions.width / 2 + LINEAGE_SCENE_MARGIN.left}, ${LINEAGE_SCENE_MARGIN.top
       })`
     )
     .html(labels.downstream);
@@ -327,7 +325,7 @@ export const buildNodes = (g, targetNode, nodes, onClick) => {
     .append('text')
     .attr('dy', NODE_LABEL_Y_OFFSET)
     .attr('text-anchor', 'middle')
-    .text((d, idx) => (idx !== 0 && d.data.data.name ? d.data.data.name : ''));
+    .text((d, idx) => (idx !== 0 && d.data.data.name ? d.data.data.schema + '.' + d.data.data.name : ''));
 
   // Position visual state for for fold/unfold
   nodeEnter
@@ -479,7 +477,7 @@ const lc = (): LineageChart => {
       dimensions.height,
       (dimensions.width -
         (LINEAGE_SCENE_MARGIN.left + LINEAGE_SCENE_MARGIN.right)) /
-        2,
+      2,
     ]);
 
     const upstreamTree = buildTree(

--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/constants.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/constants.ts
@@ -6,7 +6,7 @@ export const LINEAGE_SCENE_MARGIN = {
 };
 export const CHART_DEFAULT_DIMENSIONS = { width: 1280, height: 1024 };
 export const CHART_DEFAULT_LABELS = { upstream: '', downstream: '' };
-export const UPSTREAM_LABEL_OFFSET = 150;
+export const UPSTREAM_LABEL_OFFSET = 200;
 export const NODE_STATUS_Y_OFFSET = '.30em';
 export const NODE_LABEL_Y_OFFSET = 25;
 export const ANIMATION_DURATION = 750;


### PR DESCRIPTION

**Fix show schema in lineage :**
In the lineage, the node title only has the node name so when the lineage has two nodes to different schemas but with the same name, we can't differents between both 

Example issue:
![image](https://user-images.githubusercontent.com/26008569/154990462-4cd28c85-7f17-48e3-ae41-8fc1e5148d64.png)

Tests
![image](https://user-images.githubusercontent.com/26008569/154990980-01c3d1b6-2275-4d9e-afcf-0af7d958c433.png)


### Summary of Changes
on chart.ts file when textnode is append , it should return the next one code
`nodeEnter
    .append('text')
    .attr('dy', NODE_LABEL_Y_OFFSET)
    .attr('text-anchor', 'middle')
    .text((d, idx) => (idx !== 0 && d.data.data.name ? d.data.data.schema + '.' + d.data.data.name : ''));`

