### PR TITLE
feat: Update metadata neo4j proxy column query to retrieve its TypeMetadata

### DIFF
--- a/metadata/metadata_service/__init__.py
+++ b/metadata/metadata_service/__init__.py
@@ -38,6 +38,8 @@ from metadata_service.api.table import (TableBadgeAPI, TableDashboardAPI,
                                         TableLineageAPI, TableOwnerAPI,
                                         TableTagAPI)
 from metadata_service.api.tag import TagAPI
+from metadata_service.api.type_metadata import (TypeMetadataBadgeAPI,
+                                                TypeMetadataDescriptionAPI)
 from metadata_service.api.user import (UserDetailAPI, UserFollowAPI,
                                        UserFollowsAPI, UserOwnAPI, UserOwnsAPI,
                                        UserReadsAPI)
@@ -134,6 +136,11 @@ def create_app(*, config_module_class: str) -> Flask:
                      '/table/<path:table_uri>/column/<column_name>/badge/<badge>')
     api.add_resource(ColumnLineageAPI,
                      '/table/<path:table_uri>/column/<column_name>/lineage')
+    api.add_resource(TypeMetadataDescriptionAPI,
+                     '/table/<path:table_uri>/column/<column_name>/type_metadata/<path:type_metadata_path>/description')
+    api.add_resource(TypeMetadataBadgeAPI,
+                     '/table/<path:table_uri>/column/<column_name>/type_metadata/<path:type_metadata_path>'
+                     '/badge/<badge>')
     api.add_resource(Neo4jDetailAPI,
                      '/latest_updated_ts')
     api.add_resource(StatisticsMetricsAPI,

--- a/metadata/metadata_service/__init__.py
+++ b/metadata/metadata_service/__init__.py
@@ -137,10 +137,9 @@ def create_app(*, config_module_class: str) -> Flask:
     api.add_resource(ColumnLineageAPI,
                      '/table/<path:table_uri>/column/<column_name>/lineage')
     api.add_resource(TypeMetadataDescriptionAPI,
-                     '/table/<path:table_uri>/column/<column_name>/type_metadata/<path:type_metadata_path>/description')
+                     '/type_metadata/<path:type_metadata_key>/description')
     api.add_resource(TypeMetadataBadgeAPI,
-                     '/table/<path:table_uri>/column/<column_name>/type_metadata/<path:type_metadata_path>'
-                     '/badge/<badge>')
+                     '/type_metadata/<path:type_metadata_key>/badge/<badge>')
     api.add_resource(Neo4jDetailAPI,
                      '/latest_updated_ts')
     api.add_resource(StatisticsMetricsAPI,

--- a/metadata/metadata_service/api/swagger_doc/template.yml
+++ b/metadata/metadata_service/api/swagger_doc/template.yml
@@ -171,6 +171,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ColumnStatFields'
+        badges:
+          type: array
+          description: 'Badges associated with the column'
+          items:
+            $ref: '#/components/schemas/Badge'
+        type_metadata:
+          type: object
+          description: 'Object representing the column type'
+          $ref: '#/components/schemas/TypeMetadata'
     ColumnStatFields:
       type: object
       properties:
@@ -186,6 +195,37 @@ components:
         end_epoch:
           type: integer
           description: 'End of the statistic (epoch)'
+    TypeMetadata:
+      type: object
+      properties:
+        kind:
+          type: string
+          description: 'The type kind (e.g. array, map, struct, etc)'
+        name:
+          type: string
+          description: 'Type metadata name'
+        key:
+          type: string
+          description: 'Type metadata key'
+        description:
+          type: string
+          description: 'Type metadata description'
+        data_type:
+          type: string
+          description: 'Representation of full type'
+        sort_order:
+          type: integer
+          description: 'Sort order when there are multiple type metadata objects on one level'
+        badges:
+          type: array
+          description: 'Badges associated with the type metadata'
+          items:
+            $ref: '#/components/schemas/Badge'
+        children:
+          type: array
+          description: 'List of nested type metadata objects one level down'
+          items:
+            $ref: '#/components/schemas/TypeMetadata'
     WatermarkFields:
       type: object
       properties:
@@ -257,7 +297,7 @@ components:
             type: array
             description: 'Badges associated with the table'
             items:
-              $ref: '#/components/schemas/TagFields'
+              $ref: '#/components/schemas/Badge'
           table_readers:
             type: array
             description: 'Table readers'
@@ -338,7 +378,7 @@ components:
           type: array
           description: 'Badges associated with the feature'
           items:
-            $ref: '#/components/schemas/TagFields'
+            $ref: '#/components/schemas/Badge'
         owners:
           type: array
           description: 'Owners of the feature'
@@ -506,7 +546,7 @@ components:
             type: array
             description: 'Badges associated with the Dashboard'
             items:
-              $ref: '#/components/schemas/TagFields'
+              $ref: '#/components/schemas/Badge'
         recent_view_count:
           type: int
           description: 'Dashboard recent view count. Not using explicit duration, as it is up to timely ingestion and timely removal of stale data'

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/badge_delete.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/badge_delete.yml
@@ -1,0 +1,53 @@
+Delete badges of a resource
+---
+tags:
+  - 'type_metadata'
+parameters:
+  - name: table_uri
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'hive://gold.test_schema/test_table1'
+  - name: column_name
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'beta'
+  - name: type_metadata_path
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'type/beta'
+  - name: badge_name
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'beta'
+  - name: category
+    in: query
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'table_status'
+responses:
+  200:
+    description: 'The badge was deleted successfully'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/MessageResponse'
+  404:
+    description: 'TypeMetadata or badge not found'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/badge_delete.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/badge_delete.yml
@@ -3,27 +3,13 @@ Delete badges of a resource
 tags:
   - 'type_metadata'
 parameters:
-  - name: table_uri
+  - name: type_metadata_key
     in: path
     type: string
     schema:
       type: string
     required: true
-    example: 'hive://gold.test_schema/test_table1'
-  - name: column_name
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'beta'
-  - name: type_metadata_path
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'type/beta'
+    example: 'hive://gold.test_schema/test_table1/beta/type/beta'
   - name: badge_name
     in: path
     type: string

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/badge_put.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/badge_put.yml
@@ -3,27 +3,13 @@ Add badge to a resource
 tags:
   - 'type_metadata'
 parameters:
-  - name: table_uri
+  - name: type_metadata_key
     in: path
     type: string
     schema:
       type: string
     required: true
-    example: 'hive://gold.test_schema/test_table1'
-  - name: column_name
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'beta'
-  - name: type_metadata_path
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'type/beta'
+    example: 'hive://gold.test_schema/test_table1/beta/type/beta'
   - name: badge
     in: path
     type: string

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/badge_put.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/badge_put.yml
@@ -1,0 +1,53 @@
+Add badge to a resource
+---
+tags:
+  - 'type_metadata'
+parameters:
+  - name: table_uri
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'hive://gold.test_schema/test_table1'
+  - name: column_name
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'beta'
+  - name: type_metadata_path
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'type/beta'
+  - name: badge
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'beta'
+  - name: category
+    in: query
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'table_status'
+responses:
+  200:
+    description: 'The badge was added successfully'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/MessageResponse'
+  404:
+    description: 'TypeMetadata not found, or badge is not whitelisted'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/description_get.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/description_get.yml
@@ -1,29 +1,15 @@
-Gets type_metadata description using table_uri, column_name, and type_metadata_path
+Gets type_metadata description using table_uri, column_name, and type_metadata_key
 ---
 tags:
   - 'type_metadata'
 parameters:
-  - name: table_uri
+  - name: type_metadata_key
     in: path
     type: string
     schema:
       type: string
     required: true
-    example: 'dynamo://gold.test_schema/test_table2'
-  - name: column_name
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'col2'
-  - name: type_metadata_path
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'type/col2'
+    example: 'dynamo://gold.test_schema/test_table2/col2/type/col2'
 responses:
   200:
     description: 'TypeMetadata description'

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/description_get.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/description_get.yml
@@ -1,0 +1,49 @@
+Gets type_metadata description using table_uri, column_name, and type_metadata_path
+---
+tags:
+  - 'type_metadata'
+parameters:
+  - name: table_uri
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'dynamo://gold.test_schema/test_table2'
+  - name: column_name
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'col2'
+  - name: type_metadata_path
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'type/col2'
+responses:
+  200:
+    description: 'TypeMetadata description'
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            description:
+              type: string
+              example: 'Identifies a user'
+  404:
+    description: 'TypeMetadata not found'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'
+  500:
+    description: 'Internal error fetching the TypeMetadata description'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/description_put.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/description_put.yml
@@ -3,27 +3,13 @@ Updates type_metadata description (passed as a request body)
 tags:
   - 'type_metadata'
 parameters:
-  - name: table_uri
+  - name: type_metadata_key
     in: path
     type: string
     schema:
       type: string
     required: true
-    example: 'dynamo://gold.test_schema/test_table2'
-  - name: column_name
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'col2'
-  - name: type_metadata_path
-    in: path
-    type: string
-    schema:
-      type: string
-    required: true
-    example: 'type/col2'
+    example: 'dynamo://gold.test_schema/test_table2/col2/type/col2'
 requestBody:
   content:
     application/json:

--- a/metadata/metadata_service/api/swagger_doc/type_metadata/description_put.yml
+++ b/metadata/metadata_service/api/swagger_doc/type_metadata/description_put.yml
@@ -1,0 +1,46 @@
+Updates type_metadata description (passed as a request body)
+---
+tags:
+  - 'type_metadata'
+parameters:
+  - name: table_uri
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'dynamo://gold.test_schema/test_table2'
+  - name: column_name
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'col2'
+  - name: type_metadata_path
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+    example: 'type/col2'
+requestBody:
+  content:
+    application/json:
+      schema:
+        $ref: '#/components/schemas/Description'
+        description: 'TypeMetadata description'
+        required: true
+responses:
+  200:
+    description: 'Empty json response'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/EmptyResponse'
+  404:
+    description: 'TypeMetadata not found'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/metadata/metadata_service/api/type_metadata.py
+++ b/metadata/metadata_service/api/type_metadata.py
@@ -1,0 +1,103 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from http import HTTPStatus
+from typing import Iterable, Mapping, Union
+
+from amundsen_common.entity.resource_type import ResourceType
+from flasgger import swag_from
+from flask import request
+from flask_restful import Resource, reqparse
+
+from metadata_service.api.badge import BadgeCommon
+from metadata_service.exception import NotFoundException
+from metadata_service.proxy import get_proxy_client
+
+
+class TypeMetadataDescriptionAPI(Resource):
+    """
+    TypeMetadataDescriptionAPI supports PUT and GET operations to upsert type_metadata description
+    """
+
+    def __init__(self) -> None:
+        self.client = get_proxy_client()
+        super(TypeMetadataDescriptionAPI, self).__init__()
+
+    @swag_from('swagger_doc/type_metadata/description_put.yml')
+    def put(self, table_uri: str, column_name: str, type_metadata_path: str) -> Iterable[Union[dict, tuple, int, None]]:
+        """
+        Updates type_metadata description (passed as a request body)
+        :param table_uri:
+        :param column_name:
+        :param type_metadata_path:
+        :return:
+        """
+        try:
+            description = json.loads(request.data).get('description')
+            self.client.put_type_metadata_description(table_uri=table_uri,
+                                                      column_name=column_name,
+                                                      type_metadata_path=type_metadata_path,
+                                                      description=description)
+            return None, HTTPStatus.OK
+
+        except NotFoundException:
+            msg = 'type_metadata with key {}/{}/{} does not exist'.format(table_uri, column_name, type_metadata_path)
+            return {'message': msg}, HTTPStatus.NOT_FOUND
+
+    @swag_from('swagger_doc/type_metadata/description_get.yml')
+    def get(self, table_uri: str, column_name: str, type_metadata_path: str) -> Union[tuple, int, None]:
+        """
+        Gets type_metadata descriptions in Neo4j
+        """
+        try:
+            description = self.client.get_type_metadata_description(table_uri=table_uri,
+                                                                    column_name=column_name,
+                                                                    type_metadata_path=type_metadata_path)
+
+            return {'description': description}, HTTPStatus.OK
+
+        except NotFoundException:
+            msg = 'type_metadata with key {}/{}/{} does not exist'.format(table_uri, column_name, type_metadata_path)
+            return {'message': msg}, HTTPStatus.NOT_FOUND
+
+        except Exception:
+            return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+class TypeMetadataBadgeAPI(Resource):
+    def __init__(self) -> None:
+        self.client = get_proxy_client()
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument('category', type=str, required=True)
+        super(TypeMetadataBadgeAPI, self).__init__()
+
+        self._badge_common = BadgeCommon(client=self.client)
+
+    @swag_from('swagger_doc/type_metadata/badge_put.yml')
+    def put(self,
+            table_uri: str,
+            column_name: str,
+            type_metadata_path: str,
+            badge: str) -> Iterable[Union[Mapping, int, None]]:
+        args = self.parser.parse_args()
+        category = args.get('category', '')
+
+        return self._badge_common.put(id=f"{table_uri}/{column_name}/{type_metadata_path}",
+                                      resource_type=ResourceType.Type_Metadata,
+                                      badge_name=badge,
+                                      category=category)
+
+    @swag_from('swagger_doc/type_metadata/badge_delete.yml')
+    def delete(self,
+               table_uri: str,
+               column_name: str,
+               type_metadata_path: str,
+               badge: str) -> Iterable[Union[Mapping, int, None]]:
+        args = self.parser.parse_args()
+        category = args.get('category', '')
+
+        return self._badge_common.delete(id=f"{table_uri}/{column_name}/{type_metadata_path}",
+                                         resource_type=ResourceType.Type_Metadata,
+                                         badge_name=badge,
+                                         category=category)

--- a/metadata/metadata_service/api/type_metadata.py
+++ b/metadata/metadata_service/api/type_metadata.py
@@ -25,40 +25,34 @@ class TypeMetadataDescriptionAPI(Resource):
         super(TypeMetadataDescriptionAPI, self).__init__()
 
     @swag_from('swagger_doc/type_metadata/description_put.yml')
-    def put(self, table_uri: str, column_name: str, type_metadata_path: str) -> Iterable[Union[dict, tuple, int, None]]:
+    def put(self, type_metadata_key: str) -> Iterable[Union[dict, tuple, int, None]]:
         """
         Updates type_metadata description (passed as a request body)
-        :param table_uri:
-        :param column_name:
-        :param type_metadata_path:
+        :param type_metadata_key:
         :return:
         """
         try:
             description = json.loads(request.data).get('description')
-            self.client.put_type_metadata_description(table_uri=table_uri,
-                                                      column_name=column_name,
-                                                      type_metadata_path=type_metadata_path,
+            self.client.put_type_metadata_description(type_metadata_key=type_metadata_key,
                                                       description=description)
             return None, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'type_metadata with key {}/{}/{} does not exist'.format(table_uri, column_name, type_metadata_path)
+            msg = 'type_metadata with key {} does not exist'.format(type_metadata_key)
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
     @swag_from('swagger_doc/type_metadata/description_get.yml')
-    def get(self, table_uri: str, column_name: str, type_metadata_path: str) -> Union[tuple, int, None]:
+    def get(self, type_metadata_key: str) -> Union[tuple, int, None]:
         """
         Gets type_metadata descriptions in Neo4j
         """
         try:
-            description = self.client.get_type_metadata_description(table_uri=table_uri,
-                                                                    column_name=column_name,
-                                                                    type_metadata_path=type_metadata_path)
+            description = self.client.get_type_metadata_description(type_metadata_key=type_metadata_key)
 
             return {'description': description}, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'type_metadata with key {}/{}/{} does not exist'.format(table_uri, column_name, type_metadata_path)
+            msg = 'type_metadata with key {} does not exist'.format(type_metadata_key)
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
         except Exception:
@@ -75,29 +69,21 @@ class TypeMetadataBadgeAPI(Resource):
         self._badge_common = BadgeCommon(client=self.client)
 
     @swag_from('swagger_doc/type_metadata/badge_put.yml')
-    def put(self,
-            table_uri: str,
-            column_name: str,
-            type_metadata_path: str,
-            badge: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, type_metadata_key: str, badge: str) -> Iterable[Union[Mapping, int, None]]:
         args = self.parser.parse_args()
         category = args.get('category', '')
 
-        return self._badge_common.put(id=f"{table_uri}/{column_name}/{type_metadata_path}",
+        return self._badge_common.put(id=type_metadata_key,
                                       resource_type=ResourceType.Type_Metadata,
                                       badge_name=badge,
                                       category=category)
 
     @swag_from('swagger_doc/type_metadata/badge_delete.yml')
-    def delete(self,
-               table_uri: str,
-               column_name: str,
-               type_metadata_path: str,
-               badge: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, type_metadata_key: str, badge: str) -> Iterable[Union[Mapping, int, None]]:
         args = self.parser.parse_args()
         category = args.get('category', '')
 
-        return self._badge_common.delete(id=f"{table_uri}/{column_name}/{type_metadata_path}",
+        return self._badge_common.delete(id=type_metadata_key,
                                          resource_type=ResourceType.Type_Metadata,
                                          badge_name=badge,
                                          category=category)

--- a/metadata/metadata_service/proxy/atlas_proxy.py
+++ b/metadata/metadata_service/proxy/atlas_proxy.py
@@ -1712,14 +1712,10 @@ class AtlasProxy(BaseProxy):
         raise NotImplementedError
 
     def put_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str,
+                                      type_metadata_key: str,
                                       description: str) -> None:
         pass
 
     def get_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str) -> Union[str, None]:
+                                      type_metadata_key: str) -> Union[str, None]:
         pass

--- a/metadata/metadata_service/proxy/atlas_proxy.py
+++ b/metadata/metadata_service/proxy/atlas_proxy.py
@@ -1710,3 +1710,16 @@ class AtlasProxy(BaseProxy):
                               resource_types: List[str],
                               user_id: Optional[str] = None) -> Dict[str, List]:
         raise NotImplementedError
