### PR TITLE
force Jinja2>=3.0.3,<3.1.0

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -13,7 +13,7 @@ flasgger==0.9.5
 Flask==1.0.2
 Flask-RESTful>=0.3.6
 flask-cors==3.0.8
-Jinja2>=2.10.1
+Jinja2>=3.0.3,<3.1.0
 jsonschema>=3.0.1,<4.0
 marshmallow>=3.0,<=3.6
 marshmallow3-annotations>=1.0.0


### PR DESCRIPTION
As jinja version 3.1.0 has been released, it is incompatible with current flask version.

### Summary of Changes
Just force jinja version to stay below 3.1.0

### Tests
No tests where added

### Documentation
No documentation added

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
