### PR TITLE
chore: bump common version in requirements-common.txt

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.24.0
+amundsen-common>=0.25.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
### Summary of Changes

bump common version in requirements-common.txt to 0.25.0 after Elasticsearch 8 compatibility introduction

### Tests

n/a

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
