### PR TITLE
fix: Improve Lineage chart UI

### DIFF
--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.ts
@@ -493,7 +493,6 @@ export const buildSVG = (el: HTMLElement, dimensions: Dimensions) => {
     .classed('svg-content', true)
     .attr('width', dimensions.width)
     .attr('height', dimensions.height)
-    .attr('height', dimensions.height)
     .attr('viewBox', `0 0 ${dimensions.width} ${dimensions.height}`)
     .attr('preserveAspectRatio', 'xMinYMin meet');
 

--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/constants.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/constants.ts
@@ -1,12 +1,14 @@
 export const LINEAGE_SCENE_MARGIN = {
-  top: 20,
-  right: 100,
-  bottom: 20,
-  left: 100,
+  top: 10,
+  right: 10,
+  bottom: 10,
+  left: 10,
 };
 export const CHART_DEFAULT_DIMENSIONS = { width: 1280, height: 1024 };
 export const CHART_DEFAULT_LABELS = { upstream: '', downstream: '' };
 export const UPSTREAM_LABEL_OFFSET = 200;
 export const NODE_STATUS_Y_OFFSET = '.30em';
+export const NODE_LABEL_X_OFFSET = 10;
 export const NODE_LABEL_Y_OFFSET = 25;
 export const ANIMATION_DURATION = 750;
+export const NODE_WIDTH = 450;

--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/index.spec.tsx
@@ -37,7 +37,7 @@ describe('Graph', () => {
         width: 1920,
         height: 1080,
       } as DOMRect);
-      expect(dimensions).toMatchObject({ height: 1040, width: 1720 });
+      expect(dimensions).toMatchObject({ height: 1060, width: 1900 });
     });
   });
 


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

### Summary of Changes

This PR introduces some UI improvements to especially fix the overlapping of node labels in the Lineage chart when there are many nodes being rendered.

This is achieved by assigning a fixed the horizontal space between different labels in the graph and rearranging the position of the labels based on the graph direction.

Here are the screenshot to compare before and after:

*Before:*
![Screenshot 2022-04-15 at 12 02 43](https://user-images.githubusercontent.com/5598573/163558010-c7a1a0e1-fd76-4135-8e6f-1dea4869c19a.png)

*After:*
![Screenshot 2022-04-15 at 11 10 04](https://user-images.githubusercontent.com/5598573/163558075-5fcc3650-bff0-4047-862a-05be6699e1d6.png)


### Tests

Updated one test case for Lineage graph dimension calculation.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