+
+    def put_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str,
+                                      description: str) -> None:
+        pass
+
+    def get_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str) -> Union[str, None]:
+        pass

--- a/metadata/metadata_service/proxy/base_proxy.py
+++ b/metadata/metadata_service/proxy/base_proxy.py
@@ -120,6 +120,21 @@ class BaseProxy(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def put_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str,
+                                      description: str) -> None:
+        pass
+
+    @abstractmethod
+    def get_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str) -> Union[str, None]:
+        pass
+
+    @abstractmethod
     def get_popular_tables(self, *,
                            num_entries: int,
                            user_id: Optional[str] = None) -> List[PopularTable]:

--- a/metadata/metadata_service/proxy/base_proxy.py
+++ b/metadata/metadata_service/proxy/base_proxy.py
@@ -121,17 +121,13 @@ class BaseProxy(metaclass=ABCMeta):
 
     @abstractmethod
     def put_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str,
+                                      type_metadata_key: str,
                                       description: str) -> None:
         pass
 
     @abstractmethod
     def get_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str) -> Union[str, None]:
+                                      type_metadata_key: str) -> Union[str, None]:
         pass
 
     @abstractmethod

--- a/metadata/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata/metadata_service/proxy/gremlin_proxy.py
@@ -1782,6 +1782,19 @@ class AbstractGremlinProxy(BaseProxy):
                               user_id: Optional[str] = None) -> Dict[str, List]:
         raise NotImplementedError
 
