### PR TITLE
fix: open file in read mode and close on cleanup for ElasticsearchPublisher

### DIFF
--- a/databuilder/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/databuilder/publisher/elasticsearch_publisher.py
@@ -44,7 +44,7 @@ class ElasticsearchPublisher(Publisher):
         self.conf = conf
 
         self.file_path = self.conf.get_string(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY)
-        self.file_mode = self.conf.get_string(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY, 'w')
+        self.file_mode = self.conf.get_string(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY, 'r')
 
         self.elasticsearch_type = self.conf.get_string(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY)
         self.elasticsearch_client = self.conf.get(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY)

--- a/databuilder/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/databuilder/publisher/elasticsearch_publisher.py
@@ -124,5 +124,13 @@ class ElasticsearchPublisher(Publisher):
         # perform alias update and index delete in single atomic operation
         self.elasticsearch_client.indices.update_aliases(update_action)
 
+    def close(self) -> None:
+        """
+        close the file handler
+        :return:
+        """
+        if self.file_handler:
+            self.file_handler.close()
+
     def get_scope(self) -> str:
         return 'publisher.elasticsearch'


### PR DESCRIPTION
* fix: open file in read mode
* fix: close file handler on cleanup

### Summary of Changes

Since we only read from the file, we do not need to open it in write mode. Furthermore we close the file on cleanup in order to avoid issues with open file handlers. In particular this affects the automatic cleanup of [temporary directories](https://docs.python.org/3.10/library/tempfile.html#tempfile.TemporaryDirectory) containing the file.

### Tests

This affects low level aspect of how we open and close files, which might be beyond the scope of tests.

### Documentation

Nothing to document as there is not effective change in behaviour.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
