### PR TITLE
feat: OpenSearch search plugin

### DIFF
--- a/frontend/amundsen_application/api/__init__.py
+++ b/frontend/amundsen_application/api/__init__.py
@@ -14,14 +14,17 @@ LOGGER = logging.getLogger(__name__)
 
 
 def init_routes(app: Flask) -> None:
+    frontend_base = app.config.get('FRONTEND_BASE')
+
     app.add_url_rule('/healthcheck', 'healthcheck', healthcheck)
-    app.add_url_rule('/', 'index', index, defaults={'path': ''})  # also functions as catch_all
-    app.add_url_rule('/<path:path>', 'index', index)  # catch_all
+    app.add_url_rule('/', 'index', index, defaults={'path': '',
+                                                    'frontend_base': frontend_base})  # also functions as catch_all
+    app.add_url_rule('/<path:path>', 'index', index, defaults={'frontend_base': frontend_base})  # catch_all
 
 
-def index(path: str) -> Any:
+def index(path: str, frontend_base: str) -> Any:
     try:
-        return render_template("index.html", env=ENVIRONMENT)  # pragma: no cover
+        return render_template("index.html", env=ENVIRONMENT, frontend_base=frontend_base)  # pragma: no cover
     except jinja2.exceptions.TemplateNotFound as e:
         LOGGER.error("index.html template not found, have you built the front-end JS (npm run build in static/?")
         raise e

--- a/frontend/amundsen_application/static/templates/index.html
+++ b/frontend/amundsen_application/static/templates/index.html
@@ -20,6 +20,14 @@
 
     <%= htmlWebpackPlugin.tags.headTags %>
 
+    <script id="myxml" type="text/xmldata">
+      <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+        <ShortName>Amundsen</ShortName>
+        <Description>Search Amundsen</Description>
+        <Url type="text/html" method="get" template="{{ frontend_base }}/search?term={searchTerms}&amp;resource=table&amp;index=0"/>
+      </OpenSearchDescription>
+    </script>
+
     <!-- Do not remove: some analytics scripts attach to this. -->
     <script id="analyitcs-script-stub"></script>
   </head>


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This change adds an OpenSearch search plugin to Amundsen. If a user types in the url followed by a search term into their browser, they can automatically trigger the search from there. See [this doc](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) for further details.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
