### PR TITLE
chore: add upper boundary for amundsen-common pin

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.25.0,<0.26.0
+amundsen-common>=0.26.0,<0.27.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.25.0
+amundsen-common>=0.25.0,<0.26.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
### Summary of Changes

Currently pinning with only lower boundary makes our packages vulnerable to breaking changes in Amundsen common. This PR adds upper boundary so our packages are relying on common within range of neighbouring versions so we minimize risk of creating incompatible combinations.

Previous approach resulted in a fact that a significantly older version of any service (databuilder/frontend/search/metadata) was relying on the newest possible version of common (established on pip install) which could (and actually did on one occasion) break things.

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
