### PR TITLE
refactor: Change error handling in ComplexTypeTransformer

### DIFF
--- a/databuilder/databuilder/transformer/complex_type_transformer.py
+++ b/databuilder/databuilder/transformer/complex_type_transformer.py
@@ -33,12 +33,12 @@ class ComplexTypeTransformer(Transformer):
             module_name, function_name = parsing_function.rsplit(".", 1)
             mod = importlib.import_module(module_name)
             self._parsing_function = getattr(mod, function_name)
-        except Exception as e:
-            LOGGER.error(f"Invalid parsing function provided to ComplexTypeTransformer: {e}")
+        except (ValueError, ModuleNotFoundError, AttributeError):
+            raise Exception("Invalid parsing function provided to ComplexTypeTransformer")
 
     def transform(self, record: Any) -> TableMetadata:
         if not isinstance(record, TableMetadata):
-            raise Exception("ComplexTypeTransformer expects record of type TableMetadata")
+            raise Exception(f"ComplexTypeTransformer expects record of type TableMetadata, received {type(record)}")
 
         for column in record.columns:
             try:

--- a/databuilder/databuilder/transformer/complex_type_transformer.py
+++ b/databuilder/databuilder/transformer/complex_type_transformer.py
@@ -8,6 +8,7 @@ from typing import Any
 from pyhocon import ConfigTree
 
 from databuilder.models.table_metadata import TableMetadata
+from databuilder.models.type_metadata import ScalarTypeMetadata
 from databuilder.transformer.base_transformer import Transformer
 
 PARSING_FUNCTION = 'parsing_function'
@@ -44,8 +45,10 @@ class ComplexTypeTransformer(Transformer):
                 column.set_column_key(record._get_col_key(column))
                 column.set_type_metadata(self._parsing_function(column.type, column.name, column))
             except Exception as e:
+                # Default to scalar type if the type string cannot be parsed
+                column.set_type_metadata(ScalarTypeMetadata(name=column.name, parent=column, type_str=column.type))
                 self.failure_count += 1
-                LOGGER.warning(f"Could not parse type_metadata for column {column.name} in table {record.name}: {e}")
+                LOGGER.warning(f"Could not parse type for column {column.name} in table {record.name}: {e}")
             else:
                 self.success_count += 1
 

--- a/databuilder/databuilder/transformer/complex_type_transformer.py
+++ b/databuilder/databuilder/transformer/complex_type_transformer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import logging
 from typing import Any
 
 from pyhocon import ConfigTree
@@ -10,6 +11,8 @@ from databuilder.models.table_metadata import TableMetadata
 from databuilder.transformer.base_transformer import Transformer
 
 PARSING_FUNCTION = 'parsing_function'
+
+LOGGER = logging.getLogger(__name__)
 
 
 class ComplexTypeTransformer(Transformer):
