### PR TITLE
fix:  helm chart: Add forgotten annotations to ingress template.

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/ingress-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/ingress-frontend.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "common.names.name" . }}-{{ $.Values.frontEnd.serviceName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+     {{- range $key, $value := .Values.ingress.annotations }}
+       {{ $key }}: {{ $value | quote }}
+     {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
fix – Helm chart has forgotten directive in ingress template.

### Summary of Changes

Added annotations template.

### Tests

I needed certmanager annotations in my k8s cluster, and I noticed it missed.
I fixed and tested it.


