### PR TITLE
feat: Moving location of the column stats icon

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -497,11 +497,11 @@ exports[`eslint`] = {
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
-    "js/features/ColumnList/index.spec.tsx:2138919335": [
+    "js/features/ColumnList/index.spec.tsx:66693458": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
     ],
-    "js/features/ColumnList/index.tsx:2085568133": [
-      [218, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:417641019": [
+      [219, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -396,9 +396,9 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:1265451949": [
-      [362, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
-      [363, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
+    "js/config/config-default.ts:429062513": [
+      [366, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
+      [367, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
       [3, 0, 148, "\`.\` import should occur after import of \`./types\`", "4154971894"]
@@ -500,8 +500,8 @@ exports[`eslint`] = {
     "js/features/ColumnList/index.spec.tsx:2138919335": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
     ],
-    "js/features/ColumnList/index.tsx:3552909395": [
-      [205, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:2085568133": [
+      [218, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]

--- a/frontend/amundsen_application/static/js/components/SVGIcons/GraphIcon.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/GraphIcon.tsx
@@ -9,7 +9,7 @@ import { IconProps } from './types';
 import { DEFAULT_CIRCLE_FILL_COLOR } from './constants';
 
 export const GraphIcon: React.FC<IconProps> = ({
-  size = IconSizes.SMALL,
+  size = IconSizes.REGULAR,
   fill = DEFAULT_CIRCLE_FILL_COLOR,
 }: IconProps) => {
   const id = `graph_icon_${uuidv4()}`;

--- a/frontend/amundsen_application/static/js/components/SVGIcons/GraphIcon.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/GraphIcon.tsx
@@ -9,7 +9,7 @@ import { IconProps } from './types';
 import { DEFAULT_CIRCLE_FILL_COLOR } from './constants';
 
 export const GraphIcon: React.FC<IconProps> = ({
-  size = IconSizes.REGULAR,
+  size = IconSizes.SMALL,
   fill = DEFAULT_CIRCLE_FILL_COLOR,
 }: IconProps) => {
   const id = `graph_icon_${uuidv4()}`;

--- a/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
@@ -8,3 +8,4 @@ export const COLUMN_LINEAGE_DOWNSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} 
 export const COLUMN_LINEAGE_UPSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} Upstream Columns`;
 export const COLUMN_LINEAGE_MORE_TEXT = 'See More';
 export const COPY_COLUMN_LINK_TEXT = 'Copy Column Link';
+export const HAS_COLUMN_STATS = 'Column stats available';

--- a/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
@@ -8,4 +8,4 @@ export const COLUMN_LINEAGE_DOWNSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} 
 export const COLUMN_LINEAGE_UPSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} Upstream Columns`;
 export const COLUMN_LINEAGE_MORE_TEXT = 'See More';
 export const COPY_COLUMN_LINK_TEXT = 'Copy Column Link';
-export const HAS_COLUMN_STATS = 'Column stats available';
+export const HAS_COLUMN_STATS_TEXT = 'Column stats available';

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -231,11 +231,13 @@ describe('ColumnList', () => {
 
       it('should not show column statistics icon', () => {
         const { wrapper } = setup({ columns });
+        const expectedLength = 0;
 
-        const expected = 0;
-        const actual = wrapper.find('GraphIcon').length;
+        const iconElementLength = wrapper.find('GraphIcon').length;
+        const overlayTriggerLength = wrapper.find('OverlayTrigger').length;
 
-        expect(actual).toEqual(expected);
+        expect(iconElementLength).toEqual(expectedLength);
+        expect(overlayTriggerLength).toEqual(expectedLength);
       });
     });
 
@@ -252,11 +254,13 @@ describe('ColumnList', () => {
 
       it('should show column statistics icon', () => {
         const { wrapper } = setup({ columns });
+        const expectedLength = 1;
 
-        const expected = 1;
-        const actual = wrapper.find('GraphIcon').length;
+        const iconElementLength = wrapper.find('GraphIcon').length;
+        const overlayTriggerLength = wrapper.find('OverlayTrigger').length;
 
-        expect(actual).toEqual(expected);
+        expect(iconElementLength).toEqual(expectedLength);
+        expect(overlayTriggerLength).toEqual(expectedLength);
       });
     });
 
@@ -273,11 +277,13 @@ describe('ColumnList', () => {
 
       it('should show column statistics icon', () => {
         const { wrapper } = setup({ columns });
+        const expectedLength = columns.length;
 
-        const expected = columns.length;
-        const actual = wrapper.find('GraphIcon').length;
+        const iconElementLength = wrapper.find('GraphIcon').length;
+        const overlayTriggerLength = wrapper.find('OverlayTrigger').length;
 
-        expect(actual).toEqual(expected);
+        expect(iconElementLength).toEqual(expectedLength);
+        expect(overlayTriggerLength).toEqual(expectedLength);
       });
 
       describe('when usage sorting is passed', () => {

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -37,6 +37,7 @@ import {
   SortCriteria,
   SortDirection,
   Badge,
+  IconSizes,
 } from 'interfaces';
 import { TABLE_TAB } from 'pages/TableDetailPage/constants';
 import { logAction } from 'utils/analytics';
@@ -54,7 +55,7 @@ import {
   EMPTY_MESSAGE,
   EDITABLE_SECTION_TITLE,
   COPY_COLUMN_LINK_TEXT,
-  HAS_COLUMN_STATS,
+  HAS_COLUMN_STATS_TEXT,
 } from './constants';
 
 import './styles.scss';
@@ -191,7 +192,7 @@ const getColumnMetadataIconElement = (key, popoverText, iconElement) => (
     placement="top"
     overlay={<Popover id="popover-trigger-hover-focus">{popoverText}</Popover>}
   >
-    <div>{iconElement}</div>
+    <span>{iconElement}</span>
   </OverlayTrigger>
 );
 
@@ -338,8 +339,8 @@ const ColumnList: React.FC<ColumnListProps> = ({
         if (hasStats) {
           const hasStatsIcon = getColumnMetadataIconElement(
             'has-stats',
-            HAS_COLUMN_STATS,
-            <GraphIcon />
+            HAS_COLUMN_STATS_TEXT,
+            <GraphIcon size={IconSizes.SMALL} />
           );
           columnMetadataIcons = [...columnMetadataIcons, hasStatsIcon];
         }
@@ -348,7 +349,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
           <>
             {nestedLevel > 0 && (
               <>
-                <div className={`nesting-arrow-spacer spacer-${nestedLevel}`} />
+                <span className={`nesting-arrow-spacer spacer-${nestedLevel}`} />
                 <NestingArrow />
               </>
             )}

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -349,7 +349,9 @@ const ColumnList: React.FC<ColumnListProps> = ({
           <>
             {nestedLevel > 0 && (
               <>
-                <span className={`nesting-arrow-spacer spacer-${nestedLevel}`} />
+                <span
+                  className={`nesting-arrow-spacer spacer-${nestedLevel}`}
+                />
                 <NestingArrow />
               </>
             )}

--- a/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
@@ -75,6 +75,11 @@ $nested-arrow-spacer-max: $nested-arrow-spacer * 4;
     display: inline-block;
   }
 
+  .column-name-with-icons {
+    display: flex;
+    gap: $spacer-1;
+  }
+
   .ams-table-header {
     background-color: white;
   }


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Previously, an icon indicating that a column had stats was added to the left of the column name. This was to let users know at a glance if they should care about expanding the column details to see the stats. This change moves the location of that icon to the right side of the column name and moves the column name further left. This is to set up for coming improvements to nested columns, to allow for more screen space for indented column names. This also sets up the UI for the introduction of additional icons to indicate other column metadata, such as unique values, lineage, etc that can be added inline with the stats icon.

<img width="935" alt="Screen Shot 2022-04-05 at 3 54 34 PM 2" src="https://user-images.githubusercontent.com/6732445/161865157-f7cdf7da-eb26-495c-8fe4-030180bc3224.png">

### Tests

Added checking for `OverlayTrigger` components to the existing tests for the stats icon.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
