### PR TITLE
fix: Add upper-bound for Jinja2 version for backwards compatibility

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -14,7 +14,7 @@ Flask==1.0.2
 Flask-RESTful>=0.3.6
 flask-cors==3.0.8
 itsdangerous<=2.0.1
-Jinja2>=2.10.1
+Jinja2>=2.10.1,<3.1
 jsonschema>=3.0.1,<4.0
 marshmallow>=3.0,<=3.6
 marshmallow3-annotations>=1.0.0


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

Fixing Jinja2 version for backwards compatibility

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
