### PR TITLE
fix: change default exposed docker port from 5000 to 5555

### DIFF
--- a/docker-amundsen-atlas.yml
+++ b/docker-amundsen-atlas.yml
@@ -53,7 +53,7 @@ services:
       - amundsenmetadata
       - amundsensearch
     ports:
-      - 5000:5000
+      - 5555:5000
     networks:
       - amundsennet
     environment:

--- a/docker-amundsen-local.yml
+++ b/docker-amundsen-local.yml
@@ -69,7 +69,7 @@ services:
         - amundsenmetadata
         - amundsensearch
       ports:
-        - 5000:5000
+        - 5555:5000
       networks:
         - amundsennet
       environment:

--- a/docker-amundsen.yml
+++ b/docker-amundsen.yml
@@ -66,7 +66,7 @@ services:
         - amundsenmetadata
         - amundsensearch
       ports:
-        - 5000:5000
+        - 5555:5000
       networks:
         - amundsennet
       environment:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,7 +29,7 @@ The following instructions are for setting up a version of Amundsen using Docker
     $ python3 setup.py install
     $ python3 example/scripts/sample_data_loader.py
    ```
-5. View UI at [`http://localhost:5000`](http://localhost:5000) and try to search `test`, it should return some result.
+5. View UI at [`http://localhost:5555`](http://localhost:5555) and try to search `test`, it should return some result.
 ![](img/search-page.png)
 
 6. We could also do an exact matched search for table entity. For example: search `test_table1` in table field and 
@@ -45,8 +45,8 @@ Atlas would be ready once you'll have the following output in the docker output 
 1. You can verify dummy data has been ingested into Neo4j by by visiting [`http://localhost:7474/browser/`](http://localhost:7474/browser/) and run `MATCH (n:Table) RETURN n LIMIT 25` in the query box. You should see few tables.
 ![](img/neo4j-debug.png)
 2. You can verify the data has been loaded into the metadataservice by visiting:
-   1. [`http://localhost:5000/table_detail/gold/hive/test_schema/test_table1`](http://localhost:5000/table_detail/gold/hive/test_schema/test_table1)
-   2. [`http://localhost:5000/table_detail/gold/dynamo/test_schema/test_table2`](http://localhost:5000/table_detail/gold/dynamo/test_schema/test_table2)
+   1. [`http://localhost:5555/table_detail/gold/hive/test_schema/test_table1`](http://localhost:5555/table_detail/gold/hive/test_schema/test_table1)
+   2. [`http://localhost:5555/table_detail/gold/dynamo/test_schema/test_table2`](http://localhost:5555/table_detail/gold/dynamo/test_schema/test_table2)
 
 ### Troubleshooting
 
@@ -77,7 +77,7 @@ Atlas would be ready once you'll have the following output in the docker output 
  ```
    Then check if all 5 Amundsen related containers are running with `docker ps`? Can you connect to the Neo4j UI at http://localhost:7474/browser/ and similarly the raw ES API at http://localhost:9200? Does Docker logs reveal any serious issues?
 
-5. If ES container crashed with Docker error 137 on the first call from the website (http://localhost:5000/), this is because you are using the default Docker engine memory allocation of 2GB. The minimum needed for all the containers to run with the loaded sample data is 3GB. To do this go to your `Docker -> Preferences -> Resources -> Advanced` and increase the `Memory`, then restart the Docker engine.
+5. If ES container crashed with Docker error 137 on the first call from the website (http://localhost:5555/), this is because you are using the default Docker engine memory allocation of 2GB. The minimum needed for all the containers to run with the loaded sample data is 3GB. To do this go to your `Docker -> Preferences -> Resources -> Advanced` and increase the `Memory`, then restart the Docker engine.
 ![](img/docker_memory_setup.jpg)
 
 6. [Windows Troubleshooting](windows_troubleshooting.md)


### PR DESCRIPTION
Closes #1813

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

This PR changes the default port of the web service in:

- docker-amundsen-atlas.yml
- docker-amundsen-local.yml
- docker-amundsen.yml

To resolve an issue in which port 5000 conflicts on macOS Monterey.

Please let me know if this change is undesired, or if a port other than _5555_ would be more ideal. Thank you.

### Tests

Confirmed local environment was operational.

### Documentation

The _installation_ docs were updated to inform the user to navigate to localhost:5555 in place of localhost:5000.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
