### PR TITLE
fix: Type_Metadata ResourceType needs to match the node label format

### DIFF
--- a/common/amundsen_common/entity/resource_type.py
+++ b/common/amundsen_common/entity/resource_type.py
@@ -9,7 +9,7 @@ class ResourceType(Enum):
     Dashboard = auto()
     User = auto()
     Column = auto()
-    TypeMetadata = auto()
+    Type_Metadata = auto()
     Feature = auto()
 
 

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.26.1'
+__version__ = '0.26.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

`Type_Metadata` was originally added to common `ResourceType` with the name format matching the common class name. It needs to instead match the format of the node label which includes the underscore as defined [here](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/models/type_metadata.py#L17).

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
