### PR TITLE
feat: add boolean config for adding publisher metadata to neo4j node

### DIFF
--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -63,6 +63,10 @@ PUBLISHED_TAG_PROPERTY_NAME = 'published_tag'
 # Neo4j property name for last updated timestamp
 LAST_UPDATED_EPOCH_MS = 'publisher_last_updated_epoch_ms'
 
+# A boolean flag to indicate if publisher_metadata (e.g. published_tag, publisher_last_updated_epoch_ms)
+# will be add as properties of Neo4j nodes
+ADD_PUBLISHER_METADATA = 'add_publisher_metadata'
+
 RELATION_PREPROCESSOR = 'relation_preprocessor'
 
 # CSV HEADER
@@ -99,6 +103,7 @@ DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_TRANSACTION_SIZE: 500,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50,
                                           NEO4J_ENCRYPTED: True,
                                           NEO4J_VALIDATE_SSL: False,
+                                          ADD_PUBLISHER_METADATA: True,
                                           RELATION_PREPROCESSOR: NoopRelationPreprocessor()})
 
 # transient error retries and sleep time
@@ -153,6 +158,7 @@ class Neo4jCsvPublisher(Publisher):
         self.publish_tag: str = conf.get_string(JOB_PUBLISH_TAG)
         if not self.publish_tag:
             raise Exception(f'{JOB_PUBLISH_TAG} should not be empty')
+        self.add_publisher_metadata: bool = conf.get_bool(ADD_PUBLISHER_METADATA)
 
         self._relation_preprocessor = conf.get(RELATION_PREPROCESSOR)
 
@@ -404,8 +410,9 @@ class Neo4jCsvPublisher(Publisher):
 
             props.append(f'{identifier}.{k} = ${k}')
 
-        props.append(f"{identifier}.{PUBLISHED_TAG_PROPERTY_NAME} = '{self.publish_tag}'")
-        props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
+            if self.add_publisher_metadata:
+                props.append(f"{identifier}.{PUBLISHED_TAG_PROPERTY_NAME} = '{self.publish_tag}'")
+                props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
 
         return ', '.join(props)
 

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -64,7 +64,7 @@ PUBLISHED_TAG_PROPERTY_NAME = 'published_tag'
 LAST_UPDATED_EPOCH_MS = 'publisher_last_updated_epoch_ms'
 
 # A boolean flag to indicate if publisher_metadata (e.g. published_tag, publisher_last_updated_epoch_ms)
-# will be add as properties of Neo4j nodes
+# will be included as properties of the Neo4j nodes
 ADD_PUBLISHER_METADATA = 'add_publisher_metadata'
 
 RELATION_PREPROCESSOR = 'relation_preprocessor'

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -410,9 +410,9 @@ class Neo4jCsvPublisher(Publisher):
 
             props.append(f'{identifier}.{k} = ${k}')
 
-            if self.add_publisher_metadata:
-                props.append(f"{identifier}.{PUBLISHED_TAG_PROPERTY_NAME} = '{self.publish_tag}'")
-                props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
+        if self.add_publisher_metadata:
+            props.append(f"{identifier}.{PUBLISHED_TAG_PROPERTY_NAME} = '{self.publish_tag}'")
+            props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
 
         return ', '.join(props)
 

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -156,9 +156,9 @@ class Neo4jCsvPublisher(Publisher):
         self.deadlock_node_labels = set(conf.get_list(NEO4J_DEADLOCK_NODE_LABELS, default=[]))
         self.labels: Set[str] = set()
         self.publish_tag: str = conf.get_string(JOB_PUBLISH_TAG)
-        if not self.publish_tag:
-            raise Exception(f'{JOB_PUBLISH_TAG} should not be empty')
         self.add_publisher_metadata: bool = conf.get_bool(ADD_PUBLISHER_METADATA)
+        if self.add_publisher_metadata and not self.publish_tag:
+            raise Exception(f'{JOB_PUBLISH_TAG} should not be empty')
 
         self._relation_preprocessor = conf.get(RELATION_PREPROCESSOR)
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

Adding a boolean config to control whether publisher metadata (e.g. ) need to be added as properties. Through this config (default True), we can [retain the data](https://github.com/amundsen-io/amundsen/blob/c9727bffaa6aeb53623ad2a808013e35c549f18a/databuilder/databuilder/task/neo4j_staleness_removal_task.py#L173) (won't get purged in async mode) when such metadata is not included.

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
