### PR TITLE
fix: Fix neo4j proxy column query retrieval of type metadata, adding logging

### DIFF
--- a/metadata/metadata_service/api/type_metadata.py
+++ b/metadata/metadata_service/api/type_metadata.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 from http import HTTPStatus
 from typing import Iterable, Mapping, Union
 
@@ -13,6 +14,8 @@ from flask_restful import Resource, reqparse
 from metadata_service.api.badge import BadgeCommon
 from metadata_service.exception import NotFoundException
 from metadata_service.proxy import get_proxy_client
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TypeMetadataDescriptionAPI(Resource):
@@ -38,7 +41,8 @@ class TypeMetadataDescriptionAPI(Resource):
             return None, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'type_metadata with key {} does not exist'.format(type_metadata_key)
+            msg = f'type_metadata with key {type_metadata_key} does not exist'
+            LOGGER.error(f'NotFoundException: {msg}')
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
     @swag_from('swagger_doc/type_metadata/description_get.yml')
@@ -52,10 +56,12 @@ class TypeMetadataDescriptionAPI(Resource):
             return {'description': description}, HTTPStatus.OK
 
         except NotFoundException:
-            msg = 'type_metadata with key {} does not exist'.format(type_metadata_key)
+            msg = f'type_metadata with key {type_metadata_key} does not exist'
+            LOGGER.error(f'NotFoundException: {msg}')
             return {'message': msg}, HTTPStatus.NOT_FOUND
 
-        except Exception:
+        except Exception as e:
+            LOGGER.error(f'Internal server error occurred when getting type metadata description: {e}')
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

The original change to the table metadata API in https://github.com/amundsen-io/amundsen/pull/1776 looked for the type metadata path by splitting on the string `/type/`, however this did not work in all cases because a table or column could be named type. Fixed this issue by using a named groups regex to be clear about the expected location of the type metadata path within the full key.

Also, did some general cleanup of the logic for constructing the `TypeMetadata` objects with their children. Rather than constructing a dict of node name to a tuple of the object itself and a dict of its children, now two dicts are constructed. The first is a mapping of the type metadata path section of the key to the `TypeMetadata` object. The second is a nested dict that maps a TM node name to a dict of its children's names. The children dict is then iterated through to set the `children` fields in the same way as before, but now retrieves the TM object from the other dict instead of accessing from a tuple.

Added some logging to help with debugging in case of issues.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