+    def put_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str,
+                                      description: str) -> None:
+        pass
+
+    def get_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str) -> Union[str, None]:
+        pass
+
 
 class GenericGremlinProxy(AbstractGremlinProxy):
     """

--- a/metadata/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata/metadata_service/proxy/gremlin_proxy.py
@@ -1783,16 +1783,12 @@ class AbstractGremlinProxy(BaseProxy):
         raise NotImplementedError
 
     def put_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str,
+                                      type_metadata_key: str,
                                       description: str) -> None:
         pass
 
     def get_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str) -> Union[str, None]:
+                                      type_metadata_key: str) -> Union[str, None]:
         pass
 
 

--- a/metadata/metadata_service/proxy/mysql_proxy.py
+++ b/metadata/metadata_service/proxy/mysql_proxy.py
@@ -1466,3 +1466,16 @@ class MySQLProxy(BaseProxy):
 
     def get_resource_generation_code(self, *, uri: str, resource_type: ResourceType) -> GenerationCode:
         pass
+
+    def put_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str,
+                                      description: str) -> None:
+        pass
+
+    def get_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str) -> Union[str, None]:
+        pass

--- a/metadata/metadata_service/proxy/mysql_proxy.py
+++ b/metadata/metadata_service/proxy/mysql_proxy.py
@@ -1468,14 +1468,10 @@ class MySQLProxy(BaseProxy):
         pass
 
     def put_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str,
+                                      type_metadata_key: str,
                                       description: str) -> None:
         pass
 
     def get_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str) -> Union[str, None]:
+                                      type_metadata_key: str) -> Union[str, None]:
         pass

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -561,20 +561,16 @@ class Neo4jProxy(BaseProxy):
 
     @timer_with_counter
     def get_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str) -> Union[str, None]:
+                                      type_metadata_key: str) -> Union[str, None]:
         """
         Get the type_metadata description based on its key. Any exception will propagate back to api server.
 
