### PR TITLE
feat: Elasticsearch 8 compatiblity

### DIFF
--- a/common/amundsen_common/models/index_map.py
+++ b/common/amundsen_common/models/index_map.py
@@ -13,102 +13,100 @@ import textwrap
 TABLE_INDEX_MAP = textwrap.dedent(
     """
     {
-    "settings": {
-      "analysis": {
-        "normalizer": {
-          "column_names_normalizer": {
-            "type": "custom",
-            "filter": ["lowercase"]
-          }
-        }
-      }
-    },
-    "mappings":{
-        "table":{
-          "properties": {
-            "name": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
+        "settings": {
+            "analysis": {
+                "normalizer": {
+                    "column_names_normalizer": {
+                        "type": "custom",
+                        "filter": ["lowercase"]
+                    }
                 }
-              }
-            },
-            "schema": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "display_name": {
-              "type": "keyword"
-            },
-            "last_updated_timestamp": {
-              "type": "date",
-              "format": "epoch_second"
-            },
-            "description": {
-              "type": "text",
-              "analyzer": "simple"
-            },
-            "column_names": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword",
-                  "normalizer": "column_names_normalizer"
-                }
-              }
-            },
-            "column_descriptions": {
-              "type": "text",
-              "analyzer": "simple"
-            },
-            "tags": {
-              "type": "keyword"
-            },
-            "badges": {
-              "type": "keyword"
-            },
-            "cluster": {
-              "type": "text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "database": {
-              "type": "text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "key": {
-              "type": "keyword"
-            },
-            "total_usage":{
-              "type": "long"
-            },
-            "unique_usage": {
-              "type": "long"
-            },
-            "programmatic_descriptions": {
-              "type": "text",
-              "analyzer": "simple"
             }
-          }
+        },
+        "mappings": {
+            "properties": {
+                "name": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "schema": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "display_name": {
+                    "type": "keyword"
+                },
+                "last_updated_timestamp": {
+                    "type": "date",
+                    "format": "epoch_second"
+                },
+                "description": {
+                    "type": "text",
+                    "analyzer": "simple"
+                },
+                "column_names": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword",
+                            "normalizer": "column_names_normalizer"
+                        }
+                    }
+                },
+                "column_descriptions": {
+                    "type": "text",
+                    "analyzer": "simple"
+                },
+                "tags": {
+                    "type": "keyword"
+                },
+                "badges": {
+                    "type": "keyword"
+                },
+                "cluster": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "database": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "key": {
+                    "type": "keyword"
+                },
+                "total_usage": {
+                    "type": "long"
+                },
+                "unique_usage": {
+                    "type": "long"
+                },
+                "programmatic_descriptions": {
+                    "type": "text",
+                    "analyzer": "simple"
+                }
+            }
         }
-      }
     }
     """
 )
@@ -117,142 +115,138 @@ DASHBOARD_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
     """
     {
         "settings": {
-          "analysis": {
-            "normalizer": {
-              "lowercase_normalizer": {
-                "type": "custom",
-                "char_filter": [],
-                "filter": ["lowercase", "asciifolding"]
-              }
-            }
-          }
-        },
-        "mappings":{
-            "dashboard":{
-              "properties": {
-                "group_name": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword",
-                      "normalizer": "lowercase_normalizer"
+            "analysis": {
+                "normalizer": {
+                    "lowercase_normalizer": {
+                        "type": "custom",
+                        "char_filter": [],
+                        "filter": ["lowercase", "asciifolding"]
                     }
-                  }
+                }
+            }
+        },
+        "mappings": {
+            "properties": {
+                "group_name": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                        }
+                    }
                 },
                 "name": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword",
-                      "normalizer": "lowercase_normalizer"
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                        }
                     }
-                  }
                 },
                 "description": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
                     }
-                  }
                 },
                 "group_description": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
                     }
-                  }
                 },
                 "query_names": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
                     }
-                  }
                 },
                 "chart_names": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
                     }
-                  }
                 },
                 "tags": {
-                  "type": "keyword"
+                    "type": "keyword"
                 },
                 "badges": {
-                  "type": "keyword"
+                    "type": "keyword"
                 }
-              }
             }
-          }
         }
+    }
     """
 )
 
 USER_INDEX_MAP = textwrap.dedent(
     """
     {
-    "mappings":{
-        "user":{
-          "properties": {
-            "email": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
+        "mappings": {
+            "properties": {
+                "email": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "first_name": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "last_name": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "full_name": {
+                    "type": "text",
+                    "analyzer": "simple",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "total_read": {
+                    "type": "long"
+                },
+                "total_own": {
+                    "type": "long"
+                },
+                "total_follow": {
+                    "type": "long"
                 }
-              }
-            },
-            "first_name": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "last_name": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "full_name": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "total_read":{
-              "type": "long"
-            },
-            "total_own": {
-              "type": "long"
-            },
-            "total_follow": {
-              "type": "long"
             }
-          }
         }
-      }
     }
     """
 )
