### PR TITLE
feat: Add TypeMetadata to ResourceType enums

### DIFF
--- a/common/amundsen_common/entity/resource_type.py
+++ b/common/amundsen_common/entity/resource_type.py
@@ -9,6 +9,7 @@ class ResourceType(Enum):
     Dashboard = auto()
     User = auto()
     Column = auto()
+    TypeMetadata = auto()
     Feature = auto()
 
 

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.26.0'
+__version__ = '0.26.1'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -23,5 +23,5 @@ requests>=2.25.0
 requests-aws4auth==1.1.0
 statsd==3.2.1
 typing==3.6.4
-werkzeug>=2.0.0
+werkzeug==2.0.3
 wheel==0.36.2


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This adds `TypeMetadata` to the list of `ResourceType` enums. This will allow the use of this resource type in the generalized description and badge metadata APIs for `TypeMetadata` resources.

This PR also pins the version of `werkzeug` to 2.0.3 due to the removal of an argument in version 2.1.0 that the current version of `flask` uses.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
