### PR TITLE
feat: Reducing width of left side panel on resource detail pages

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -500,7 +500,7 @@ exports[`eslint`] = {
     "js/features/ColumnList/index.spec.tsx:66693458": [
       [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
     ],
-    "js/features/ColumnList/index.tsx:417641019": [
+    "js/features/ColumnList/index.tsx:1069626171": [
       [219, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
@@ -589,7 +589,7 @@ exports[`eslint`] = {
       [22, 0, 63, "\`../../fixtures/mockRouter\` import should occur before import of \`./ChartList\`", "1389010998"],
       [24, 0, 41, "\`./constants\` import should occur before import of \`.\`", "1965203596"]
     ],
-    "js/pages/DashboardPage/index.tsx:3034144558": [
+    "js/pages/DashboardPage/index.tsx:551950010": [
       [119, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
       [208, 10, 7, "A form label must be associated with a control.", "2729454337"]
     ],
@@ -708,7 +708,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:4211828621": [
+    "js/pages/TableDetailPage/index.tsx:1784772787": [
       [147, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [189, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -589,9 +589,8 @@ exports[`eslint`] = {
       [22, 0, 63, "\`../../fixtures/mockRouter\` import should occur before import of \`./ChartList\`", "1389010998"],
       [24, 0, 41, "\`./constants\` import should occur before import of \`.\`", "1965203596"]
     ],
-    "js/pages/DashboardPage/index.tsx:551950010": [
-      [119, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [208, 10, 7, "A form label must be associated with a control.", "2729454337"]
+    "js/pages/DashboardPage/index.tsx:3925966750": [
+      [130, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/pages/HomePage/index.spec.tsx:2731110878": [
       [33, 4, 25, "Use object destructuring.", "354229464"],
@@ -708,7 +707,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:1784772787": [
+    "js/pages/TableDetailPage/index.tsx:2188560127": [
       [147, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [189, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -5,10 +5,12 @@
 @import 'typography';
 
 $resource-header-height: 84px;
-$aside-separation-space: 40px;
+$aside-separation-space: 30px;
 $screen-lg-container: 1440px;
 $header-link-height: 32px;
 $icon-header-size: 32px;
+$inner-column-size: 162px;
+$left-panel-size: 400px;
 
 .resource-detail-layout {
   height: calc(100vh - #{$nav-bar-height} - #{$footer-height});
@@ -104,7 +106,7 @@ $icon-header-size: 32px;
 
     > .left-panel {
       border-right: 4px solid $divider;
-      flex-basis: 600px;
+      flex-basis: $left-panel-size;
       flex-shrink: 0;
       min-height: min-content;
       overflow-y: auto;
@@ -180,13 +182,13 @@ $icon-header-size: 32px;
     display: flex;
 
     > .left-panel {
-      flex-basis: 262px;
+      flex-basis: $inner-column-size;
       flex-direction: column;
       margin-right: 12px;
     }
 
     > .right-panel {
-      flex-basis: 262px;
+      flex-basis: $inner-column-size;
       margin-left: 12px;
     }
   }

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -9,8 +9,8 @@ $aside-separation-space: 30px;
 $screen-lg-container: 1440px;
 $header-link-height: 32px;
 $icon-header-size: 32px;
-$inner-column-size: 162px;
-$left-panel-size: 400px;
+$inner-column-size: 175px;
+$left-panel-size: 425px;
 
 .resource-detail-layout {
   height: calc(100vh - #{$nav-bar-height} - #{$footer-height});

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -100,7 +100,7 @@ $left-panel-size: 425px;
   }
 
   // Outer column layout
-  .column-layout-1 {
+  .single-column-layout {
     display: flex;
     height: calc(100% - #{$resource-header-height});
 
@@ -156,7 +156,7 @@ $left-panel-size: 425px;
       }
     }
 
-    > .right-panel {
+    > .main-content-panel {
       flex-basis: 500px;
       flex-grow: 1;
       flex-shrink: 0;
@@ -178,23 +178,23 @@ $left-panel-size: 425px;
   }
 
   // Inner column layout
-  .column-layout-2 {
+  .two-column-layout {
     display: flex;
 
-    > .left-panel {
+    > .left-column {
       flex-basis: $inner-column-size;
       flex-direction: column;
       margin-right: 12px;
     }
 
-    > .right-panel {
+    > .right-column {
       flex-basis: $inner-column-size;
       margin-left: 12px;
     }
   }
 
   .left-panel,
-  .right-panel {
+  .main-content-panel {
     display: flex;
     flex-direction: column;
   }

--- a/frontend/amundsen_application/static/js/components/TabsComponent/styles.scss
+++ b/frontend/amundsen_application/static/js/components/TabsComponent/styles.scss
@@ -58,7 +58,7 @@
     }
   }
 
-  .right-panel & {
+  .main-content-panel & {
     .tab-content .list-group-item:first-child {
       border-top: none;
     }

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/constants.ts
@@ -1,10 +1,21 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
 export const TABLES_PER_PAGE = 10;
 export const DASHBOARD_SOURCE = 'dashboard_page';
 
-export const OWNER_HEADER_TEXT = 'Owners';
+export const DESCRIPTION_TITLE = 'Description';
+export const OWNERS_TITLE = 'Owners';
+export const CREATED_TITLE = 'Created';
+export const LAST_UPDATED_TITLE = 'Last Updated';
+export const RECENT_VIEW_COUNT_TITLE = 'Recent View Count';
+export const TAG_TITLE = 'Tags';
+export const LAST_SUCCESSFUL_RUN_TITLE = 'Last Successful Run';
+export const LAST_RUN_TITLE = 'Last Run';
 
 export const ADD_DESC_TEXT = 'Add Description in';
 export const EDIT_DESC_TEXT = 'Click to edit description in';
+export const ERROR_MESSAGE = 'Something went wrong...';
 
 export const LAST_RUN_SUCCEEDED = 'succeeded';
 export const STATUS_TEXT = 'Status:';
@@ -12,6 +23,10 @@ export const STATUS_TEXT = 'Status:';
 export const TABLES_TAB_TITLE = 'Tables';
 export const CHARTS_TAB_TITLE = 'Charts';
 export const QUERIES_TAB_TITLE = 'Queries';
+
+export const DASHBOARD_IN_LABEL = 'Dashboard in';
+export const OPEN_GROUP_LABEL = 'Open Group';
+export const OPEN_DASHBOARD_LABEL = 'Open Dashboard';
 
 export enum DASHBOARD_TAB {
   TABLE = 'tables',

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
@@ -43,7 +43,8 @@ import { NO_TIMESTAMP_TEXT } from '../../constants';
 import {
   ADD_DESC_TEXT,
   EDIT_DESC_TEXT,
-  OWNER_HEADER_TEXT,
+  ERROR_MESSAGE,
+  OWNERS_TITLE,
   DASHBOARD_SOURCE,
   TABLES_PER_PAGE,
   LAST_RUN_SUCCEEDED,
@@ -52,6 +53,16 @@ import {
   TABLES_TAB_TITLE,
   CHARTS_TAB_TITLE,
   QUERIES_TAB_TITLE,
+  DASHBOARD_IN_LABEL,
+  OPEN_GROUP_LABEL,
+  OPEN_DASHBOARD_LABEL,
+  CREATED_TITLE,
+  LAST_UPDATED_TITLE,
+  RECENT_VIEW_COUNT_TITLE,
+  TAG_TITLE,
+  LAST_SUCCESSFUL_RUN_TITLE,
+  LAST_RUN_TITLE,
+  DESCRIPTION_TITLE,
 } from './constants';
 import ChartList from './ChartList';
 import QueryList from './QueryList';
@@ -206,7 +217,7 @@ export class DashboardPage extends React.Component<
       return (
         <div className="container error-label">
           <Breadcrumb />
-          <label>Something went wrong...</label>
+          <label>{ERROR_MESSAGE}</label>
         </div>
       );
     }
@@ -231,11 +242,11 @@ export class DashboardPage extends React.Component<
               bookmarkKey={dashboard.uri}
               resourceType={ResourceType.dashboard}
             />
-            <div className="body-2">
-              Dashboard in&nbsp;
+            <div className="header-details">
+              {DASHBOARD_IN_LABEL}&nbsp;
               <button
                 type="button"
-                className="btn btn-link body-2"
+                className="btn btn-link header-details"
                 data-type="dashboard-group-link"
                 onClick={this.searchGroup}
               >
@@ -253,7 +264,7 @@ export class DashboardPage extends React.Component<
               className="btn btn-default btn-lg dashboard-group"
               rel="noopener noreferrer"
             >
-              Open Group
+              {OPEN_GROUP_LABEL}
             </a>
             <a
               data-type="dashboard-link"
@@ -263,11 +274,11 @@ export class DashboardPage extends React.Component<
               className="btn btn-default btn-lg"
               rel="noopener noreferrer"
             >
-              Open Dashboard
+              {OPEN_DASHBOARD_LABEL}
             </a>
           </div>
         </header>
-        <article className="column-layout-1">
+        <article className="single-column-layout">
           <aside className="left-panel">
             {!!dashboardNotice && (
               <Alert
@@ -276,7 +287,7 @@ export class DashboardPage extends React.Component<
               />
             )}
             <EditableSection
-              title="Description"
+              title={DESCRIPTION_TITLE}
               readOnly
               editUrl={dashboard.url}
               editText={`${EDIT_DESC_TEXT} ${getSourceDisplayName(
@@ -291,7 +302,7 @@ export class DashboardPage extends React.Component<
               )}
               {!hasDescription && (
                 <a
-                  className="edit-link body-2"
+                  className="edit-link dashboard-details-body-text"
                   target="_blank"
                   href={dashboard.url}
                   rel="noopener noreferrer"
@@ -303,36 +314,36 @@ export class DashboardPage extends React.Component<
                 </a>
               )}
             </EditableSection>
-            <section className="column-layout-2">
-              <section className="left-panel">
-                <EditableSection title={OWNER_HEADER_TEXT} readOnly>
+            <section className="two-column-layout">
+              <section className="left-column">
+                <EditableSection title={OWNERS_TITLE} readOnly>
                   <DashboardOwnerEditor resourceType={ResourceType.dashboard} />
                 </EditableSection>
                 <section className="metadata-section">
-                  <div className="section-title title-3">Created</div>
-                  <time className="body-2 text-primary">
+                  <div className="section-title">{CREATED_TITLE}</div>
+                  <time className="dashboard-details-body-text text-primary">
                     {formatDateTimeShort({
                       epochTimestamp: dashboard.created_timestamp,
                     })}
                   </time>
                 </section>
                 <section className="metadata-section">
-                  <div className="section-title title-3">Last Updated</div>
-                  <time className="body-2 text-primary">
+                  <div className="section-title">{LAST_UPDATED_TITLE}</div>
+                  <time className="dashboard-details-body-text text-primary">
                     {formatDateTimeShort({
                       epochTimestamp: dashboard.updated_timestamp,
                     })}
                   </time>
                 </section>
                 <section className="metadata-section">
-                  <div className="section-title title-3">Recent View Count</div>
-                  <div className="body-2 text-primary">
+                  <div className="section-title">{RECENT_VIEW_COUNT_TITLE}</div>
+                  <div className="dashboard-details-body-text text-primary">
                     {dashboard.recent_view_count}
                   </div>
                 </section>
               </section>
-              <section className="right-panel">
-                <EditableSection title="Tags">
+              <section className="right-column">
+                <EditableSection title={TAG_TITLE}>
                   <TagInput
                     resourceType={ResourceType.dashboard}
                     uriKey={dashboard.uri}
@@ -340,10 +351,10 @@ export class DashboardPage extends React.Component<
                 </EditableSection>
                 {hasLastRunState && [
                   <section className="metadata-section">
-                    <div className="section-title title-3">
-                      Last Successful Run
+                    <div className="section-title">
+                      {LAST_SUCCESSFUL_RUN_TITLE}
                     </div>
-                    <time className="last-successful-run-timestamp body-2 text-primary">
+                    <time className="last-successful-run-timestamp dashboard-details-body-text text-primary">
                       {dashboard.last_successful_run_timestamp
                         ? formatDateTimeShort({
                             epochTimestamp:
@@ -353,9 +364,9 @@ export class DashboardPage extends React.Component<
                     </time>
                   </section>,
                   <section className="metadata-section">
-                    <div className="section-title title-3">Last Run</div>
+                    <div className="section-title">{LAST_RUN_TITLE}</div>
                     <div>
-                      <time className="last-run-timestamp body-2 text-primary">
+                      <time className="last-run-timestamp dashboard-details-body-text text-primary">
                         {dashboard.last_run_timestamp
                           ? formatDateTimeShort({
                               epochTimestamp: dashboard.last_run_timestamp,
@@ -378,7 +389,7 @@ export class DashboardPage extends React.Component<
             </section>
             <ImagePreview uri={stateURI} redirectUrl={dashboard.url} />
           </aside>
-          <main className="right-panel">{this.renderTabs()}</main>
+          <main className="main-content-panel">{this.renderTabs()}</main>
         </article>
       </div>
     );

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
@@ -303,79 +303,70 @@ export class DashboardPage extends React.Component<
                 </a>
               )}
             </EditableSection>
-            <section className="column-layout-2">
-              <section className="left-panel">
-                <EditableSection title={OWNER_HEADER_TEXT} readOnly>
-                  <DashboardOwnerEditor resourceType={ResourceType.dashboard} />
-                </EditableSection>
-                <section className="metadata-section">
-                  <div className="section-title title-3">Created</div>
-                  <time className="body-2 text-primary">
-                    {formatDateTimeShort({
-                      epochTimestamp: dashboard.created_timestamp,
-                    })}
-                  </time>
-                </section>
-                <section className="metadata-section">
-                  <div className="section-title title-3">Last Updated</div>
-                  <time className="body-2 text-primary">
-                    {formatDateTimeShort({
-                      epochTimestamp: dashboard.updated_timestamp,
-                    })}
-                  </time>
-                </section>
-                <section className="metadata-section">
-                  <div className="section-title title-3">Recent View Count</div>
-                  <div className="body-2 text-primary">
-                    {dashboard.recent_view_count}
-                  </div>
-                </section>
-              </section>
-              <section className="right-panel">
-                <EditableSection title="Tags">
-                  <TagInput
-                    resourceType={ResourceType.dashboard}
-                    uriKey={dashboard.uri}
-                  />
-                </EditableSection>
-                {hasLastRunState && [
-                  <section className="metadata-section">
-                    <div className="section-title title-3">
-                      Last Successful Run
-                    </div>
-                    <time className="last-successful-run-timestamp body-2 text-primary">
-                      {dashboard.last_successful_run_timestamp
-                        ? formatDateTimeShort({
-                            epochTimestamp:
-                              dashboard.last_successful_run_timestamp,
-                          })
-                        : NO_TIMESTAMP_TEXT}
-                    </time>
-                  </section>,
-                  <section className="metadata-section">
-                    <div className="section-title title-3">Last Run</div>
-                    <div>
-                      <time className="last-run-timestamp body-2 text-primary">
-                        {dashboard.last_run_timestamp
-                          ? formatDateTimeShort({
-                              epochTimestamp: dashboard.last_run_timestamp,
-                            })
-                          : NO_TIMESTAMP_TEXT}
-                      </time>
-                      <div className="last-run-state">
-                        <span className="status">{STATUS_TEXT}</span>
-                        <ResourceStatusMarker
-                          stateText={dashboard.last_run_state}
-                          succeeded={this.mapStatusToBoolean(
-                            dashboard.last_run_state
-                          )}
-                        />
-                      </div>
-                    </div>
-                  </section>,
-                ]}
-              </section>
+            <EditableSection title={OWNER_HEADER_TEXT} readOnly>
+              <DashboardOwnerEditor resourceType={ResourceType.dashboard} />
+            </EditableSection>
+            <section className="metadata-section">
+              <div className="section-title title-3">Created</div>
+              <time className="body-2 text-primary">
+                {formatDateTimeShort({
+                  epochTimestamp: dashboard.created_timestamp,
+                })}
+              </time>
             </section>
+            <section className="metadata-section">
+              <div className="section-title title-3">Last Updated</div>
+              <time className="body-2 text-primary">
+                {formatDateTimeShort({
+                  epochTimestamp: dashboard.updated_timestamp,
+                })}
+              </time>
+            </section>
+            <section className="metadata-section">
+              <div className="section-title title-3">Recent View Count</div>
+              <div className="body-2 text-primary">
+                {dashboard.recent_view_count}
+              </div>
+            </section>
+            <EditableSection title="Tags">
+              <TagInput
+                resourceType={ResourceType.dashboard}
+                uriKey={dashboard.uri}
+              />
+            </EditableSection>
+            {hasLastRunState && [
+              <section className="metadata-section">
+                <div className="section-title title-3">Last Successful Run</div>
+                <time className="last-successful-run-timestamp body-2 text-primary">
+                  {dashboard.last_successful_run_timestamp
+                    ? formatDateTimeShort({
+                        epochTimestamp: dashboard.last_successful_run_timestamp,
+                      })
+                    : NO_TIMESTAMP_TEXT}
+                </time>
+              </section>,
+              <section className="metadata-section">
+                <div className="section-title title-3">Last Run</div>
+                <div>
+                  <time className="last-run-timestamp body-2 text-primary">
+                    {dashboard.last_run_timestamp
+                      ? formatDateTimeShort({
+                          epochTimestamp: dashboard.last_run_timestamp,
+                        })
+                      : NO_TIMESTAMP_TEXT}
+                  </time>
+                  <div className="last-run-state">
+                    <span className="status">{STATUS_TEXT}</span>
+                    <ResourceStatusMarker
+                      stateText={dashboard.last_run_state}
+                      succeeded={this.mapStatusToBoolean(
+                        dashboard.last_run_state
+                      )}
+                    />
+                  </div>
+                </div>
+              </section>,
+            ]}
             <ImagePreview uri={stateURI} redirectUrl={dashboard.url} />
           </aside>
           <main className="right-panel">{this.renderTabs()}</main>

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
@@ -303,70 +303,79 @@ export class DashboardPage extends React.Component<
                 </a>
               )}
             </EditableSection>
-            <EditableSection title={OWNER_HEADER_TEXT} readOnly>
-              <DashboardOwnerEditor resourceType={ResourceType.dashboard} />
-            </EditableSection>
-            <section className="metadata-section">
-              <div className="section-title title-3">Created</div>
-              <time className="body-2 text-primary">
-                {formatDateTimeShort({
-                  epochTimestamp: dashboard.created_timestamp,
-                })}
-              </time>
-            </section>
-            <section className="metadata-section">
-              <div className="section-title title-3">Last Updated</div>
-              <time className="body-2 text-primary">
-                {formatDateTimeShort({
-                  epochTimestamp: dashboard.updated_timestamp,
-                })}
-              </time>
-            </section>
-            <section className="metadata-section">
-              <div className="section-title title-3">Recent View Count</div>
-              <div className="body-2 text-primary">
-                {dashboard.recent_view_count}
-              </div>
-            </section>
-            <EditableSection title="Tags">
-              <TagInput
-                resourceType={ResourceType.dashboard}
-                uriKey={dashboard.uri}
-              />
-            </EditableSection>
-            {hasLastRunState && [
-              <section className="metadata-section">
-                <div className="section-title title-3">Last Successful Run</div>
-                <time className="last-successful-run-timestamp body-2 text-primary">
-                  {dashboard.last_successful_run_timestamp
-                    ? formatDateTimeShort({
-                        epochTimestamp: dashboard.last_successful_run_timestamp,
-                      })
-                    : NO_TIMESTAMP_TEXT}
-                </time>
-              </section>,
-              <section className="metadata-section">
-                <div className="section-title title-3">Last Run</div>
-                <div>
-                  <time className="last-run-timestamp body-2 text-primary">
-                    {dashboard.last_run_timestamp
-                      ? formatDateTimeShort({
-                          epochTimestamp: dashboard.last_run_timestamp,
-                        })
-                      : NO_TIMESTAMP_TEXT}
+            <section className="column-layout-2">
+              <section className="left-panel">
+                <EditableSection title={OWNER_HEADER_TEXT} readOnly>
+                  <DashboardOwnerEditor resourceType={ResourceType.dashboard} />
+                </EditableSection>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Created</div>
+                  <time className="body-2 text-primary">
+                    {formatDateTimeShort({
+                      epochTimestamp: dashboard.created_timestamp,
+                    })}
                   </time>
-                  <div className="last-run-state">
-                    <span className="status">{STATUS_TEXT}</span>
-                    <ResourceStatusMarker
-                      stateText={dashboard.last_run_state}
-                      succeeded={this.mapStatusToBoolean(
-                        dashboard.last_run_state
-                      )}
-                    />
+                </section>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Last Updated</div>
+                  <time className="body-2 text-primary">
+                    {formatDateTimeShort({
+                      epochTimestamp: dashboard.updated_timestamp,
+                    })}
+                  </time>
+                </section>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Recent View Count</div>
+                  <div className="body-2 text-primary">
+                    {dashboard.recent_view_count}
                   </div>
-                </div>
-              </section>,
-            ]}
+                </section>
+              </section>
+              <section className="right-panel">
+                <EditableSection title="Tags">
+                  <TagInput
+                    resourceType={ResourceType.dashboard}
+                    uriKey={dashboard.uri}
+                  />
+                </EditableSection>
+                {hasLastRunState && [
+                  <section className="metadata-section">
+                    <div className="section-title title-3">
+                      Last Successful Run
+                    </div>
+                    <time className="last-successful-run-timestamp body-2 text-primary">
+                      {dashboard.last_successful_run_timestamp
+                        ? formatDateTimeShort({
+                            epochTimestamp:
+                              dashboard.last_successful_run_timestamp,
+                          })
+                        : NO_TIMESTAMP_TEXT}
+                    </time>
+                  </section>,
+                  <section className="metadata-section">
+                    <div className="section-title title-3">Last Run</div>
+                    <div>
+                      <time className="last-run-timestamp body-2 text-primary">
+                        {dashboard.last_run_timestamp
+                          ? formatDateTimeShort({
+                              epochTimestamp: dashboard.last_run_timestamp,
+                            })
+                          : NO_TIMESTAMP_TEXT}
+                      </time>
+                      <div className="last-run-state">
+                        <span className="status">{STATUS_TEXT}</span>
+                        <ResourceStatusMarker
+                          stateText={dashboard.last_run_state}
+                          succeeded={this.mapStatusToBoolean(
+                            dashboard.last_run_state
+                          )}
+                        />
+                      </div>
+                    </div>
+                  </section>,
+                ]}
+              </section>
+            </section>
             <ImagePreview uri={stateURI} redirectUrl={dashboard.url} />
           </aside>
           <main className="right-panel">{this.renderTabs()}</main>

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/styles.scss
@@ -20,12 +20,20 @@
     @extend %text-headline-w2;
   }
 
+  .header-details {
+    @extend %text-body-w2;
+  }
+
   .edit-link {
     text-decoration: none;
   }
 
   .dashboard-group {
     margin-right: $spacer-3;
+  }
+
+  .dashboard-details-body-text {
+    @extend %text-body-w2;
   }
 
   .last-run-state {

--- a/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
@@ -109,14 +109,14 @@ export const FeaturePageLoader: React.FC = () => (
         <div className="shimmer-page-subtitle is-shimmer-animated" />
       </section>
     </header>
-    <article className="column-layout-1">
+    <article className="single-column-layout">
       <aside className="left-panel">
         <section className="metadata-section">
           <div className="shimmer-section-title is-shimmer-animated" />
           <div className="shimmer-section-content is-shimmer-animated" />
         </section>
-        <section className="column-layout-2">
-          <section className="left-panel">
+        <section className="two-column-layout">
+          <section className="left-column">
             <section className="metadata-section">
               <div className="shimmer-section-title is-shimmer-animated" />
               <div className="shimmer-section-content is-shimmer-animated" />
@@ -134,7 +134,7 @@ export const FeaturePageLoader: React.FC = () => (
               <div className="shimmer-section-content is-shimmer-animated" />
             </section>
           </section>
-          <section className="right-panel">
+          <section className="right-column">
             <section className="metadata-section">
               <div className="shimmer-section-title is-shimmer-animated" />
               <div className="shimmer-section-content is-shimmer-animated" />
@@ -154,7 +154,7 @@ export const FeaturePageLoader: React.FC = () => (
           </section>
         </section>
       </aside>
-      <main className="right-panel">
+      <main className="main-content-panel">
         <section className="metadata-section">
           <div className="shimmer-tab-title">
             <div className="shimmer-tab is-shimmer-animated" />
@@ -284,7 +284,7 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
           </p>
         </section>
       </header>
-      <article className="column-layout-1">
+      <article className="single-column-layout">
         <aside className="left-panel">
           <EditableSection title={DESCRIPTION_TITLE}>
             <FeatureDescEditableText
@@ -293,8 +293,8 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
               editable
             />
           </EditableSection>
-          <section className="column-layout-2">
-            <section className="left-panel">
+          <section className="two-column-layout">
+            <section className="left-column">
               <section className="metadata-section">
                 <h3 className="section-title text-title-w3">{ENTITY_TITLE}</h3>
                 {feature.entity}
@@ -326,19 +326,18 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
                 />
               </EditableSection>
             </section>
-            <section className="right-panel">
+            <section className="right-column">
               <EditableSection title={OWNERS_TITLE}>
                 <FeatureOwnerEditor resourceType={ResourceType.feature} />
               </EditableSection>
-              {feature.partition_column !== null &&
-                feature.partition_column !== undefined && (
-                  <section className="metadata-section">
-                    <h3 className="section-title text-title-w3">
-                      {PARTITION_KEY_TITLE}
-                    </h3>
-                    {feature.partition_column}
-                  </section>
-                )}
+              {feature.partition_column && (
+                <section className="metadata-section">
+                  <h3 className="section-title text-title-w3">
+                    {PARTITION_KEY_TITLE}
+                  </h3>
+                  {feature.partition_column}
+                </section>
+              )}
               <section className="metadata-section">
                 <h3 className="section-title text-title-w3">{VERSION_TITLE}</h3>
                 {feature.version}
@@ -352,7 +351,7 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
             </section>
           </section>
         </aside>
-        <main className="right-panel">
+        <main className="main-content-panel">
           {renderTabs(featureCode, featureLineage, preview)}
         </main>
       </article>

--- a/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
@@ -293,55 +293,63 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
               editable
             />
           </EditableSection>
-          <section className="metadata-section">
-            <h3 className="section-title text-title-w3">{ENTITY_TITLE}</h3>
-            {feature.entity}
-          </section>
-          <section className="metadata-section">
-            <h3 className="section-title text-title-w3">{DATA_TYPE_TITLE}</h3>
-            {feature.data_type}
-          </section>
-          <section className="metadata-section">
-            <h3 className="section-title text-title-w3">{SOURCE_TITLE}</h3>
-            {feature.availability}
-          </section>
-          <section className="metadata-section">
-            <h3 className="section-title text-title-w3">
-              {LAST_UPDATED_TITLE}
-            </h3>
-            <time>
-              {formatDateTimeShort({
-                epochTimestamp: feature.last_updated_timestamp,
-              })}
-            </time>
-          </section>
-          <EditableSection title={TAG_TITLE}>
-            <TagInput
-              resourceType={ResourceType.feature}
-              uriKey={feature.key}
-            />
-          </EditableSection>
-          <EditableSection title={OWNERS_TITLE}>
-            <FeatureOwnerEditor resourceType={ResourceType.feature} />
-          </EditableSection>
-          {feature.partition_column !== null &&
-            feature.partition_column !== undefined && (
+          <section className="column-layout-2">
+            <section className="left-panel">
+              <section className="metadata-section">
+                <h3 className="section-title text-title-w3">{ENTITY_TITLE}</h3>
+                {feature.entity}
+              </section>
               <section className="metadata-section">
                 <h3 className="section-title text-title-w3">
-                  {PARTITION_KEY_TITLE}
+                  {DATA_TYPE_TITLE}
                 </h3>
-                {feature.partition_column}
+                {feature.data_type}
               </section>
-            )}
-          <section className="metadata-section">
-            <h3 className="section-title text-title-w3">{VERSION_TITLE}</h3>
-            {feature.version}
-          </section>
-          <section className="metadata-section">
-            <h3 className="section-title text-title-w3">
-              {FEATURE_GROUP_TITLE}
-            </h3>
-            {feature.feature_group}
+              <section className="metadata-section">
+                <h3 className="section-title text-title-w3">{SOURCE_TITLE}</h3>
+                {feature.availability}
+              </section>
+              <section className="metadata-section">
+                <h3 className="section-title text-title-w3">
+                  {LAST_UPDATED_TITLE}
+                </h3>
+                <time>
+                  {formatDateTimeShort({
+                    epochTimestamp: feature.last_updated_timestamp,
+                  })}
+                </time>
+              </section>
+              <EditableSection title={TAG_TITLE}>
+                <TagInput
+                  resourceType={ResourceType.feature}
+                  uriKey={feature.key}
+                />
+              </EditableSection>
+            </section>
+            <section className="right-panel">
+              <EditableSection title={OWNERS_TITLE}>
+                <FeatureOwnerEditor resourceType={ResourceType.feature} />
+              </EditableSection>
+              {feature.partition_column !== null &&
+                feature.partition_column !== undefined && (
+                  <section className="metadata-section">
+                    <h3 className="section-title text-title-w3">
+                      {PARTITION_KEY_TITLE}
+                    </h3>
+                    {feature.partition_column}
+                  </section>
+                )}
+              <section className="metadata-section">
+                <h3 className="section-title text-title-w3">{VERSION_TITLE}</h3>
+                {feature.version}
+              </section>
+              <section className="metadata-section">
+                <h3 className="section-title text-title-w3">
+                  {FEATURE_GROUP_TITLE}
+                </h3>
+                {feature.feature_group}
+              </section>
+            </section>
           </section>
         </aside>
         <main className="right-panel">

--- a/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
@@ -293,63 +293,55 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
               editable
             />
           </EditableSection>
-          <section className="column-layout-2">
-            <section className="left-panel">
-              <section className="metadata-section">
-                <h3 className="section-title text-title-w3">{ENTITY_TITLE}</h3>
-                {feature.entity}
-              </section>
-              <section className="metadata-section">
-                <h3 className="section-title text-title-w3">
-                  {DATA_TYPE_TITLE}
-                </h3>
-                {feature.data_type}
-              </section>
-              <section className="metadata-section">
-                <h3 className="section-title text-title-w3">{SOURCE_TITLE}</h3>
-                {feature.availability}
-              </section>
-              <section className="metadata-section">
-                <h3 className="section-title text-title-w3">
-                  {LAST_UPDATED_TITLE}
-                </h3>
-                <time>
-                  {formatDateTimeShort({
-                    epochTimestamp: feature.last_updated_timestamp,
-                  })}
-                </time>
-              </section>
-              <EditableSection title={TAG_TITLE}>
-                <TagInput
-                  resourceType={ResourceType.feature}
-                  uriKey={feature.key}
-                />
-              </EditableSection>
-            </section>
-            <section className="right-panel">
-              <EditableSection title={OWNERS_TITLE}>
-                <FeatureOwnerEditor resourceType={ResourceType.feature} />
-              </EditableSection>
-              {feature.partition_column !== null &&
-                feature.partition_column !== undefined && (
-                  <section className="metadata-section">
-                    <h3 className="section-title text-title-w3">
-                      {PARTITION_KEY_TITLE}
-                    </h3>
-                    {feature.partition_column}
-                  </section>
-                )}
-              <section className="metadata-section">
-                <h3 className="section-title text-title-w3">{VERSION_TITLE}</h3>
-                {feature.version}
-              </section>
+          <section className="metadata-section">
+            <h3 className="section-title text-title-w3">{ENTITY_TITLE}</h3>
+            {feature.entity}
+          </section>
+          <section className="metadata-section">
+            <h3 className="section-title text-title-w3">{DATA_TYPE_TITLE}</h3>
+            {feature.data_type}
+          </section>
+          <section className="metadata-section">
+            <h3 className="section-title text-title-w3">{SOURCE_TITLE}</h3>
+            {feature.availability}
+          </section>
+          <section className="metadata-section">
+            <h3 className="section-title text-title-w3">
+              {LAST_UPDATED_TITLE}
+            </h3>
+            <time>
+              {formatDateTimeShort({
+                epochTimestamp: feature.last_updated_timestamp,
+              })}
+            </time>
+          </section>
+          <EditableSection title={TAG_TITLE}>
+            <TagInput
+              resourceType={ResourceType.feature}
+              uriKey={feature.key}
+            />
+          </EditableSection>
+          <EditableSection title={OWNERS_TITLE}>
+            <FeatureOwnerEditor resourceType={ResourceType.feature} />
+          </EditableSection>
+          {feature.partition_column !== null &&
+            feature.partition_column !== undefined && (
               <section className="metadata-section">
                 <h3 className="section-title text-title-w3">
-                  {FEATURE_GROUP_TITLE}
+                  {PARTITION_KEY_TITLE}
                 </h3>
-                {feature.feature_group}
+                {feature.partition_column}
               </section>
-            </section>
+            )}
+          <section className="metadata-section">
+            <h3 className="section-title text-title-w3">{VERSION_TITLE}</h3>
+            {feature.version}
+          </section>
+          <section className="metadata-section">
+            <h3 className="section-title text-title-w3">
+              {FEATURE_GROUP_TITLE}
+            </h3>
+            {feature.feature_group}
           </section>
         </aside>
         <main className="right-panel">

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/constants.ts
@@ -1,5 +1,3 @@
 export const ISSUES_TITLE = 'Issues';
 export const NO_DATA_ISSUES_TEXT = 'No open issues';
 export const CREATE_ISSUE_ERROR_TEXT = 'Could not create issue!';
-export const SINGLE_ISSUE = 'issue';
-export const MULTIPLE_ISSUES = 'issues';

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.spec.tsx
@@ -107,9 +107,7 @@ describe('TableIssues', () => {
         openIssuesUrl: 'url',
         closedIssuesUrl: undefined,
       });
-      expect(wrapper.find('.table-issue-more-issues').text()).toEqual(
-        'View 1 open issue'
-      );
+      expect(wrapper.find('.table-issue-more-issues').text()).toEqual('1 open');
     });
 
     it('renders open issue and closed issue links if the urls are set', () => {
@@ -131,10 +129,10 @@ describe('TableIssues', () => {
         closedIssuesUrl: 'url',
       });
       expect(wrapper.find('.table-issue-more-issues').first().text()).toEqual(
-        'View 1 open issue'
+        '1 open'
       );
       expect(wrapper.find('.table-issue-more-issues').at(1).text()).toEqual(
-        'View 0 closed issues'
+        '0 closed'
       );
     });
   });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableIssues/index.tsx
@@ -15,8 +15,6 @@ import {
   ISSUES_TITLE,
   NO_DATA_ISSUES_TEXT,
   CREATE_ISSUE_ERROR_TEXT,
-  SINGLE_ISSUE,
-  MULTIPLE_ISSUES,
 } from './constants';
 import './styles.scss';
 
@@ -122,11 +120,6 @@ export class TableIssues extends React.Component<TableIssueProps> {
     const openIssueCount = openCount || 0;
     const closedIssueCount = totalCount - openIssueCount;
 
-    const openIssuesText =
-      openIssueCount === 1 ? SINGLE_ISSUE : MULTIPLE_ISSUES;
-    const closedIssuesText =
-      closedIssueCount === 1 ? SINGLE_ISSUE : MULTIPLE_ISSUES;
-
     const hasIssues = issues.length !== 0 || totalCount > 0;
 
     const reportIssueLink = (
@@ -150,7 +143,7 @@ export class TableIssues extends React.Component<TableIssueProps> {
             href={openIssuesUrl}
             onClick={logClick}
           >
-            View {openIssueCount} open {openIssuesText}
+            {openIssueCount} open
           </a>
         )}
         {openIssuesUrl && closedIssuesUrl ? '|' : ''}
@@ -165,7 +158,7 @@ export class TableIssues extends React.Component<TableIssueProps> {
             href={closedIssuesUrl}
             onClick={logClick}
           >
-            View {closedIssueCount} closed {closedIssuesText}
+            {closedIssueCount} closed
           </a>
         )}
         |{reportIssueLink}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -445,7 +445,7 @@ export class TableDetail extends React.Component<
                 bookmarkKey={data.key}
                 resourceType={ResourceType.table}
               />
-              <div className="body-2">
+              <div className="header-details">
                 <TableHeaderBullets
                   database={data.database}
                   cluster={data.cluster}
@@ -466,7 +466,7 @@ export class TableDetail extends React.Component<
               <ExploreButton tableData={data} />
             </div>
           </header>
-          <div className="column-layout-1">
+          <div className="single-column-layout">
             <aside className="left-panel">
               {!!tableNotice && (
                 <Alert
@@ -497,14 +497,14 @@ export class TableDetail extends React.Component<
                   />
                 </section>
               )}
-              <section className="column-layout-2">
-                <section className="left-panel">
+              <section className="two-column-layout">
+                <section className="left-column">
                   {!!data.last_updated_timestamp && (
                     <section className="metadata-section">
                       <div className="section-title">
                         {Constants.LAST_UPDATED_TITLE}
                       </div>
-                      <time className="body-2">
+                      <time className="time-body-text">
                         {formatDateTimeShort({
                           epochTimestamp: data.last_updated_timestamp,
                         })}
@@ -530,7 +530,7 @@ export class TableDetail extends React.Component<
                     data.programmatic_descriptions.left
                   )}
                 </section>
-                <section className="right-panel">
+                <section className="right-column">
                   <EditableSection
                     title={Constants.OWNERS_TITLE}
                     readOnly={!data.is_editable}
@@ -554,7 +554,7 @@ export class TableDetail extends React.Component<
                 data.programmatic_descriptions.other
               )}
             </aside>
-            <main className="right-panel">
+            <main className="main-content-panel">
               {currentTab === Constants.TABLE_TAB.COLUMN && (
                 <ListSortingDropdown
                   options={SORT_CRITERIAS}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -497,51 +497,59 @@ export class TableDetail extends React.Component<
                   />
                 </section>
               )}
-              {!!data.last_updated_timestamp && (
-                <section className="metadata-section">
-                  <div className="section-title">
-                    {Constants.LAST_UPDATED_TITLE}
-                  </div>
-                  <time className="body-2">
-                    {formatDateTimeShort({
-                      epochTimestamp: data.last_updated_timestamp,
-                    })}
-                  </time>
+              <section className="column-layout-2">
+                <section className="left-panel">
+                  {!!data.last_updated_timestamp && (
+                    <section className="metadata-section">
+                      <div className="section-title">
+                        {Constants.LAST_UPDATED_TITLE}
+                      </div>
+                      <time className="body-2">
+                        {formatDateTimeShort({
+                          epochTimestamp: data.last_updated_timestamp,
+                        })}
+                      </time>
+                    </section>
+                  )}
+                  <section className="metadata-section">
+                    <div className="section-title">
+                      {Constants.DATE_RANGE_TITLE}
+                    </div>
+                    <WatermarkLabel watermarks={data.watermarks} />
+                  </section>
+                  <EditableSection title={Constants.TAG_TITLE}>
+                    <TagInput
+                      resourceType={ResourceType.table}
+                      uriKey={tableData.key}
+                    />
+                  </EditableSection>
+                  {isTableQualityCheckEnabled() && (
+                    <TableQualityChecksLabel tableKey={tableData.key} />
+                  )}
+                  {this.renderProgrammaticDesc(
+                    data.programmatic_descriptions.left
+                  )}
                 </section>
-              )}
-              <section className="metadata-section">
-                <div className="section-title">
-                  {Constants.DATE_RANGE_TITLE}
-                </div>
-                <WatermarkLabel watermarks={data.watermarks} />
+                <section className="right-panel">
+                  <EditableSection
+                    title={Constants.OWNERS_TITLE}
+                    readOnly={!data.is_editable}
+                    editText={ownersEditText}
+                    editUrl={editUrl || undefined}
+                  >
+                    <TableOwnerEditor resourceType={ResourceType.table} />
+                  </EditableSection>
+                  <section className="metadata-section">
+                    <div className="section-title">
+                      {Constants.FREQ_USERS_TITLE}
+                    </div>
+                    <FrequentUsers readers={data.table_readers} />
+                  </section>
+                  {this.renderProgrammaticDesc(
+                    data.programmatic_descriptions.right
+                  )}
+                </section>
               </section>
-              <EditableSection title={Constants.TAG_TITLE}>
-                <TagInput
-                  resourceType={ResourceType.table}
-                  uriKey={tableData.key}
-                />
-              </EditableSection>
-              <EditableSection
-                title={Constants.OWNERS_TITLE}
-                readOnly={!data.is_editable}
-                editText={ownersEditText}
-                editUrl={editUrl || undefined}
-              >
-                <TableOwnerEditor resourceType={ResourceType.table} />
-              </EditableSection>
-              <section className="metadata-section">
-                <div className="section-title">
-                  {Constants.FREQ_USERS_TITLE}
-                </div>
-                <FrequentUsers readers={data.table_readers} />
-              </section>
-              {isTableQualityCheckEnabled() && (
-                <TableQualityChecksLabel tableKey={tableData.key} />
-              )}
-              {this.renderProgrammaticDesc(data.programmatic_descriptions.left)}
-              {this.renderProgrammaticDesc(
-                data.programmatic_descriptions.right
-              )}
               {this.renderProgrammaticDesc(
                 data.programmatic_descriptions.other
               )}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -497,59 +497,51 @@ export class TableDetail extends React.Component<
                   />
                 </section>
               )}
-              <section className="column-layout-2">
-                <section className="left-panel">
-                  {!!data.last_updated_timestamp && (
-                    <section className="metadata-section">
-                      <div className="section-title">
-                        {Constants.LAST_UPDATED_TITLE}
-                      </div>
-                      <time className="body-2">
-                        {formatDateTimeShort({
-                          epochTimestamp: data.last_updated_timestamp,
-                        })}
-                      </time>
-                    </section>
-                  )}
-                  <section className="metadata-section">
-                    <div className="section-title">
-                      {Constants.DATE_RANGE_TITLE}
-                    </div>
-                    <WatermarkLabel watermarks={data.watermarks} />
-                  </section>
-                  <EditableSection title={Constants.TAG_TITLE}>
-                    <TagInput
-                      resourceType={ResourceType.table}
-                      uriKey={tableData.key}
-                    />
-                  </EditableSection>
-                  {isTableQualityCheckEnabled() && (
-                    <TableQualityChecksLabel tableKey={tableData.key} />
-                  )}
-                  {this.renderProgrammaticDesc(
-                    data.programmatic_descriptions.left
-                  )}
+              {!!data.last_updated_timestamp && (
+                <section className="metadata-section">
+                  <div className="section-title">
+                    {Constants.LAST_UPDATED_TITLE}
+                  </div>
+                  <time className="body-2">
+                    {formatDateTimeShort({
+                      epochTimestamp: data.last_updated_timestamp,
+                    })}
+                  </time>
                 </section>
-                <section className="right-panel">
-                  <EditableSection
-                    title={Constants.OWNERS_TITLE}
-                    readOnly={!data.is_editable}
-                    editText={ownersEditText}
-                    editUrl={editUrl || undefined}
-                  >
-                    <TableOwnerEditor resourceType={ResourceType.table} />
-                  </EditableSection>
-                  <section className="metadata-section">
-                    <div className="section-title">
-                      {Constants.FREQ_USERS_TITLE}
-                    </div>
-                    <FrequentUsers readers={data.table_readers} />
-                  </section>
-                  {this.renderProgrammaticDesc(
-                    data.programmatic_descriptions.right
-                  )}
-                </section>
+              )}
+              <section className="metadata-section">
+                <div className="section-title">
+                  {Constants.DATE_RANGE_TITLE}
+                </div>
+                <WatermarkLabel watermarks={data.watermarks} />
               </section>
+              <EditableSection title={Constants.TAG_TITLE}>
+                <TagInput
+                  resourceType={ResourceType.table}
+                  uriKey={tableData.key}
+                />
+              </EditableSection>
+              <EditableSection
+                title={Constants.OWNERS_TITLE}
+                readOnly={!data.is_editable}
+                editText={ownersEditText}
+                editUrl={editUrl || undefined}
+              >
+                <TableOwnerEditor resourceType={ResourceType.table} />
+              </EditableSection>
+              <section className="metadata-section">
+                <div className="section-title">
+                  {Constants.FREQ_USERS_TITLE}
+                </div>
+                <FrequentUsers readers={data.table_readers} />
+              </section>
+              {isTableQualityCheckEnabled() && (
+                <TableQualityChecksLabel tableKey={tableData.key} />
+              )}
+              {this.renderProgrammaticDesc(data.programmatic_descriptions.left)}
+              {this.renderProgrammaticDesc(
+                data.programmatic_descriptions.right
+              )}
               {this.renderProgrammaticDesc(
                 data.programmatic_descriptions.other
               )}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/styles.scss
@@ -5,10 +5,14 @@
 @import 'typography';
 
 .table-detail {
-  .column-layout-1 .left-panel {
+  .single-column-layout .left-panel {
     .alert {
       margin-top: $spacer-4;
       margin-bottom: 0;
+    }
+
+    .time-body-text {
+      @extend %text-body-w2;
     }
 
     .programmatic-title {
@@ -25,6 +29,10 @@
 
   .header-title-text {
     @extend %text-headline-w2;
+  }
+
+  .header-details {
+    @extend %text-body-w2;
   }
 
   .header-links {
@@ -55,7 +63,7 @@
     margin: 0 $spacer-1;
   }
 
-  .right-panel {
+  .main-content-panel {
     position: relative;
   }
 


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

The left side panel that is displayed on the table, dashboard, and feature detail pages has been reduced in size. This allows users to see more of the main content for these resources since this panel does not close. It is also part of a longer term plan for the table detail view to implement a right side panel that can open to display column details, and this change will also will allow more space when showing nested columns.

**Before:**
![Screen Shot 2022-04-11 at 4 38 49 PM](https://user-images.githubusercontent.com/6732445/162850884-e9152bd7-85c3-441a-973c-6734d685b699.png)

**After:**
![Screen Shot 2022-04-11 at 6 37 45 PM](https://user-images.githubusercontent.com/6732445/162861455-2b43f7cb-c406-4269-a6c6-4e0a71a5ec63.png)


### Tests

Updated TableIssues tests to account for the change made to the text in the links to view open and closed issues, to accommodate for the reduced space.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