-        :param table_uri:
-        :param column_name:
-        :param type_metadata_path:
+        :param type_metadata_key:
         :return:
         """
 
         return self.get_resource_description(resource_type=ResourceType.Type_Metadata,
-                                             uri=f'{table_uri}/{column_name}/{type_metadata_path}').description
+                                             uri=type_metadata_key).description
 
     @timer_with_counter
     def put_resource_description(self, *,
@@ -646,20 +642,16 @@ class Neo4jProxy(BaseProxy):
 
     @timer_with_counter
     def put_type_metadata_description(self, *,
-                                      table_uri: str,
-                                      column_name: str,
-                                      type_metadata_path: str,
+                                      type_metadata_key: str,
                                       description: str) -> None:
         """
         Update type_metadata description with one from user
-        :param table_uri:
-        :param column_name:
-        :param type_metadata_path:
+        :param type_metadata_key:
         :param description:
         """
 
         self.put_resource_description(resource_type=ResourceType.Type_Metadata,
-                                      uri=f'{table_uri}/{column_name}/{type_metadata_path}',
+                                      uri=type_metadata_key,
                                       description=description)
 
     @timer_with_counter

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -207,14 +207,16 @@ class Neo4jProxy(BaseProxy):
 
         return sorted(cols, key=lambda item: item.sort_order), last_neo4j_record
 
-    def _get_type_metadata(self, type_metadata_results: Iterable) -> Optional[TypeMetadata]:
+    def _get_type_metadata(self, type_metadata_results: List) -> Optional[TypeMetadata]:
         """
         Generates a TypeMetadata object for a column
 
         :param type_metadata_results: A list of type metadata values for a column
         :return: a TypeMetadata object
         """
-        if type_metadata_results:
+        # If there are no Type_Metadata nodes for a column, type_metadata_results
+        # will have one object with an empty node value
+        if len(type_metadata_results) > 0 and type_metadata_results[0]['node'] is not None:
             sorted_type_metadata = sorted(type_metadata_results, key=lambda x: x['node']['key'])
         else:
             return None

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -514,7 +514,7 @@ class Neo4jProxy(BaseProxy):
         """
         Generates a list of Badges objects
 