@@ -261,79 +255,77 @@ FEATURE_INDEX_MAP = textwrap.dedent(
     """
     {
     "settings": {
-      "analysis": {
-        "normalizer": {
-          "lowercase_normalizer": {
-            "type": "custom",
-            "filter": ["lowercase"]
-          }
-        }
-      }
-    },
-    "mappings":{
-        "feature":{
-          "properties": {
-            "feature_group": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword",
-                  "normalizer": "lowercase_normalizer"
+        "analysis": {
+            "normalizer": {
+                "lowercase_normalizer": {
+                    "type": "custom",
+                    "filter": ["lowercase"]
                 }
-              }
+            }
+        }
+    },
+    "mappings": {
+        "properties": {
+            "feature_group": {
+                "type": "text",
+                "analyzer": "simple",
+                "fields": {
+                    "raw": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                    }
+                }
             },
             "feature_name": {
-              "type":"text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword",
-                  "normalizer": "lowercase_normalizer"
+                "type": "text",
+                "analyzer": "simple",
+                "fields": {
+                    "raw": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                    }
                 }
-              }
             },
             "version": {
-              "type": "keyword",
-              "normalizer": "lowercase_normalizer"
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
             },
             "key": {
-              "type": "keyword"
+                "type": "keyword"
             },
-            "total_usage":{
-              "type": "long"
+            "total_usage": {
+                "type": "long"
             },
             "status": {
-              "type": "keyword"
+                "type": "keyword"
             },
             "entity": {
-              "type": "keyword"
+                "type": "keyword"
             },
             "description": {
-              "type": "text"
+                "type": "text"
             },
             "availability": {
-              "type": "text",
-              "analyzer": "simple",
-              "fields": {
-                "raw": {
-                  "type": "keyword"
+                "type": "text",
+                "analyzer": "simple",
+                "fields": {
+                    "raw": {
+                        "type": "keyword"
+                    }
                 }
-              }
             },
             "badges": {
-              "type": "keyword"
+                "type": "keyword"
             },
             "tags": {
-              "type": "keyword"
+                "type": "keyword"
             },
             "last_updated_timestamp": {
-              "type": "date",
-              "format": "epoch_second"
+                "type": "date",
+                "format": "epoch_second"
             }
-          }
         }
-      }
     }
-    """
+}
+"""
 )

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.24.1'
+__version__ = '0.25.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/databuilder/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/databuilder/publisher/elasticsearch_publisher.py
@@ -90,11 +90,12 @@ class ElasticsearchPublisher(Publisher):
         cnt = 0
 
         # create new index with mapping
-        self.elasticsearch_client.indices.create(index=self.elasticsearch_new_index, body=self.elasticsearch_mapping,
-                                                 params={'include_type_name': 'true'})
+        self.elasticsearch_client.indices.create(index=self.elasticsearch_new_index, body=self.elasticsearch_mapping)
+
         for action in actions:
-            index_row = dict(index=dict(_index=self.elasticsearch_new_index,
-                                        _type=self.elasticsearch_type))
+            index_row = dict(index=dict(_index=self.elasticsearch_new_index))
+            action['resource_type'] = self.elasticsearch_type
+
             bulk_actions.append(index_row)
             bulk_actions.append(action)
             cnt += 1

--- a/databuilder/databuilder/task/search/document_mappings.py
+++ b/databuilder/databuilder/task/search/document_mappings.py
@@ -78,6 +78,8 @@ class SearchableResource(Document):
     usage = RankFeatures()  # values can be used to boost document search score
     last_updated_timestamp = Date()
 
+    resource_type = Keyword(required=True)
+
 
 class Table(SearchableResource):
     display_name = Text(required=True,

--- a/databuilder/example/scripts/sample_search_metadata_task.py
+++ b/databuilder/example/scripts/sample_search_metadata_task.py
@@ -1,0 +1,52 @@
+import os
+from elasticsearch import Elasticsearch
+from pyhocon import ConfigFactory
+
+from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
+from databuilder.job.job import DefaultJob
+from databuilder.task.search.search_metadata_to_elasticsearch_task import SearchMetadatatoElasticasearchTask
+
+es_host = os.getenv('CREDENTIALS_ELASTICSEARCH_PROXY_HOST', 'localhost')
+neo_host = os.getenv('CREDENTIALS_NEO4J_PROXY_HOST', 'localhost')
+
+es_port = os.getenv('CREDENTIALS_ELASTICSEARCH_PROXY_PORT', 9200)
+neo_port = os.getenv('CREDENTIALS_NEO4J_PROXY_PORT', 7687)
+
+es = Elasticsearch([
+    {'host': es_host, 'port': es_port},
+])
+
+neo4j_endpoint = f'bolt://{neo_host}:{neo_port}'
+
+neo4j_user = 'neo4j'
+neo4j_password = 'test'
+
+
+def run_search_metadata_task(resource_type: str):
+    task_config = {
+        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ENTITY_TYPE}': resource_type,
+        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ELASTICSEARCH_CLIENT_CONFIG_KEY}': es,
+        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ELASTICSEARCH_ALIAS_CONFIG_KEY}': f'{resource_type}_search_index',
+        'extractor.search_data.entity_type': resource_type,
+        'extractor.search_data.extractor.neo4j.graph_url': neo4j_endpoint,
+        'extractor.search_data.extractor.neo4j.neo4j_auth_user': neo4j_user,
+        'extractor.search_data.extractor.neo4j.neo4j_auth_pw': neo4j_password,
+        'extractor.search_data.extractor.neo4j.neo4j_encrypted': False,
+    }
+
+    job_config = ConfigFactory.from_dict({
+        **task_config,
+    })
+
+    extractor = Neo4jSearchDataExtractor()
+    task = SearchMetadatatoElasticasearchTask(extractor=extractor)
+
+    job = DefaultJob(conf=job_config, task=task)
+
+    job.launch()
+
+
+run_search_metadata_task('table')
+run_search_metadata_task('dashboard')
+run_search_metadata_task('user')
+run_search_metadata_task('feature')

--- a/databuilder/example/scripts/sample_search_metadata_task.py
+++ b/databuilder/example/scripts/sample_search_metadata_task.py
@@ -1,4 +1,8 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
+
 from elasticsearch import Elasticsearch
 from pyhocon import ConfigFactory
 

--- a/databuilder/example/scripts/sample_search_metadata_task.py
+++ b/databuilder/example/scripts/sample_search_metadata_task.py
@@ -59,7 +59,6 @@ def run_search_metadata_task(resource_type: str):
 
 
 if __name__ == "__main__":
-    run_search_metadata_task('table')
-    run_search_metadata_task('dashboard')
-    run_search_metadata_task('user')
-    run_search_metadata_task('feature')
+    for resource_type in ['table', 'dashboard', 'user', 'feature']:
+        run_search_metadata_task(resource_type)
+

--- a/databuilder/example/scripts/sample_search_metadata_task.py
+++ b/databuilder/example/scripts/sample_search_metadata_task.py
@@ -24,14 +24,22 @@ neo4j_password = 'test'
 
 def run_search_metadata_task(resource_type: str):
     task_config = {
-        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ENTITY_TYPE}': resource_type,
-        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ELASTICSEARCH_CLIENT_CONFIG_KEY}': es,
-        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ELASTICSEARCH_ALIAS_CONFIG_KEY}': f'{resource_type}_search_index',
-        'extractor.search_data.entity_type': resource_type,
-        'extractor.search_data.extractor.neo4j.graph_url': neo4j_endpoint,
-        'extractor.search_data.extractor.neo4j.neo4j_auth_user': neo4j_user,
-        'extractor.search_data.extractor.neo4j.neo4j_auth_pw': neo4j_password,
-        'extractor.search_data.extractor.neo4j.neo4j_encrypted': False,
+        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ENTITY_TYPE}':
+            resource_type,
+        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ELASTICSEARCH_CLIENT_CONFIG_KEY}':
+            es,
+        f'task.search_metadata_to_elasticsearch.{SearchMetadatatoElasticasearchTask.ELASTICSEARCH_ALIAS_CONFIG_KEY}':
+            f'{resource_type}_search_index',
+        'extractor.search_data.entity_type':
+            resource_type,
+        'extractor.search_data.extractor.neo4j.graph_url':
+            neo4j_endpoint,
+        'extractor.search_data.extractor.neo4j.neo4j_auth_user':
+            neo4j_user,
+        'extractor.search_data.extractor.neo4j.neo4j_auth_pw':
+            neo4j_password,
+        'extractor.search_data.extractor.neo4j.neo4j_encrypted':
+            False,
     }
 
     job_config = ConfigFactory.from_dict({

--- a/databuilder/example/scripts/sample_search_metadata_task.py
+++ b/databuilder/example/scripts/sample_search_metadata_task.py
@@ -58,7 +58,8 @@ def run_search_metadata_task(resource_type: str):
     job.launch()
 
 
-run_search_metadata_task('table')
-run_search_metadata_task('dashboard')
-run_search_metadata_task('user')
-run_search_metadata_task('feature')
+if __name__ == "__main__":
+    run_search_metadata_task('table')
+    run_search_metadata_task('dashboard')
+    run_search_metadata_task('user')
+    run_search_metadata_task('feature')

--- a/databuilder/example/scripts/sample_search_metadata_task.py
+++ b/databuilder/example/scripts/sample_search_metadata_task.py
@@ -61,4 +61,3 @@ def run_search_metadata_task(resource_type: str):
 if __name__ == "__main__":
     for resource_type in ['table', 'dashboard', 'user', 'feature']:
         run_search_metadata_task(resource_type)
-

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.5.2'
+__version__ = '6.6.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/tests/unit/publisher/test_elasticsearch_publisher.py
+++ b/databuilder/tests/unit/publisher/test_elasticsearch_publisher.py
@@ -69,13 +69,14 @@ class TestElasticsearchPublisher(unittest.TestCase):
             # ensure indices create endpoint was called
             default_mapping = ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING
             self.mock_es_client.indices.create.assert_called_once_with(index=self.test_es_new_index,
-                                                                       body=default_mapping,
-                                                                       params={'include_type_name': 'true'})
+                                                                       body=default_mapping)
 
             # bulk endpoint called once
             self.mock_es_client.bulk.assert_called_once_with(
-                [{'index': {'_type': self.test_doc_type, '_index': self.test_es_new_index}},
-                 {'KEY_DOESNOT_MATTER': 'NO_VALUE', 'KEY_DOESNOT_MATTER2': 'NO_VALUE2'}]
+                [{'index': {'_index': self.test_es_new_index}},
+                 {'KEY_DOESNOT_MATTER': 'NO_VALUE',
+                  'KEY_DOESNOT_MATTER2': 'NO_VALUE2',
+                  'resource_type': 'test_doc_type'}]
             )
 
             # update alias endpoint called once
@@ -103,13 +104,14 @@ class TestElasticsearchPublisher(unittest.TestCase):
             # ensure indices create endpoint was called
             default_mapping = ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING
             self.mock_es_client.indices.create.assert_called_once_with(index=self.test_es_new_index,
-                                                                       body=default_mapping,
-                                                                       params={'include_type_name': 'true'})
+                                                                       body=default_mapping)
 
             # bulk endpoint called once
             self.mock_es_client.bulk.assert_called_once_with(
-                [{'index': {'_type': self.test_doc_type, '_index': self.test_es_new_index}},
-                 {'KEY_DOESNOT_MATTER': 'NO_VALUE', 'KEY_DOESNOT_MATTER2': 'NO_VALUE2'}]
+                [{'index': {'_index': self.test_es_new_index}},
+                 {'KEY_DOESNOT_MATTER': 'NO_VALUE',
+                  'KEY_DOESNOT_MATTER2': 'NO_VALUE2',
+                  'resource_type': 'test_doc_type'}]
             )
 
             # update alias endpoint called once

--- a/docker-amundsen-local.yml
+++ b/docker-amundsen-local.yml
@@ -18,7 +18,7 @@ services:
       networks:
         - amundsennet
   elasticsearch:
-      image: elasticsearch:7.13.3
+      image: elasticsearch:8.0.0
       container_name: es_amundsen
       ports:
           - 9200:9200
@@ -30,6 +30,7 @@ services:
           hard: 65536
       environment:
         - discovery.type=single-node
+        - xpack.security.enabled=false
   amundsensearch:
       build:
         context: .

--- a/docker-amundsen.yml
+++ b/docker-amundsen.yml
@@ -20,7 +20,7 @@ services:
       networks:
         - amundsennet
   elasticsearch:
-      image: elasticsearch:7.13.3
+      image: elasticsearch:8.0.0
       container_name: es_amundsen
       ports:
           - 9200:9200
@@ -34,6 +34,7 @@ services:
           hard: 65536
       environment:
         - discovery.type=single-node
+        - xpack.security.enabled=false
   amundsensearch:
       image: amundsendev/amundsen-search:2.11.1
       container_name: amundsensearch

--- a/search/README.md
+++ b/search/README.md
@@ -18,7 +18,9 @@ For information about Amundsen and our other services, refer to this [README.md]
 ## Requirements
 
 - Python >= 3.6
-- elasticsearch 6.x (currently it doesn't support 7.x)
+- Elasticsearch, supported versions:
+    - 7.x
+    - 8.0.0
 
 ## Doc
 - https://www.amundsen.io/amundsen

--- a/search/search_service/proxy/es_search_proxy.py
+++ b/search/search_service/proxy/es_search_proxy.py
@@ -41,7 +41,8 @@ class ElasticsearchProxy():
         'column': 'column_names.raw',
         'database': 'database.raw',
         'cluster': 'cluster.raw',
-        'description': 'description'
+        'description': 'description',
+        'resource_type': 'resource_type'
     }
 
     # mapping to translate request for dashboard resources
@@ -54,7 +55,8 @@ class ElasticsearchProxy():
         'product': 'product',
         'tag': 'tags',
         'description': 'description',
-        'last_successful_run_timestamp': 'last_successful_run_timestamp'
+        'last_successful_run_timestamp': 'last_successful_run_timestamp',
+        'resource_type': 'resource_type'
     }
 
     # mapping to translate request for feature resources
@@ -68,14 +70,16 @@ class ElasticsearchProxy():
         'availability': 'availability.raw',
         'tags': 'tags',
         'badges': 'badges',
-        'description': 'description'
+        'description': 'description',
+        'resource_type': 'resource_type'
     }
 
     USER_MAPPING = {
         'full_name': 'full_name',
         'first_name': 'first_name',
         'last_name': 'last_name',
-        'email': 'email'
+        'email': 'email',
+        'resource_type': 'resource_type'
     }
 
     RESOUCE_TO_MAPPING = {
@@ -240,7 +244,7 @@ class ElasticsearchProxy():
             if r.success():
                 results_count = r.hits.total.value
                 if results_count > 0:
-                    resource_type = r.hits.hits[0]._type
+                    resource_type = r.hits.hits[0]._source['resource_type']
                     results = []
                     for search_result in r.hits.hits:
                         # mapping gives all the fields in the response

--- a/search/search_service/proxy/es_search_proxy.py
+++ b/search/search_service/proxy/es_search_proxy.py
@@ -253,13 +253,17 @@ class ElasticsearchProxy():
                         for f in fields.keys():
                             # remove "raw" from mapping value
                             field = fields[f].split('.')[0]
-                            result_for_field = search_result._source[field]
-                            # AttrList and AttrDict are not json serializable
-                            if type(result_for_field) is AttrList:
-                                result_for_field = list(result_for_field)
-                            elif type(result_for_field) is AttrDict:
-                                result_for_field = result_for_field.to_dict()
-                            result[f] = result_for_field
+                            try:
+                                result_for_field = search_result._source[field]
+                                # AttrList and AttrDict are not json serializable
+                                if type(result_for_field) is AttrList:
+                                    result_for_field = list(result_for_field)
+                                elif type(result_for_field) is AttrDict:
+                                    result_for_field = result_for_field.to_dict()
+                                result[f] = result_for_field
+                            except KeyError:
+                                logging.debug(f'Field: {field} missing in search response.')
+                                pass
                         result["search_score"] = search_result._score
                         results.append(result)
                     # replace empty results with actual results
@@ -319,6 +323,7 @@ class ElasticsearchProxy():
         responses = self.execute_queries(queries=queries,
                                          page_index=page_index,
                                          results_per_page=results_per_page)
+        print(responses)
 
         formatted_response = self._format_response(page_index=page_index,
                                                    results_per_page=results_per_page,

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 oidc = ['flaskoidc>=1.0.0']
 

--- a/search/tests/unit/proxy/fixtures.py
+++ b/search/tests/unit/proxy/fixtures.py
@@ -170,7 +170,8 @@ RESPONSE_1 = [
                             "mock_tag_3"
                         ],
                         "total_usage": 74841,
-                        "unique_usage": 457
+                        "unique_usage": 457,
+                        "resource_type": "table"
                     }
                 },
                 {
@@ -206,7 +207,8 @@ RESPONSE_1 = [
                             "mock_tag_6"
                         ],
                         "total_usage": 4715,
-                        "unique_usage": 254
+                        "unique_usage": 254,
+                        "resource_type": "table"
                     }
                 }
             ]
@@ -288,7 +290,8 @@ RESPONSE_2 = [
                             "mock_tag_3"
                         ],
                         "total_usage": 74841,
-                        "unique_usage": 457
+                        "unique_usage": 457,
+                        "resource_type": "table"
                     }
                 },
                 {
@@ -324,7 +327,8 @@ RESPONSE_2 = [
                             "mock_tag_6"
                         ],
                         "total_usage": 4715,
-                        "unique_usage": 254
+                        "unique_usage": 254,
+                        "resource_type": "table"
                     }
                 }
             ]
@@ -366,7 +370,8 @@ RESPONSE_2 = [
                         "team_name": "Amundsen",
                         "total_follow": 0,
                         "total_own": 1,
-                        "total_read": 0
+                        "total_read": 0,
+                        "resource_type": "user"
                     }
                 }
             ]
@@ -406,7 +411,8 @@ RESPONSE_2 = [
                         "status": "active",
                         "tags": [],
                         "total_usage": 0,
-                        "version": 1
+                        "version": 1,
+                        "resource_type": "feature"
                     }
                 },
                 {
@@ -426,7 +432,8 @@ RESPONSE_2 = [
                         "status": "active",
                         "tags": [],
                         "total_usage": 10,
-                        "version": 1
+                        "version": 1,
+                        "resource_type": "feature"
                     }
                 },
                 {
@@ -448,7 +455,8 @@ RESPONSE_2 = [
                         "status": "active",
                         "tags": [],
                         "total_usage": 3,
-                        "version": 2
+                        "version": 2,
+                        "resource_type": "feature"
                     }
                 }
             ]

--- a/search/tests/unit/proxy/test_elasticsearch.py
+++ b/search/tests/unit/proxy/test_elasticsearch.py
@@ -37,6 +37,7 @@ class MockSearchResult:
                  tags: Iterable[Tag],
                  badges: Iterable[Tag],
                  last_updated_timestamp: int,
+                 resource_type: str,
                  programmatic_descriptions: List[str] = None) -> None:
         self.name = name
         self.key = key
@@ -49,6 +50,7 @@ class MockSearchResult:
         self.badges = badges
         self.last_updated_timestamp = last_updated_timestamp
         self.programmatic_descriptions = programmatic_descriptions
+        self.resource_type = resource_type
 
 
 class MockUserSearchResult:
@@ -63,7 +65,8 @@ class MockUserSearchResult:
                  is_active: bool,
                  employee_type: str,
                  role_name: str,
-                 new_attr: str) -> None:
+                 new_attr: str,
+                 resource_type: str) -> None:
         self.full_name = full_name
         self.first_name = first_name
         self.last_name = last_name
@@ -75,6 +78,7 @@ class MockUserSearchResult:
         self.employee_type = employee_type
         self.new_attr = new_attr
         self.role_name = role_name
+        self.resource_type = resource_type
 
 
 class Response:
@@ -111,6 +115,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         self.mock_empty_badge = []  # type: List[Tag]
         self.mock_empty_tag = []  # type: List[Tag]
         self.mock_result1 = MockSearchResult(name='test_table',
+                                             resource_type='table',
                                              key='test_key',
                                              description='test_description',
                                              cluster='gold',
@@ -123,6 +128,7 @@ class TestElasticsearchProxy(unittest.TestCase):
                                              programmatic_descriptions=[])
 
         self.mock_result2 = MockSearchResult(name='test_table2',
+                                             resource_type='table',
                                              key='test_key2',
                                              description='test_description2',
                                              cluster='gold',
@@ -155,7 +161,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                  is_active=True,
                                                  employee_type='FTE',
                                                  role_name='swe',
-                                                 new_attr='aaa')
+                                                 new_attr='aaa',
+                                                 resource_type='user', )
 
     def test_setup_client(self) -> None:
         self.es_proxy = ElasticsearchProxy(
@@ -165,7 +172,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         )
         a = self.es_proxy.elasticsearch
         for client in [a, a.cat, a.cluster, a.indices, a.ingest, a.nodes, a.snapshot, a.tasks]:
-            _host = client.transport.hosts[0]   # type: ignore
+            _host = client.transport.hosts[0]  # type: ignore
             self.assertEqual(_host['host'], "0.0.0.0")
             self.assertEqual(_host['port'], 9200)
 

--- a/search/tests/unit/proxy/test_es_search_proxy.py
+++ b/search/tests/unit/proxy/test_es_search_proxy.py
@@ -96,7 +96,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   ],
                                                   "database": "mock_db",
                                                   "cluster": "mock_cluster",
-                                                  "search_score": 804.52716
+                                                  "search_score": 804.52716,
+                                                  "resource_type": "table"
                                               },
                                               {
                                                   "key": "mock_db://mock_cluster.mock_schema/mock_table_2",
@@ -116,7 +117,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   ],
                                                   "database": "mock_db",
                                                   "cluster": "mock_cluster",
-                                                  "search_score": 9.104584
+                                                  "search_score": 9.104584,
+                                                  "resource_type": "table"
                                               }
                                           ],
                                           "total_results": 2
@@ -168,7 +170,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   ],
                                                   "database": "mock_db",
                                                   "cluster": "mock_cluster",
-                                                  "search_score": 804.52716
+                                                  "search_score": 804.52716,
+                                                  "resource_type": "table"
                                               },
                                               {
                                                   "key": "mock_db://mock_cluster.mock_schema/mock_table_2",
@@ -188,7 +191,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   ],
                                                   "database": "mock_db",
                                                   "cluster": "mock_cluster",
-                                                  "search_score": 9.104584
+                                                  "search_score": 9.104584,
+                                                  "resource_type": "table"
                                               }
                                           ],
                                           "total_results": 2
@@ -200,7 +204,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   "first_name": "Allison",
                                                   "last_name": "Suarez Miranda",
                                                   "email": "mock_user@amundsen.com",
-                                                  "search_score": 61.40606
+                                                  "search_score": 61.40606,
+                                                  "resource_type": "user"
                                               }
                                           ],
                                           "total_results": 1
@@ -218,7 +223,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   "availability": None,
                                                   "tags": [],
                                                   "badges": [],
-                                                  "search_score": 62.66787
+                                                  "search_score": 62.66787,
+                                                  "resource_type": "feature"
                                               },
                                               {
                                                   "key": "fg_2/feature_2/1",
@@ -231,7 +237,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   "availability": None,
                                                   "tags": [],
                                                   "badges": [],
-                                                  "search_score": 62.66787
+                                                  "search_score": 62.66787,
+                                                  "resource_type": "feature"
                                               },
                                               {
                                                   "key": "fg_3/feature_3/2",
@@ -246,7 +253,8 @@ class TestElasticsearchProxy(unittest.TestCase):
                                                   "badges": [
                                                       "pii"
                                                   ],
-                                                  "search_score": 62.66787
+                                                  "search_score": 62.66787,
+                                                  "resource_type": "feature"
                                               }
                                           ],
                                           "total_results": 3


### PR DESCRIPTION
### Summary of Changes

Document types were already deprecated in ES 7 but are completely removed in ES 8. This PR proposes minor refactor which makes our search proxy and databuilder elasticsearch publisher job & task compatible with Elasticsearch 8 and also backwards compatible with Elasticsearch 7. 

**The change proposes:**

- stop relying on `_type` meta field (not available in ES 8, deprecated in ES 7)
- add mandatory `resource_type` keyword field in `SearchableResource`
- populate mandatory `resource_type` keyword field in databuilder jobs/tasks relying on `elasticsearch_type` property
- rely on `resource_type` in search proxy to properly select which resource is being returned from elasticsearch
- **discontinuation of Elasticsearch 6.x support as it's reached it's EOL https://www.elastic.co/support/eol** 

The proposal builds on best-practice suggestion from Elasticsearch docs: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html

### Tests

- adjusted tests

### Documentation

- updated docs to highlight that both ES 7 and 8 are compatible with Amundsen (removed ES 6 from list)

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
