### PR TITLE
fix: add annotations to ingress in helm chart

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/ingress-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/ingress-frontend.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "common.names.name" . }}-{{ $.Values.frontEnd.serviceName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end}}  
 spec:
 {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
### Summary of Changes
The ingress annotations are [specified in the documentation](https://github.com/amundsen-io/amundsen/tree/main/amundsen-kube-helm#ingress-support). But they are not in a chart's template.

### Tests
N/A

### Documentation
N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does