### PR TITLE
fix: Improve Lineage chart UI -- follow-up 

### DIFF
--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/chart.ts
@@ -34,6 +34,7 @@ export interface LineageChart {
 const NODE_LIMIT = 1000;
 const ROOT_RADIUS = 12;
 const NODE_RADIUS = 8;
+const CHARACTER_OFFSET = 10;
 
 /**
  * Generates a fixed node ID from original and offset
@@ -279,7 +280,7 @@ export const decompactLineage = (nodes): TreeLineageNode[] => {
   nodes.forEach((d, idx) => {
     const nodeLabel = getNodeLabel(d, idx);
     // Offset 10 pixels for each character
-    const currentNodeWidth = nodeLabel.length * 10 + NODE_RADIUS;
+    const currentNodeWidth = nodeLabel.length * CHARACTER_OFFSET + NODE_RADIUS;
     if (currentNodeWidth > depthMaxNodeWidthMapping[d.depth]) {
       depthMaxNodeWidthMapping[d.depth] = currentNodeWidth;
     }
@@ -346,11 +347,11 @@ export const buildEdges = (g, targetNode, nodes) => {
     .insert('path', 'g')
     .attr('class', 'graph-link')
     .attr('d', (d) => {
-      const o =
+      const coordinates =
         d.parent === null
           ? { x: targetNode.x0 || 0, y: targetNode.y0 || 0 }
           : { x: d.parent.x, y: d.parent.y };
-      return generatePath(o, o);
+      return generatePath(coordinates, coordinates);
     });
 
   // Render connection
@@ -367,8 +368,8 @@ export const buildEdges = (g, targetNode, nodes) => {
     .transition()
     .duration(ANIMATION_DURATION)
     .attr('d', (d) => {
-      const o = { x: d.parent.x, y: d.parent.y };
-      return generatePath(o, o);
+      const coordinates = { x: d.parent.x, y: d.parent.y };
+      return generatePath(coordinates, coordinates);
     })
     .remove();
 };

--- a/frontend/amundsen_application/static/js/components/Lineage/Graph/constants.ts
+++ b/frontend/amundsen_application/static/js/components/Lineage/Graph/constants.ts
@@ -11,4 +11,3 @@ export const NODE_STATUS_Y_OFFSET = '.30em';
 export const NODE_LABEL_X_OFFSET = 10;
 export const NODE_LABEL_Y_OFFSET = 25;
 export const ANIMATION_DURATION = 750;
-export const NODE_WIDTH = 450;


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

A follow-up to https://github.com/amundsen-io/amundsen/pull/1815, instead of assigning a fixed horizontal spacing between different levels of Lineage graph, this PR introduces the changes to set this spacing dynamically, based on the longest label length of that level.

Additionally, some changes are introduced to fix the transition effect of children nodes to move in and out from their respective parents. Previously, all nodes were transitioning from the root node.

### Tests

No test changes are needed for this UI change.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
