### PR TITLE
feat: added highlight options to search API definition

### DIFF
--- a/common/amundsen_common/models/search.py
+++ b/common/amundsen_common/models/search.py
@@ -1,11 +1,23 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Dict
+from typing import Any, List, Optional, Dict
 
 import attr
 
 from marshmallow3_annotations.ext.attrs import AttrsSchema
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class HighlightOptions:
+    enable_highlight: bool = False
+    fields: Optional[Dict[str, Any]]
+
+
+class HighlightOptionsSchema(AttrsSchema):
+    class Meta:
+        target = HighlightOptions
+        register_as_scheme = True
 
 
 @attr.s(auto_attribs=True, kw_only=True)
@@ -28,8 +40,7 @@ class SearchRequest:
     page_index: Optional[int] = 0
     results_per_page: Optional[int] = 10
     filters: List[Filter] = []
-    highlight_matches: bool = False
-    highlight_field_options: Optional[Dict[str, Dict]] = {}
+    highlight_options: Optional[HighlightOptions]
 
 
 class SearchRequestSchema(AttrsSchema):
@@ -43,7 +54,7 @@ class SearchResponse:
     msg: str
     page_index: int
     results_per_page: int
-    results: Dict  # type: ignore
+    results: Dict[str, Any]  # type: ignore
     status_code: int
 
 

--- a/common/amundsen_common/models/search.py
+++ b/common/amundsen_common/models/search.py
@@ -28,6 +28,8 @@ class SearchRequest:
     page_index: Optional[int] = 0
     results_per_page: Optional[int] = 10
     filters: List[Filter] = []
+    highlight_matches: bool = False
+    highlight_field_options: Optional[Dict] = {}
 
 
 class SearchRequestSchema(AttrsSchema):

--- a/common/amundsen_common/models/search.py
+++ b/common/amundsen_common/models/search.py
@@ -55,7 +55,7 @@ class SearchResponse:
     msg: str
     page_index: int
     results_per_page: int
-    results: Dict[str, Any]  # type: ignore
+    results: Dict[str, Any]
     status_code: int
 
 

--- a/common/amundsen_common/models/search.py
+++ b/common/amundsen_common/models/search.py
@@ -40,7 +40,8 @@ class SearchRequest:
     page_index: Optional[int] = 0
     results_per_page: Optional[int] = 10
     filters: List[Filter] = []
-    highlight_options: Optional[HighlightOptions]
+    # highlight options are defined per resource
+    highlight_options: Optional[Dict[str, HighlightOptions]]
 
 
 class SearchRequestSchema(AttrsSchema):

--- a/common/amundsen_common/models/search.py
+++ b/common/amundsen_common/models/search.py
@@ -11,7 +11,6 @@ from marshmallow3_annotations.ext.attrs import AttrsSchema
 @attr.s(auto_attribs=True, kw_only=True)
 class HighlightOptions:
     enable_highlight: bool = False
-    fields: Optional[Dict[str, Any]]
 
 
 class HighlightOptionsSchema(AttrsSchema):

--- a/common/amundsen_common/models/search.py
+++ b/common/amundsen_common/models/search.py
@@ -29,7 +29,7 @@ class SearchRequest:
     results_per_page: Optional[int] = 10
     filters: List[Filter] = []
     highlight_matches: bool = False
-    highlight_field_options: Optional[Dict] = {}
+    highlight_field_options: Optional[Dict[str, Dict]] = {}
 
 
 class SearchRequestSchema(AttrsSchema):

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.26.2'
+__version__ = '0.27.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.26.0,<0.27.0
+amundsen-common>=0.26.0,<=0.27.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
Related PR for Search Service #1820 
Added optional `highlight_options` field to search request, these allow highlighting to be enabled for each resource like:
```
{
    "results_per_page": 10,
    "page_index": 0,
    "resource_types": [
        "table"
    ],
    "query_term": "amundsen",
    "filters": [],
    "highlight_options": {
        "table": {
            "enable_highlight": true
        }
    }
}
```