### PR TITLE
fix: Backwards-compatibility changes for ESv6.x in the (new) es_search_proxy

### DIFF
--- a/search/search_service/proxy/es_search_proxy.py
+++ b/search/search_service/proxy/es_search_proxy.py
@@ -246,7 +246,10 @@ class ElasticsearchProxy():
 
         for r in responses:
             if r.success():
-                results_count = r.hits.total.value
+                if isinstance(r.hits.total, AttrDict):
+                    results_count = r.hits.total.value
+                else:
+                    results_count = r.hits.total
                 if results_count > 0:
                     resource_type = r.hits.hits[0]._source['resource_type']
                     results = []
@@ -351,7 +354,10 @@ class ElasticsearchProxy():
 
         response = response[0]
         if response.success():
-            results_count = response.hits.total.value
+            if isinstance(response.hits.total, AttrDict):
+                results_count = response.hits.total.value
+            else:
+                results_count = response.hits.total
             if results_count == 1:
                 es_result = response.hits.hits[0]
                 return es_result


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

These changes make the (new) es_search_proxy backwards-compatible with ES v6.x or earlier and gracefully handles the api response 

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