@@ -21,21 +24,30 @@ class ComplexTypeTransformer(Transformer):
     field with the parsed results contained in a TypeMetadata object.
     """
     def init(self, conf: ConfigTree) -> None:
+        self.success_count = 0
+        self.failure_count = 0
+
         try:
             parsing_function = conf.get_string(PARSING_FUNCTION)
             module_name, function_name = parsing_function.rsplit(".", 1)
             mod = importlib.import_module(module_name)
             self._parsing_function = getattr(mod, function_name)
-        except (ValueError, ModuleNotFoundError, AttributeError):
-            raise Exception("Invalid parsing function provided to ComplexTypeTransformer")
+        except Exception as e:
+            LOGGER.error(f"Invalid parsing function provided to ComplexTypeTransformer: {e}")
 
     def transform(self, record: Any) -> TableMetadata:
         if not isinstance(record, TableMetadata):
             raise Exception("ComplexTypeTransformer expects record of type TableMetadata")
 
         for column in record.columns:
-            column.set_column_key(record._get_col_key(column))
-            column.set_type_metadata(self._parsing_function(column.type, column.name, column))
+            try:
+                column.set_column_key(record._get_col_key(column))
+                column.set_type_metadata(self._parsing_function(column.type, column.name, column))
+            except Exception as e:
+                self.failure_count += 1
+                LOGGER.warning(f"Could not parse type_metadata for column {column.name} in table {record.name}: {e}")
+            else:
+                self.success_count += 1
 
         return record
 

--- a/databuilder/databuilder/transformer/complex_type_transformer.py
+++ b/databuilder/databuilder/transformer/complex_type_transformer.py
@@ -28,13 +28,10 @@ class ComplexTypeTransformer(Transformer):
         self.success_count = 0
         self.failure_count = 0
 
-        try:
-            parsing_function = conf.get_string(PARSING_FUNCTION)
-            module_name, function_name = parsing_function.rsplit(".", 1)
-            mod = importlib.import_module(module_name)
-            self._parsing_function = getattr(mod, function_name)
-        except (ValueError, ModuleNotFoundError, AttributeError):
-            raise Exception("Invalid parsing function provided to ComplexTypeTransformer")
+        parsing_function = conf.get_string(PARSING_FUNCTION)
+        module_name, function_name = parsing_function.rsplit(".", 1)
+        mod = importlib.import_module(module_name)
+        self._parsing_function = getattr(mod, function_name)
 
     def transform(self, record: Any) -> TableMetadata:
         if not isinstance(record, TableMetadata):

--- a/databuilder/databuilder/utils/hive_complex_type_parser.py
+++ b/databuilder/databuilder/utils/hive_complex_type_parser.py
@@ -5,8 +5,7 @@ import logging
 from typing import Union
 
 from pyparsing import (
-    Forward, Group, Keyword, OneOrMore, Optional, ParseException, Word, alphanums, delimitedList, nestedExpr, nums,
-    originalTextFor,
+    Forward, Group, Keyword, OneOrMore, Optional, Word, alphanums, delimitedList, nestedExpr, nums, originalTextFor,
 )
 
 from databuilder.models.table_metadata import ColumnMetadata
@@ -55,14 +54,7 @@ complex_type = (array_type("array_type") | map_type("map_type") | struct_type("s
 
 def parse_hive_type(type_str: str, name: str, parent: Union[ColumnMetadata, TypeMetadata]) -> TypeMetadata:
     type_str = type_str.lower()
-    try:
-        parsed_type = complex_type.parseString(type_str, parseAll=True)
-    except ParseException:
-        # Default to scalar type if the type string cannot be parsed
-        LOGGER.warning(f"Could not parse type string, so defaulting to scalar value for type: {type_str}")
-        return ScalarTypeMetadata(name=name,
-                                  parent=parent,
-                                  type_str=type_str)
+    parsed_type = complex_type.parseString(type_str, parseAll=True)
 
     if parsed_type.scalar_type:
         return ScalarTypeMetadata(name=name,

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.7.2'
+__version__ = '6.7.3'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/tests/unit/transformer/test_complex_type_transformer.py
+++ b/databuilder/tests/unit/transformer/test_complex_type_transformer.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
-from databuilder.models.type_metadata import ArrayTypeMetadata, ScalarTypeMetadata, TypeMetadata
+from databuilder.models.type_metadata import (
+    ArrayTypeMetadata, ScalarTypeMetadata, TypeMetadata,
+)
 from databuilder.transformer.complex_type_transformer import PARSING_FUNCTION, ComplexTypeTransformer
 
 

--- a/databuilder/tests/unit/transformer/test_complex_type_transformer.py
+++ b/databuilder/tests/unit/transformer/test_complex_type_transformer.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
 from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
-from databuilder.models.type_metadata import ArrayTypeMetadata, TypeMetadata
+from databuilder.models.type_metadata import ArrayTypeMetadata, ScalarTypeMetadata, TypeMetadata
 from databuilder.transformer.complex_type_transformer import PARSING_FUNCTION, ComplexTypeTransformer
 
 
@@ -53,6 +53,10 @@ class TestComplexTypeTransformer(unittest.TestCase):
             [column]
         )
 
+        default_scalar_type = ScalarTypeMetadata(name='col1',
+                                                 parent=column,
+                                                 type_str='array<array<int>>')
+
         with patch.object(transformer, '_parsing_function') as mock:
             mock.side_effect = MagicMock(side_effect=Exception('Could not parse'))
 
@@ -61,7 +65,7 @@ class TestComplexTypeTransformer(unittest.TestCase):
             self.assertEqual(transformer.success_count, 0)
             self.assertEqual(transformer.failure_count, 1)
             for actual in result.columns:
-                self.assertEqual(actual.get_type_metadata(), None)
+                self.assertEqual(actual.get_type_metadata(), default_scalar_type)
 
     def test_hive_parser_usage(self) -> None:
         transformer = ComplexTypeTransformer()

--- a/databuilder/tests/unit/transformer/test_complex_type_transformer.py
+++ b/databuilder/tests/unit/transformer/test_complex_type_transformer.py
@@ -19,24 +19,24 @@ class TestComplexTypeTransformer(unittest.TestCase):
         config = ConfigFactory.from_dict({
             PARSING_FUNCTION: 'invalid_function',
         })
-        transformer.init(conf=config)
-        self.assertFalse(hasattr(transformer, '_parsing_function'))
+        with self.assertRaises(Exception):
+            transformer.init(conf=config)
 
     def test_invalid_parsing_function_invalid_module(self) -> None:
         transformer = ComplexTypeTransformer()
         config = ConfigFactory.from_dict({
             PARSING_FUNCTION: 'invalid_module.invalid_function',
         })
-        transformer.init(conf=config)
-        self.assertFalse(hasattr(transformer, '_parsing_function'))
+        with self.assertRaises(Exception):
+            transformer.init(conf=config)
 
     def test_invalid_parsing_function_invalid_function(self) -> None:
         transformer = ComplexTypeTransformer()
         config = ConfigFactory.from_dict({
             PARSING_FUNCTION: 'databuilder.utils.hive_complex_type_parser.invalid_function',
         })
-        transformer.init(conf=config)
-        self.assertFalse(hasattr(transformer, '_parsing_function'))
+        with self.assertRaises(Exception):
+            transformer.init(conf=config)
 
     def test_hive_parser_with_failures(self) -> None:
         transformer = ComplexTypeTransformer()

--- a/databuilder/tests/unit/utils/test_hive_complex_type_parser.py
+++ b/databuilder/tests/unit/utils/test_hive_complex_type_parser.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+from pyparsing import ParseException
+
 from databuilder.models.table_metadata import ColumnMetadata
 from databuilder.models.type_metadata import (
     ArrayTypeMetadata, MapTypeMetadata, ScalarTypeMetadata, StructTypeMetadata,
@@ -282,25 +284,16 @@ class TestHiveComplexTypeParser(unittest.TestCase):
         column = ColumnMetadata('col1', None, 'array<array<int*>>', 0)
         column.set_column_key(self.column_key)
 
-        default_scalar_type = ScalarTypeMetadata(name='col1',
-                                                 parent=column,
-                                                 type_str='array<array<int*>>')
-
-        actual = parse_hive_type(column.type, column.name, column)
-        self.assertEqual(actual, default_scalar_type)
+        with self.assertRaises(ParseException):
+            parse_hive_type(column.type, column.name, column)
 
     def test_transform_invalid_struct_inner_type(self) -> None:
         column = ColumnMetadata('col1', None, 'struct<nest1:varchar(256)å,'
                                               'nest2:<derived from deserializer>>', 0)
         column.set_column_key(self.column_key)
 
-        default_scalar_type = ScalarTypeMetadata(name='col1',
-                                                 parent=column,
-                                                 type_str='struct<nest1:varchar(256)å,'
-                                                          'nest2:<derived from deserializer>>')
-
-        actual = parse_hive_type(column.type, column.name, column)
-        self.assertEqual(actual, default_scalar_type)
+        with self.assertRaises(ParseException):
+            parse_hive_type(column.type, column.name, column)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Prior to this change, if there was anything that went wrong in the `ComplexTypeTransformer` then an exception would be thrown. Since `TypeMetadata` is an optional field for columns, if anything fails in this transformer it makes more sense to log the issues rather than throw exceptions so that any process using the transformer can continue.

### Tests

Updated related tests in `test_complex_type_transformer.py` and added a test for if the parsing function fails.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