-        :param badges: A list of badges of a table or a column
+        :param badges: A list of badges of a table, column, or type_metadata
         :return: a list of Badge objects
         """
         _badges = []
@@ -556,6 +556,23 @@ class Neo4jProxy(BaseProxy):
         """
 
         return self.get_resource_description(resource_type=ResourceType.Table, uri=table_uri).description
+
+    @timer_with_counter
+    def get_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str) -> Union[str, None]:
+        """
+        Get the type_metadata description based on its key. Any exception will propagate back to api server.
+
+        :param table_uri:
+        :param column_name:
+        :param type_metadata_path:
+        :return:
+        """
+
+        return self.get_resource_description(resource_type=ResourceType.Type_Metadata,
+                                             uri=f'{table_uri}/{column_name}/{type_metadata_path}').description
 
     @timer_with_counter
     def put_resource_description(self, *,
@@ -623,6 +640,24 @@ class Neo4jProxy(BaseProxy):
 
         self.put_resource_description(resource_type=ResourceType.Table,
                                       uri=table_uri,
+                                      description=description)
+
+    @timer_with_counter
+    def put_type_metadata_description(self, *,
+                                      table_uri: str,
+                                      column_name: str,
+                                      type_metadata_path: str,
+                                      description: str) -> None:
+        """
+        Update type_metadata description with one from user
+        :param table_uri:
+        :param column_name:
+        :param type_metadata_path:
+        :param description:
+        """
+
+        self.put_resource_description(resource_type=ResourceType.Type_Metadata,
+                                      uri=f'{table_uri}/{column_name}/{type_metadata_path}',
                                       description=description)
 
     @timer_with_counter

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -219,7 +219,7 @@ class Neo4jProxy(BaseProxy):
         else:
             return None
 
-        type_metadata_with_children = {}
+        type_metadata_with_children: Dict[str, Tuple[TypeMetadata, Dict]] = {}
         for tm in sorted_type_metadata:
             tm_node = tm['node']
             description = self._safe_get(tm, 'description', 'description')

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -167,7 +167,7 @@ class Neo4jProxy(BaseProxy):
         WITH db, clstr, schema, tbl, tbl_dscrpt, col, col_dscrpt, collect(distinct stat) as col_stats,
         collect(distinct badge) as col_badges,
         {node: tm, description: tm_dscrpt, badges: collect(distinct tm_badge)} as tm_results
-        RETURN db, clstr, schema, tbl, tbl_dscrpt, col, col_dscrpt, col_stats, col_badges, 
+        RETURN db, clstr, schema, tbl, tbl_dscrpt, col, col_dscrpt, col_stats, col_badges,
         collect(distinct tm_results) as col_type_metadata
         ORDER BY col.sort_order;""")
 

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -209,13 +209,16 @@ class Neo4jProxy(BaseProxy):
 
     def _get_type_metadata(self, type_metadata_results: List) -> Optional[TypeMetadata]:
         """
-        Generates a TypeMetadata object for a column
+        Generates a TypeMetadata object for a column. All columns will have at least
+        one associated type metadata node if the ComplexTypeTransformer is configured
+        to transform table metadata. Otherwise, there will be no type metadata found
+        and this will return quickly.
 
         :param type_metadata_results: A list of type metadata values for a column
         :return: a TypeMetadata object
         """
-        # If there are no Type_Metadata nodes for a column, type_metadata_results
-        # will have one object with an empty node value
+        # If there are no Type_Metadata nodes, type_metadata_results will have
+        # one object with an empty node value
         if len(type_metadata_results) > 0 and type_metadata_results[0]['node'] is not None:
             sorted_type_metadata = sorted(type_metadata_results, key=lambda x: x['node']['key'])
         else:
@@ -227,6 +230,8 @@ class Neo4jProxy(BaseProxy):
             description = self._safe_get(tm, 'description', 'description')
             sort_order = self._safe_get(tm_node, 'sort_order') or 0
             badges = self._safe_get(tm, 'badges')
+            # kind refers to the general type of the TypeMetadata, such as "array" or "map",
+            # while data_type refers to the entire type such as "array<int>" or "map<string, string>"
             type_metadata = TypeMetadata(kind=tm_node['kind'], name=tm_node['name'], key=tm_node['key'],
                                          description=description, data_type=tm_node['data_type'],
                                          sort_order=sort_order, badges=self._make_badges(badges) if badges else [])

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -53,7 +53,8 @@ class TestNeo4jProxy(unittest.TestCase):
 
         col1 = copy.deepcopy(table_entry)  # type: Dict[Any, Any]
         col1['col'] = {'name': 'bar_id_1',
-                       'col_type': 'varchar',
+                       'col_type': 'array<struct<c1:string,c2:array<string>,'
+                                   'c3:map<string,string>,c4:struct<c5:int,c6:int>>>',
                        'sort_order': 0}
         col1['col_dscrpt'] = {'description': 'bar col description'}
         col1['col_stats'] = [{'stat_type': 'avg', 'start_epoch': 1, 'end_epoch': 1, 'stat_val': '1'}]
@@ -101,7 +102,7 @@ class TestNeo4jProxy(unittest.TestCase):
 
         col2 = copy.deepcopy(table_entry)  # type: Dict[Any, Any]
         col2['col'] = {'name': 'bar_id_2',
-                       'col_type': 'bigint',
+                       'col_type': 'array<struct<c1:string,c2:array<string>>>',
                        'sort_order': 1}
         col2['col_dscrpt'] = {'description': 'bar col2 description'}
         col2['col_stats'] = [{'stat_type': 'avg', 'start_epoch': 2, 'end_epoch': 2, 'stat_val': '2'}]
@@ -381,13 +382,16 @@ class TestNeo4jProxy(unittest.TestCase):
                                                    partition_key='ds',
                                                    partition_value='fake_value',
                                                    create_time='fake_time')],
-                             columns=[Column(name='bar_id_1', description='bar col description', col_type='varchar',
+                             columns=[Column(name='bar_id_1', description='bar col description',
+                                             col_type='array<struct<c1:string,c2:array<string>,'
+                                                      'c3:map<string,string>,c4:struct<c5:int,c6:int>>>',
                                              sort_order=0, stats=[Stat(start_epoch=1,
                                                                        end_epoch=1,
                                                                        stat_type='avg',
                                                                        stat_val='1')], badges=[],
                                              type_metadata=self.col_bar_id_1_expected_type_metadata),
-                                      Column(name='bar_id_2', description='bar col2 description', col_type='bigint',
+                                      Column(name='bar_id_2', description='bar col2 description',
+                                             col_type='array<struct<c1:string,c2:array<string>>>',
                                              sort_order=1, stats=[Stat(start_epoch=2,
                                                                        end_epoch=2,
                                                                        stat_type='avg',
@@ -465,13 +469,16 @@ class TestNeo4jProxy(unittest.TestCase):
                                                    partition_key='ds',
                                                    partition_value='fake_value',
                                                    create_time='fake_time')],
-                             columns=[Column(name='bar_id_1', description='bar col description', col_type='varchar',
+                             columns=[Column(name='bar_id_1', description='bar col description',
+                                             col_type='array<struct<c1:string,c2:array<string>,'
+                                                      'c3:map<string,string>,c4:struct<c5:int,c6:int>>>',
                                              sort_order=0, stats=[Stat(start_epoch=1,
                                                                        end_epoch=1,
                                                                        stat_type='avg',
                                                                        stat_val='1')], badges=[],
                                              type_metadata=self.col_bar_id_1_expected_type_metadata),
-                                      Column(name='bar_id_2', description='bar col2 description', col_type='bigint',
+                                      Column(name='bar_id_2', description='bar col2 description',
+                                             col_type='array<struct<c1:string,c2:array<string>>>',
                                              sort_order=1, stats=[Stat(start_epoch=2,
                                                                        end_epoch=2,
                                                                        stat_type='avg',

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -669,9 +669,8 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_execute.return_value.single.return_value = dict(description='sample description')
 
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            col_description = neo4j_proxy.get_type_metadata_description(table_uri='test_table',
-                                                                        column_name='test_column',
-                                                                        type_metadata_path='test_type_metadata')
+            col_description = neo4j_proxy.get_type_metadata_description(type_metadata_key='test_table/test_column'
+                                                                                          '/test_type_metadata')
 
             type_metadata_description_query = textwrap.dedent("""
             MATCH (n:Type_Metadata {key: $key})-[:DESCRIPTION]->(d:Description)
@@ -691,9 +690,8 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_execute.return_value.single.return_value = None
 
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            col_description = neo4j_proxy.get_type_metadata_description(table_uri='test_table',
-                                                                        column_name='test_column',
-                                                                        type_metadata_path='test_type_metadata')
+            col_description = neo4j_proxy.get_type_metadata_description(type_metadata_key='test_table/test_column'
+                                                                                          '/test_type_metadata')
 
             type_metadata_description_query = textwrap.dedent("""
             MATCH (n:Type_Metadata {key: $key})-[:DESCRIPTION]->(d:Description)
@@ -722,9 +720,7 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_transaction.commit = mock_commit
 
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            neo4j_proxy.put_type_metadata_description(table_uri='test_table',
-                                                      column_name='test_column',
-                                                      type_metadata_path='test_type_metadata',
+            neo4j_proxy.put_type_metadata_description(type_metadata_key='test_table/test_column/test_type_metadata',
                                                       description='test_description')
 
             self.assertEqual(mock_run.call_count, 2)

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -20,7 +20,7 @@ from amundsen_common.models.table import (Application, Badge, Column,
                                           ProgrammaticDescription,
                                           ResourceReport, Source, SqlJoin,
                                           SqlWhere, Stat, Table, TableSummary,
-                                          Tag, User, Watermark)
+                                          Tag, TypeMetadata, User, Watermark)
 from amundsen_common.models.user import User as UserModel
 from neo4j import GraphDatabase
 
@@ -58,6 +58,46 @@ class TestNeo4jProxy(unittest.TestCase):
         col1['col_dscrpt'] = {'description': 'bar col description'}
         col1['col_stats'] = [{'stat_type': 'avg', 'start_epoch': 1, 'end_epoch': 1, 'stat_val': '1'}]
         col1['col_badges'] = []
+        col1['col_type_metadata'] = [{'node': {'kind': 'array', 'name': 'bar_id_1',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1',
+                                               'data_type': 'array<struct<c1:string,c2:array<string>,'
+                                                            'c3:map<string,string>,c4:struct<c5:int,c6:int>>>'}},
+                                     {'node': {'kind': 'struct', 'name': '_inner_',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_',
+                                               'data_type': 'struct<c1:string,c2:array<string>,'
+                                                            'c3:map<string,string>,c4:struct<c5:int,c6:int>>'}},
+                                     {'node': {'kind': 'scalar', 'name': 'c1',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c1',
+                                               'data_type': 'string', 'sort_order': 0}},
+                                     {'node': {'kind': 'array', 'name': 'c2',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c2',
+                                               'data_type': 'array<string>', 'sort_order': 1}},
+                                     {'node': {'kind': 'map', 'name': 'c3',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c3',
+                                               'data_type': 'map<string,string>', 'sort_order': 2}},
+                                     {'node': {'kind': 'struct', 'name': 'c4',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c4',
+                                               'data_type': 'struct<c5:int,c6:int>', 'sort_order': 3}},
+                                     {'node': {'kind': 'scalar', 'name': 'map_key',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c3/map_key',
+                                               'data_type': 'string'}},
+                                     {'node': {'kind': 'scalar', 'name': 'map_value',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c3/map_value',
+                                               'data_type': 'string'}},
+                                     {'node': {'kind': 'scalar', 'name': 'c5',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c4/c5',
+                                               'data_type': 'int', 'sort_order': 0}},
+                                     {'node': {'kind': 'scalar', 'name': 'c6',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_'
+                                                      '/c4/c6',
+                                               'data_type': 'int', 'sort_order': 1}}]
 
         col2 = copy.deepcopy(table_entry)  # type: Dict[Any, Any]
         col2['col'] = {'name': 'bar_id_2',
@@ -66,6 +106,34 @@ class TestNeo4jProxy(unittest.TestCase):
         col2['col_dscrpt'] = {'description': 'bar col2 description'}
         col2['col_stats'] = [{'stat_type': 'avg', 'start_epoch': 2, 'end_epoch': 2, 'stat_val': '2'}]
         col2['col_badges'] = [{'key': 'primary key', 'category': 'column'}]
+        col2['col_type_metadata'] = [{'node': {'kind': 'array', 'name': 'bar_id_2',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2',
+                                               'data_type': 'array<struct<c1:string,c2:array<string>>>'},
+                                      'description': {'description': 'Array description',
+                                                      'description_source': 'description',
+                                                      'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2'
+                                                             '/_description'}},
+                                     {'node': {'kind': 'struct', 'name': '_inner_',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2/_inner_',
+                                               'data_type': 'struct<c1:string,c2:array<string>>'}},
+                                     {'node': {'kind': 'scalar', 'name': 'c1',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2/_inner_'
+                                                      '/c1',
+                                               'data_type': 'string', 'sort_order': 0},
+                                      'description': {'description': 'String description',
+                                                      'description_source': 'description',
+                                                      'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2'
+                                                             '/_inner_/c1/_description'}},
+                                     {'node': {'kind': 'array', 'name': 'c2',
+                                               'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2/_inner_'
+                                                      '/c2',
+                                               'data_type': 'array<string>', 'sort_order': 1},
+                                     'description': {'description': 'Array description',
+                                                     'description_source': 'description',
+                                                     'key': 'hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2'
+                                                            '/_inner_/c2/_description'},
+                                      'badges': [{'key': 'primary key', 'category': 'column'},
+                                                 {'key': 'pii', 'category': 'column'}]}]
 
         app1 = {
             'application_url': 'url1',
@@ -183,6 +251,74 @@ class TestNeo4jProxy(unittest.TestCase):
 
         self.table_common_usage = table_common_usage
 
+        self.col_bar_id_1_expected_type_metadata = self._get_col_bar_id_1_expected_type_metadata()
+        self.col_bar_id_2_expected_type_metadata = self._get_col_bar_id_2_expected_type_metadata()
+
+    def _get_col_bar_id_1_expected_type_metadata(self) -> TypeMetadata:
+        bar_id_1_c3_map_key_tm = TypeMetadata(kind='scalar', name='map_key',
+                                              key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1'
+                                                  '/_inner_/c3/map_key',
+                                              data_type='string', sort_order=0)
+        bar_id_1_c3_map_value_tm = TypeMetadata(kind='scalar', name='map_value',
+                                                key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1'
+                                                    '/_inner_/c3/map_value',
+                                                data_type='string', sort_order=0)
+        bar_id_1_c4_c5_tm = TypeMetadata(kind='scalar', name='c5',
+                                         key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1'
+                                             '/_inner_/c4/c5',
+                                         data_type='int', sort_order=0)
+        bar_id_1_c4_c6_tm = TypeMetadata(kind='scalar', name='c6',
+                                         key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1'
+                                             '/_inner_/c4/c6',
+                                         data_type='int', sort_order=1)
+        bar_id_1_c1_tm = TypeMetadata(kind='scalar', name='c1',
+                                      key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_/c1',
+                                      data_type='string', sort_order=0)
+        bar_id_1_c2_tm = TypeMetadata(kind='array', name='c2',
+                                      key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_/c2',
+                                      data_type='array<string>', sort_order=1)
+        bar_id_1_c3_tm = TypeMetadata(kind='map', name='c3',
+                                      key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_/c3',
+                                      data_type='map<string,string>', sort_order=2,
+                                      children=[bar_id_1_c3_map_key_tm, bar_id_1_c3_map_value_tm])
+        bar_id_1_c4_tm = TypeMetadata(kind='struct', name='c4',
+                                      key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_/c4',
+                                      data_type='struct<c5:int,c6:int>', sort_order=3,
+                                      children=[bar_id_1_c4_c5_tm, bar_id_1_c4_c6_tm])
+        bar_id_1_struct_tm = TypeMetadata(kind='struct', name='_inner_',
+                                          key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1/_inner_',
+                                          data_type='struct<c1:string,c2:array<string>,'
+                                                    'c3:map<string,string>,c4:struct<c5:int,c6:int>>', sort_order=0,
+                                          children=[bar_id_1_c1_tm, bar_id_1_c2_tm, bar_id_1_c3_tm, bar_id_1_c4_tm])
+        bar_id_1_type_metadata = TypeMetadata(kind='array', name='bar_id_1',
+                                              key='hive://gold.foo_schema/foo_table/bar_id_1/type/bar_id_1',
+                                              data_type='array<struct<c1:string,c2:array<string>,'
+                                                        'c3:map<string,string>,c4:struct<c5:int,c6:int>>>',
+                                              sort_order=0, children=[bar_id_1_struct_tm])
+        return bar_id_1_type_metadata
+
+    def _get_col_bar_id_2_expected_type_metadata(self) -> TypeMetadata:
+        bar_id_2_c1_tm = TypeMetadata(kind='scalar', name='c1',
+                                      key='hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2/_inner_/c1',
+                                      description='String description',
+                                      data_type='string', sort_order=0)
+        bar_id_2_c2_tm = TypeMetadata(kind='array', name='c2',
+                                      key='hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2/_inner_/c2',
+                                      description='Array description',
+                                      data_type='array<string>', sort_order=1,
+                                      badges=[Badge(badge_name='primary key', category='column'),
+                                              Badge(badge_name='pii', category='column')])
+        bar_id_2_struct_tm = TypeMetadata(kind='struct', name='_inner_',
+                                          key='hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2/_inner_',
+                                          data_type='struct<c1:string,c2:array<string>>', sort_order=0,
+                                          children=[bar_id_2_c1_tm, bar_id_2_c2_tm])
+        bar_id_2_type_metadata = TypeMetadata(kind='array', name='bar_id_2',
+                                              key='hive://gold.foo_schema/foo_table/bar_id_2/type/bar_id_2',
+                                              description='Array description',
+                                              data_type='array<struct<c1:string,c2:array<string>>>', sort_order=0,
+                                              children=[bar_id_2_struct_tm])
+        return bar_id_2_type_metadata
+
     def tearDown(self) -> None:
         pass
 
@@ -249,13 +385,15 @@ class TestNeo4jProxy(unittest.TestCase):
                                              sort_order=0, stats=[Stat(start_epoch=1,
                                                                        end_epoch=1,
                                                                        stat_type='avg',
-                                                                       stat_val='1')], badges=[]),
+                                                                       stat_val='1')], badges=[],
+                                             type_metadata=self.col_bar_id_1_expected_type_metadata),
                                       Column(name='bar_id_2', description='bar col2 description', col_type='bigint',
                                              sort_order=1, stats=[Stat(start_epoch=2,
                                                                        end_epoch=2,
                                                                        stat_type='avg',
                                                                        stat_val='2')],
-                                             badges=[Badge(badge_name='primary key', category='column')])],
+                                             badges=[Badge(badge_name='primary key', category='column')],
+                                             type_metadata=self.col_bar_id_2_expected_type_metadata)],
                              owners=[User(email='tester@example.com', user_id='tester@example.com')],
                              table_writer=Application(**self.app_producing, kind='Producing'),
                              table_apps=[
@@ -331,13 +469,15 @@ class TestNeo4jProxy(unittest.TestCase):
                                              sort_order=0, stats=[Stat(start_epoch=1,
                                                                        end_epoch=1,
                                                                        stat_type='avg',
-                                                                       stat_val='1')], badges=[]),
+                                                                       stat_val='1')], badges=[],
+                                             type_metadata=self.col_bar_id_1_expected_type_metadata),
                                       Column(name='bar_id_2', description='bar col2 description', col_type='bigint',
                                              sort_order=1, stats=[Stat(start_epoch=2,
                                                                        end_epoch=2,
                                                                        stat_type='avg',
                                                                        stat_val='2')],
-                                             badges=[Badge(badge_name='primary key', category='column')])],
+                                             badges=[Badge(badge_name='primary key', category='column')],
+                                             type_metadata=self.col_bar_id_2_expected_type_metadata)],
                              owners=[User(email='tester@example.com', user_id='tester@example.com')],
                              table_writer=Application(**self.app_producing, kind='Producing'),
                              table_apps=[


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This change adds a `TypeMetadata` object to each `Column` if the column node has any `TYPE_METADATA` relations when table metadata is retrieved using the `get_table` API.

The column query in `neo4j_proxy` now looks for optional `TypeMetadata` nodes along with any optional descriptions or badges related to each one. The list of all nodes are then processed based on their key paths to create the correct structure of `TypeMetadata`, where each one may have one or more nested child `TypeMetadata` objects.

### Tests

Updated `test_neo4j_proxy.py` to include `TypeMetadata` values within `Column`s to make sure the object structure is created correctly from expected query results.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
