### PR TITLE
feat: Create right side column details panel

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -346,8 +346,8 @@ exports[`eslint`] = {
       [870, 16, 34, "Use array destructuring.", "4232426022"],
       [1012, 16, 36, "Use array destructuring.", "3910325707"]
     ],
-    "js/components/Table/index.tsx:1591338903": [
-      [307, 8, 65, "A control must be associated with a text label.", "1026764939"]
+    "js/components/Table/index.tsx:825995018": [
+      [311, 8, 65, "A control must be associated with a text label.", "1026764939"]
     ],
     "js/components/Table/table.story.tsx:3074937505": [
       [8, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -478,9 +478,6 @@ exports[`eslint`] = {
     "js/features/ColumnList/ColumnStats/columnStats.story.tsx:2552692472": [
       [9, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
     ],
-    "js/features/ColumnList/ColumnStats/index.spec.tsx:991779878": [
-      [7, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
-    ],
     "js/features/ColumnList/ColumnType/index.tsx:2472856984": [
       [34, 2, 30, "nestedType should be placed after constructor", "1117758211"],
       [105, 6, 36, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3801508926"],
@@ -497,11 +494,8 @@ exports[`eslint`] = {
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
-    "js/features/ColumnList/index.spec.tsx:66693458": [
-      [14, 0, 48, "\`.\` import should occur after import of \`./testDataBuilder\`", "1857255231"]
-    ],
-    "js/features/ColumnList/index.tsx:1069626171": [
-      [219, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:1921826144": [
+      [213, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -707,9 +701,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:2188560127": [
-      [147, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [189, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:3752164586": [
+      [151, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [196, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -494,8 +494,8 @@ exports[`eslint`] = {
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
-    "js/features/ColumnList/index.tsx:2990238595": [
-      [214, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:2489134410": [
+      [215, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -701,7 +701,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:3266708816": [
+    "js/pages/TableDetailPage/index.tsx:1823174837": [
       [152, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [198, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -346,8 +346,8 @@ exports[`eslint`] = {
       [870, 16, 34, "Use array destructuring.", "4232426022"],
       [1012, 16, 36, "Use array destructuring.", "3910325707"]
     ],
-    "js/components/Table/index.tsx:825995018": [
-      [311, 8, 65, "A control must be associated with a text label.", "1026764939"]
+    "js/components/Table/index.tsx:3090207501": [
+      [305, 8, 65, "A control must be associated with a text label.", "1026764939"]
     ],
     "js/components/Table/table.story.tsx:3074937505": [
       [8, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -494,8 +494,8 @@ exports[`eslint`] = {
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
-    "js/features/ColumnList/index.tsx:1921826144": [
-      [213, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:2990238595": [
+      [214, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -701,9 +701,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:3752164586": [
-      [151, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [196, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:3266708816": [
+      [152, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [198, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -494,8 +494,8 @@ exports[`eslint`] = {
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
-    "js/features/ColumnList/index.tsx:2489134410": [
-      [215, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:3072848928": [
+      [218, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -701,7 +701,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:1823174837": [
+    "js/pages/TableDetailPage/index.tsx:113370681": [
       [152, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [198, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -341,19 +341,11 @@ exports[`eslint`] = {
       [60, 2, 51, "refToSelf should be placed after componentWillUnmount", "3412474606"],
       [105, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
-    "js/components/Table/index.spec.tsx:2964078536": [
-      [9, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"],
-      [870, 16, 34, "Use array destructuring.", "4232426022"],
-      [1012, 16, 36, "Use array destructuring.", "3910325707"]
-    ],
-    "js/components/Table/index.tsx:3090207501": [
-      [305, 8, 65, "A control must be associated with a text label.", "1026764939"]
+    "js/components/Table/index.tsx:2629931458": [
+      [314, 8, 65, "A control must be associated with a text label.", "1026764939"]
     ],
     "js/components/Table/table.story.tsx:3074937505": [
       [8, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
-    ],
-    "js/components/Table/testDataBuilder.tsx:2393767726": [
-      [196, 29, 1, "\'i\' is defined but never used.", "177612"]
     ],
     "js/components/Tags/TagInfo/index.spec.tsx:4185537358": [
       [44, 6, 25, "Use object destructuring.", "354229464"],
@@ -494,8 +486,8 @@ exports[`eslint`] = {
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
-    "js/features/ColumnList/index.tsx:3072848928": [
-      [218, 2, 871, "Arrow function expected no return value.", "1083254797"]
+    "js/features/ColumnList/index.tsx:4269963749": [
+      [219, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -701,7 +693,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
       [64, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/TableDetailPage/index.tsx:113370681": [
+    "js/pages/TableDetailPage/index.tsx:1575870806": [
       [152, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [198, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -5,12 +5,13 @@
 @import 'typography';
 
 $resource-header-height: 84px;
-$aside-separation-space: 30px;
+$aside-separation-space: $spacer-4;
 $screen-lg-container: 1440px;
 $header-link-height: 32px;
 $icon-header-size: 32px;
 $inner-column-size: 175px;
-$left-panel-size: 425px;
+$side-panel-size: 425px;
+$close-btn-size: 24px;
 
 .resource-detail-layout {
   height: calc(100vh - #{$nav-bar-height} - #{$footer-height});
@@ -106,7 +107,7 @@ $left-panel-size: 425px;
 
     > .left-panel {
       border-right: 4px solid $divider;
-      flex-basis: $left-panel-size;
+      flex-basis: $side-panel-size;
       flex-shrink: 0;
       min-height: min-content;
       overflow-y: auto;
@@ -156,6 +157,58 @@ $left-panel-size: 425px;
       }
     }
 
+    > .right-panel {
+      border-left: 4px solid $divider;
+      flex-basis: $side-panel-size;
+      flex-shrink: 0;
+      min-height: min-content;
+      overflow-y: auto;
+      padding: 0 24px $aside-separation-space;
+
+      .panel-header {
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .panel-title {
+        @extend %text-title-w1;
+
+        margin-top: $aside-separation-space;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .btn.btn-close {
+        flex-basis: $close-btn-size;
+        flex-shrink: 0;
+        margin-top: $aside-separation-space;
+      }
+
+      .buttons-row {
+        display: flex;
+        gap: $spacer-2;
+        margin-top: $aside-separation-space;
+      }
+
+      .btn.btn-default {
+        line-height: $spacer-2;
+      }
+
+      .section-title {
+        @extend %text-title-w3;
+
+        color: $text-tertiary;
+        margin-bottom: 8px;
+      }
+
+      .editable-section,
+      .metadata-section {
+        margin-top: $aside-separation-space;
+        position: relative;
+      }
+    }
+
     > .main-content-panel {
       flex-basis: 500px;
       flex-grow: 1;
@@ -194,6 +247,7 @@ $left-panel-size: 425px;
   }
 
   .left-panel,
+  .right-panel,
   .main-content-panel {
     display: flex;
     flex-direction: column;

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -20,7 +20,7 @@ $close-btn-size: 24px;
     border-bottom: 2px solid $divider;
     display: flex;
     height: $resource-header-height;
-    padding: 16px 24px;
+    padding: $spacer-2 $spacer-3;
 
     .icon-header {
       height: $icon-header-size;
@@ -67,7 +67,7 @@ $close-btn-size: 24px;
         flex-shrink: 0;
 
         > * {
-          margin-right: 16px;
+          margin-right: $spacer-2;
         }
 
         .header-link {
@@ -90,7 +90,7 @@ $close-btn-size: 24px;
         flex-shrink: 0;
 
         > * {
-          margin-right: 8px;
+          margin-right: $spacer-1;
 
           &:last-child {
             margin-right: 0;
@@ -106,25 +106,25 @@ $close-btn-size: 24px;
     height: calc(100% - #{$resource-header-height});
 
     > .left-panel {
-      border-right: 4px solid $divider;
+      border-right: $spacer-half solid $divider;
       flex-basis: $side-panel-size;
       flex-shrink: 0;
       min-height: min-content;
       overflow-y: auto;
-      padding: 0 24px $aside-separation-space;
+      padding: 0 $spacer-3 $aside-separation-space;
 
       > .banner {
         border: 1px solid $stroke;
         height: 40px;
-        margin: 24px 24px 0;
-        padding: 8px;
+        margin: $spacer-3 $spacer-3 0;
+        padding: $spacer-1;
       }
 
       .section-title {
         @extend %text-title-w3;
 
         color: $text-tertiary;
-        margin-bottom: 8px;
+        margin-bottom: $spacer-1;
       }
 
       .editable-section,
@@ -158,12 +158,12 @@ $close-btn-size: 24px;
     }
 
     > .right-panel {
-      border-left: 4px solid $divider;
+      border-left: $spacer-half solid $divider;
       flex-basis: $side-panel-size;
       flex-shrink: 0;
       min-height: min-content;
       overflow-y: auto;
-      padding: 0 24px $aside-separation-space;
+      padding: 0 $spacer-3 $aside-separation-space;
 
       .panel-header {
         display: flex;
@@ -179,7 +179,7 @@ $close-btn-size: 24px;
         text-overflow: ellipsis;
       }
 
-      .btn.btn-close {
+      .btn-close {
         flex-basis: $close-btn-size;
         flex-shrink: 0;
         margin-top: $aside-separation-space;
@@ -199,7 +199,7 @@ $close-btn-size: 24px;
         @extend %text-title-w3;
 
         color: $text-tertiary;
-        margin-bottom: 8px;
+        margin-bottom: $spacer-1;
       }
 
       .editable-section,

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -5,9 +5,8 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { mocked } from 'ts-jest/utils';
 
-import Table, { TableProps } from '.';
-
 import TestDataBuilder from './testDataBuilder';
+import Table, { TableProps } from '.';
 
 const dataBuilder = new TestDataBuilder();
 
@@ -730,6 +729,34 @@ describe('Table', () => {
           });
         });
       });
+
+      describe('when currentSelectedIndex is passed', () => {
+        it('adds the selected row styling to the selected row', () => {
+          const { wrapper } = setup({
+            options: { currentSelectedIndex: 0 },
+          });
+          const expected = 'ams-table-row is-selected-row';
+          const actual = wrapper
+            .find('.ams-table-row')
+            .get(0)
+            .props.className.trim();
+
+          expect(actual).toEqual(expected);
+        });
+
+        it('does not add the selected row styling to a non selected row', () => {
+          const { wrapper } = setup({
+            options: { currentSelectedIndex: 0 },
+          });
+          const expected = 'ams-table-row false';
+          const actual = wrapper
+            .find('.ams-table-row')
+            .get(1)
+            .props.className.trim();
+
+          expect(actual).toEqual(expected);
+        });
+      });
     });
   });
 
@@ -868,7 +895,7 @@ describe('Table', () => {
             .at(0)
             .simulate('click');
 
-          const actual = onExpandSpy.mock.calls[0];
+          const [actual] = onExpandSpy.mock.calls;
           expect(actual).toEqual(expected);
         });
       });
@@ -1010,7 +1037,7 @@ describe('Table', () => {
             .at(0)
             .simulate('click');
 
-          const actual = onCollapseSpy.mock.calls[0];
+          const [actual] = onCollapseSpy.mock.calls;
 
           expect(actual).toEqual(expected);
         });

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -199,18 +199,12 @@ const Table: React.FC<TableProps> = ({
   } = options;
   const fields = columns.map(({ field }) => field);
   const rowStyles = { height: `${rowHeight}px` };
-  const [expandedRows, setExpandedRows] = React.useState<RowIndex[]>(
-    preExpandRow === undefined ? [] : [preExpandRow]
-  );
+  const [expandedRows, setExpandedRows] = React.useState<RowIndex[]>([]);
   const expandRowRef = React.useRef(null);
   React.useEffect(() => {
     if (expandRowRef.current !== null) {
       // @ts-ignore
       expandRowRef.current.scrollIntoView();
-    }
-
-    if (preExpandRow !== undefined && onExpand !== undefined) {
-      onExpand(data[preExpandRow], preExpandRow);
     }
   }, []);
 

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -17,7 +17,11 @@ export interface TableColumn {
   title: string;
   field: string;
   horAlign?: TextAlignmentValues;
-  component?: (value: any, index: number) => React.ReactNode;
+  component?: (
+    value: any,
+    index: number,
+    columnDetails: ValidData
+  ) => React.ReactNode;
   width?: number;
   // sortable?: bool (false)
 }
@@ -266,7 +270,7 @@ const Table: React.FC<TableProps> = ({
                 // TODO: Improve the typing of this
                 let cellContent: React.ReactNode | typeof value = value;
                 if (columnInfo && columnInfo.component) {
-                  cellContent = columnInfo.component(value, rowIndex);
+                  cellContent = columnInfo.component(value, rowIndex, item);
                 }
 
                 return (

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -42,6 +42,7 @@ export interface TableOptions {
   onExpand?: (rowValues: any, index: number) => void;
   onCollapse?: (rowValues: any, index: number) => void;
   emptyMessage?: string;
+  currentSelectedIndex?: number;
 }
 
 export interface TableProps {
@@ -136,6 +137,7 @@ type ExpandingCellProps = {
   onClick: (index) => void;
   onExpand?: (rowValues: any, index: number) => void;
   onCollapse?: (rowValues: any, index: number) => void;
+  isSelectedRow: boolean;
 };
 const ExpandingCell: React.FC<ExpandingCellProps> = ({
   index,
@@ -144,6 +146,7 @@ const ExpandingCell: React.FC<ExpandingCellProps> = ({
   onCollapse,
   rowValues,
   expandedRows,
+  isSelectedRow,
 }: ExpandingCellProps) => {
   const isExpanded = expandedRows.includes(index);
   const cellStyling = { width: EXPANDING_CELL_WIDTH };
@@ -156,7 +159,9 @@ const ExpandingCell: React.FC<ExpandingCellProps> = ({
     >
       <button
         type="button"
-        className="btn ams-table-expanding-button"
+        className={`btn ams-table-expanding-button ${
+          isSelectedRow && 'is-selected-row'
+        }`}
         onClick={() => {
           const newExpandedRows = isExpanded
             ? expandedRows.filter((i) => i !== index)
@@ -196,6 +201,7 @@ const Table: React.FC<TableProps> = ({
     onExpand,
     onCollapse,
     preExpandRow,
+    currentSelectedIndex,
   } = options;
   const fields = columns.map(({ field }) => field);
   const rowStyles = { height: `${rowHeight}px` };
@@ -225,6 +231,8 @@ const Table: React.FC<TableProps> = ({
       <React.Fragment key={`index:${index}`}>
         <tr
           className={`ams-table-row ${
+            currentSelectedIndex === item.col_index && 'is-selected-row'
+          } ${
             expandRow && expandedRows.includes(index)
               ? 'has-child-expanded'
               : ''
@@ -243,6 +251,7 @@ const Table: React.FC<TableProps> = ({
                 onCollapse={onCollapse}
                 rowValues={item}
                 onClick={setExpandedRows}
+                isSelectedRow={currentSelectedIndex === item.col_index}
               />
             ) : (
               <td />

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -66,6 +66,9 @@ $row-bottom-border-color: $gray10;
   border-bottom: 1px solid $row-bottom-border-color;
 
   &.is-empty,
+  &.is-selected-row {
+    background-color: $gray10;
+  }
   &.has-child-expanded {
     border-bottom: 0;
   }
@@ -118,6 +121,10 @@ $row-bottom-border-color: $gray10;
 
   svg {
     vertical-align: bottom;
+  }
+
+  &.is-selected-row {
+    background-color: $gray10;
   }
 
   &:hover svg use {

--- a/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
@@ -5,9 +5,9 @@ import * as React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 const defaultData = [
-  { name: 'rowName', type: 'rowType', value: 1 },
-  { name: 'rowName2', type: 'rowType2', value: 2 },
-  { name: 'rowName3', type: 'rowType3', value: 3 },
+  { name: 'rowName', type: 'rowType', value: 1, col_index: 0 },
+  { name: 'rowName2', type: 'rowType2', value: 2, col_index: 1 },
+  { name: 'rowName3', type: 'rowType3', value: 3, col_index: 2 },
 ];
 
 const defaultColumns = [
@@ -194,7 +194,7 @@ function TestDataBuilder(config = {}) {
           title: 'Value',
           field: 'value',
           component: (values) =>
-            values.map((val, i) => <strong key={`key:${val}`}>{val}</strong>),
+            values.map((val) => <strong key={`key:${val}`}>{val}</strong>),
         },
       ],
     };

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/constants.ts
@@ -1,3 +1,6 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
 export const EDITABLE_SECTION_TITLE = 'Description';
 export const COPY_COL_NAME_LABEL = 'Copy column name';
 export const COPY_COL_LINK_LABEL = 'Copy column link';

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/constants.ts
@@ -1,0 +1,4 @@
+export const EDITABLE_SECTION_TITLE = 'Description';
+export const COPY_COL_NAME_LABEL = 'Copy column name';
+export const COPY_COL_LINK_LABEL = 'Copy column link';
+export const CLOSE_LABEL = 'Close';

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -83,16 +83,8 @@ describe('ColumnDetailsPanel', () => {
       }).not.toThrow();
     });
 
-    it('triggers the panel toggle when the X button is clicked', () => {
-      const { props, wrapper } = setup();
-
-      wrapper.find('.btn-close').simulate('click');
-
-      expect(props.togglePanel).toHaveBeenCalled();
-    });
-
-    describe('renders copy column info buttons', () => {
-      it('renders two column info buttons', () => {
+    describe('when the details panel is open', () => {
+      it('renders two copy column info buttons', () => {
         const { wrapper } = setup();
 
         const actual = wrapper.find('.btn-default').length;
@@ -100,31 +92,9 @@ describe('ColumnDetailsPanel', () => {
 
         expect(actual).toEqual(expected);
       });
-
-      it('first button copies column name', () => {
-        const { wrapper } = setup();
-
-        wrapper.find('.btn-default').first().simulate('click');
-
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-          'column_name'
-        );
-      });
-
-      it('second button copies column link', () => {
-        const { props, wrapper } = setup();
-
-        wrapper.find('.btn-default').at(1).simulate('click');
-        const expected = getColumnLink(
-          props.columnDetails.tableParams,
-          props.columnDetails.name
-        );
-
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
-      });
     });
 
-    describe('renders column badges', () => {
+    describe('when badges are passed', () => {
       it('should render badges', () => {
         const { wrapper } = setup();
 
@@ -133,7 +103,9 @@ describe('ColumnDetailsPanel', () => {
 
         expect(actual).toEqual(expected);
       });
+    });
 
+    describe('when no badges are passed', () => {
       it('should not render badges', () => {
         const noBadgesColDetails = {
           ...mockColumnDetails,
@@ -148,7 +120,7 @@ describe('ColumnDetailsPanel', () => {
       });
     });
 
-    describe('renders a description', () => {
+    describe('when a description, editText, and editUrl is passed and isEditable is true', () => {
       it('should render a description', () => {
         const { wrapper } = setup();
 
@@ -157,8 +129,10 @@ describe('ColumnDetailsPanel', () => {
 
         expect(actual).toEqual(expected);
       });
+    });
 
-      it('should still render a description if only content is set', () => {
+    describe('when only the content description is set', () => {
+      it('should still render a description', () => {
         const withDescriptionColDetails = {
           ...mockColumnDetails,
           content: {
@@ -171,14 +145,18 @@ describe('ColumnDetailsPanel', () => {
           editUrl: '',
           isEditable: false,
         };
-        const { wrapper } = setup({ columnDetails: withDescriptionColDetails });
+        const { wrapper } = setup({
+          columnDetails: withDescriptionColDetails,
+        });
 
         const actual = wrapper.find(ColumnDescEditableText).length;
         const expected = 1;
 
         expect(actual).toEqual(expected);
       });
+    });
 
+    describe('when no description, editText, or editUrl is passed and isEditable is false', () => {
       it('should not render a description', () => {
         const noDescriptionColDetails = {
           ...mockColumnDetails,
@@ -201,7 +179,7 @@ describe('ColumnDetailsPanel', () => {
       });
     });
 
-    describe('renders column stats', () => {
+    describe('when column stats are passed', () => {
       it('should render stats', () => {
         mockStats = mockColumnDetails.stats;
         const { wrapper } = setup();
@@ -211,7 +189,9 @@ describe('ColumnDetailsPanel', () => {
 
         expect(actual).toEqual(expected);
       });
+    });
 
+    describe('when column stats are not passed', () => {
       it('should not render stats', () => {
         mockStats = [];
         const noStatsColDetails = {
@@ -227,7 +207,7 @@ describe('ColumnDetailsPanel', () => {
       });
     });
 
-    describe('renders unique values', () => {
+    describe('when unique values are passed', () => {
       it('should render unique values', () => {
         mockStats = mockColumnDetails.stats;
         const { wrapper } = setup();
@@ -237,7 +217,9 @@ describe('ColumnDetailsPanel', () => {
 
         expect(actual).toEqual(expected);
       });
+    });
 
+    describe('when unique values are not passed', () => {
       it('should not render unique values', () => {
         mockStats = [];
         const noStatsColDetails = {
@@ -253,7 +235,7 @@ describe('ColumnDetailsPanel', () => {
       });
     });
 
-    describe('renders column lineage', () => {
+    describe('when column lineage is enabled', () => {
       it('should render lineage', () => {
         mockLineageEnabled = true;
         const { wrapper } = setup();
@@ -263,7 +245,9 @@ describe('ColumnDetailsPanel', () => {
 
         expect(actual).toEqual(expected);
       });
+    });
 
+    describe('when column lineage is not enabled', () => {
       it('should not render lineage', () => {
         mockLineageEnabled = false;
         const { wrapper } = setup();
@@ -272,6 +256,42 @@ describe('ColumnDetailsPanel', () => {
         const expected = 0;
 
         expect(actual).toEqual(expected);
+      });
+    });
+  });
+
+  describe('lifecycle', () => {
+    describe('when the X button is clicked', () => {
+      it('triggers the panel toggle', () => {
+        const { props, wrapper } = setup();
+
+        wrapper.find('.btn-close').simulate('click');
+
+        expect(props.togglePanel).toHaveBeenCalled();
+      });
+    });
+
+    describe('when the copy column info buttons are clicked', () => {
+      it('the first button copies column name', () => {
+        const { wrapper } = setup();
+
+        wrapper.find('.btn-default').first().simulate('click');
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          'column_name'
+        );
+      });
+
+      it('the second button copies column link', () => {
+        const { props, wrapper } = setup();
+
+        wrapper.find('.btn-default').at(1).simulate('click');
+        const expected = getColumnLink(
+          props.columnDetails.tableParams,
+          props.columnDetails.name
+        );
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
       });
     });
   });

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -1,0 +1,278 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { getColumnLink } from 'utils/navigationUtils';
+import ExpandableUniqueValues from 'features/ExpandableUniqueValues';
+import BadgeList from 'features/BadgeList';
+import ColumnDescEditableText from '../ColumnDescEditableText';
+import ColumnStats from '../ColumnStats';
+import ColumnLineage from '../ColumnLineage';
+import ColumnDetailsPanel, { ColumnDetailsPanelProps } from '.';
+
+const mockColumnDetails = {
+  content: {
+    title: 'column_name',
+    description: 'description',
+    nestedLevel: 0,
+    hasStats: true,
+  },
+  type: { name: 'column_name', database: 'database', type: 'string' },
+  usage: 0,
+  stats: [
+    {
+      end_epoch: 1600473600,
+      start_epoch: 1597881600,
+      stat_type: 'column_usage',
+      stat_val: '111',
+    },
+  ],
+  action: { name: 'column_name', isActionEnabled: true },
+  editText: 'Click to edit description in the data source site',
+  editUrl: 'https://test.datasource.site/table',
+  col_index: 0,
+  index: 0,
+  name: 'column_name',
+  tableParams: {
+    database: 'database',
+    cluster: 'cluster',
+    schema: 'schema',
+    table: 'table',
+  },
+  sort_order: 0,
+  isEditable: true,
+  isExpandable: false,
+  badges: [
+    {
+      badge_name: 'Badge Name 1',
+      category: 'column',
+    },
+  ],
+};
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: jest.fn() },
+});
+let mockStats = mockColumnDetails.stats;
+jest.mock('utils/stats', () => ({
+  filterOutUniqueValues: () => mockStats,
+  getUniqueValues: () => mockStats,
+}));
+let mockLineageEnabled = true;
+jest.mock('config/config-utils', () => ({
+  isColumnListLineageEnabled: () => mockLineageEnabled,
+  getMaxLength: jest.fn(),
+}));
+
+describe('ColumnDetailsPanel', () => {
+  const setup = (propOverrides?: Partial<ColumnDetailsPanelProps>) => {
+    const props: ColumnDetailsPanelProps = {
+      columnDetails: mockColumnDetails,
+      togglePanel: jest.fn(),
+      ...propOverrides,
+    };
+    const wrapper = shallow(<ColumnDetailsPanel {...props} />);
+    return { props, wrapper };
+  };
+
+  describe('render', () => {
+    it('renders without issues', () => {
+      expect(() => {
+        setup();
+      }).not.toThrow();
+    });
+
+    it('triggers the panel toggle when the X button is clicked', () => {
+      const { props, wrapper } = setup();
+
+      wrapper.find('.btn-close').simulate('click');
+
+      expect(props.togglePanel).toHaveBeenCalled();
+    });
+
+    describe('renders copy column info buttons', () => {
+      it('renders two column info buttons', () => {
+        const { wrapper } = setup();
+
+        const actual = wrapper.find('.btn-default').length;
+        const expected = 2;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('first button copies column name', () => {
+        const { wrapper } = setup();
+
+        wrapper.find('.btn-default').first().simulate('click');
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          'column_name'
+        );
+      });
+
+      it('second button copies column link', () => {
+        const { props, wrapper } = setup();
+
+        wrapper.find('.btn-default').at(1).simulate('click');
+        const expected = getColumnLink(
+          props.columnDetails.tableParams,
+          props.columnDetails.name
+        );
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected);
+      });
+    });
+
+    describe('renders column badges', () => {
+      it('should render badges', () => {
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(BadgeList).length;
+        const expected = 1;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render badges', () => {
+        const noBadgesColDetails = {
+          ...mockColumnDetails,
+          badges: [],
+        };
+        const { wrapper } = setup({ columnDetails: noBadgesColDetails });
+
+        const actual = wrapper.find(BadgeList).length;
+        const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('renders a description', () => {
+      it('should render a description', () => {
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(ColumnDescEditableText).length;
+        const expected = 1;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should still render a description if only content is set', () => {
+        const withDescriptionColDetails = {
+          ...mockColumnDetails,
+          content: {
+            title: 'column_name',
+            description: 'description',
+            nestedLevel: 0,
+            hasStats: true,
+          },
+          editText: '',
+          editUrl: '',
+          isEditable: false,
+        };
+        const { wrapper } = setup({ columnDetails: withDescriptionColDetails });
+
+        const actual = wrapper.find(ColumnDescEditableText).length;
+        const expected = 1;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render a description', () => {
+        const noDescriptionColDetails = {
+          ...mockColumnDetails,
+          content: {
+            title: 'column_name',
+            description: '',
+            nestedLevel: 0,
+            hasStats: true,
+          },
+          editText: '',
+          editUrl: '',
+          isEditable: false,
+        };
+        const { wrapper } = setup({ columnDetails: noDescriptionColDetails });
+
+        const actual = wrapper.find(ColumnDescEditableText).length;
+        const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('renders column stats', () => {
+      it('should render stats', () => {
+        mockStats = mockColumnDetails.stats;
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(ColumnStats).length;
+        const expected = 1;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render stats', () => {
+        mockStats = [];
+        const noStatsColDetails = {
+          ...mockColumnDetails,
+          stats: [],
+        };
+        const { wrapper } = setup({ columnDetails: noStatsColDetails });
+
+        const actual = wrapper.find(ColumnStats).length;
+        const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('renders unique values', () => {
+      it('should render unique values', () => {
+        mockStats = mockColumnDetails.stats;
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(ExpandableUniqueValues).length;
+        const expected = 1;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render unique values', () => {
+        mockStats = [];
+        const noStatsColDetails = {
+          ...mockColumnDetails,
+          stats: [],
+        };
+        const { wrapper } = setup({ columnDetails: noStatsColDetails });
+
+        const actual = wrapper.find(ExpandableUniqueValues).length;
+        const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('renders column lineage', () => {
+      it('should render lineage', () => {
+        mockLineageEnabled = true;
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(ColumnLineage).length;
+        const expected = 1;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render lineage', () => {
+        mockLineageEnabled = false;
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(ColumnLineage).length;
+        const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -21,7 +21,10 @@ import {
 
 export interface ColumnDetailsPanelProps {
   columnDetails: FormattedDataType;
-  togglePanel: (columnDetails: FormattedDataType, event: any) => void;
+  togglePanel: (
+    columnDetails: FormattedDataType | undefined,
+    event: any
+  ) => void;
 }
 
 const shouldRenderDescription = (columnDetails: FormattedDataType) => {
@@ -54,14 +57,26 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
   const normalStats = stats && filterOutUniqueValues(stats);
   const uniqueValueStats = stats && getUniqueValues(stats);
 
+  const handleCloseButtonClick = (e) => {
+    togglePanel(undefined, e);
+  };
+
+  const handleCopyNameClick = () => {
+    navigator.clipboard.writeText(name);
+  };
+
+  const handleCopyLinkClick = () => {
+    navigator.clipboard.writeText(getColumnLink(tableParams, name));
+  };
+
   return (
     <aside className="right-panel">
       <div className="panel-header">
-        <div className="panel-title">{name}</div>
+        <h2 className="panel-title">{name}</h2>
         <button
           type="button"
           className="btn btn-close"
-          onClick={togglePanel.bind(null, null)}
+          onClick={handleCloseButtonClick}
         >
           <span className="sr-only">{CLOSE_LABEL}</span>
         </button>
@@ -71,9 +86,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
           className="btn btn-default column-button"
           id="copy-col-name"
           type="button"
-          onClick={() => {
-            navigator.clipboard.writeText(name);
-          }}
+          onClick={handleCopyNameClick}
         >
           {COPY_COL_NAME_LABEL}
         </button>
@@ -81,10 +94,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
           className="btn btn-default"
           id="copy-col-link"
           type="button"
-          onClick={() => {
-            const link = getColumnLink(tableParams, name);
-            navigator.clipboard.writeText(link);
-          }}
+          onClick={handleCopyLinkClick}
         >
           {COPY_COL_LINK_LABEL}
         </button>

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -1,0 +1,131 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import EditableSection from 'components/EditableSection';
+import BadgeList from 'features/BadgeList';
+import ColumnDescEditableText from 'features/ColumnList/ColumnDescEditableText';
+import ColumnLineage from 'features/ColumnList/ColumnLineage';
+import ColumnStats from 'features/ColumnList/ColumnStats';
+import ExpandableUniqueValues from 'features/ExpandableUniqueValues';
+import { getMaxLength, isColumnListLineageEnabled } from 'config/config-utils';
+import { getColumnLink } from 'utils/navigationUtils';
+import { filterOutUniqueValues, getUniqueValues } from 'utils/stats';
+import { FormattedDataType } from '..';
+import {
+  COPY_COL_LINK_LABEL,
+  COPY_COL_NAME_LABEL,
+  EDITABLE_SECTION_TITLE,
+  CLOSE_LABEL,
+} from './constants';
+
+export interface ColumnDetailsPanelProps {
+  columnDetails: FormattedDataType;
+  togglePanel: (columnDetails: FormattedDataType, event: any) => void;
+}
+
+const shouldRenderDescription = (columnDetails: FormattedDataType) => {
+  const { content, editText, editUrl, isEditable } = columnDetails;
+  if (content.description) {
+    return true;
+  }
+  if (!editText && !editUrl && !isEditable) {
+    return false;
+  }
+  return true;
+};
+
+const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
+  columnDetails,
+  togglePanel,
+}: ColumnDetailsPanelProps) => {
+  const {
+    content,
+    stats,
+    editText,
+    editUrl,
+    col_index,
+    name,
+    tableParams,
+    isEditable,
+    badges,
+  } = columnDetails;
+
+  const normalStats = stats && filterOutUniqueValues(stats);
+  const uniqueValueStats = stats && getUniqueValues(stats);
+
+  return (
+    <aside className="right-panel">
+      <div className="panel-header">
+        <div className="panel-title">{name}</div>
+        <button
+          type="button"
+          className="btn btn-close"
+          onClick={togglePanel.bind(null, null)}
+        >
+          <span className="sr-only">{CLOSE_LABEL}</span>
+        </button>
+      </div>
+      <div className="buttons-row">
+        <button
+          className="btn btn-default column-button"
+          id="copy-col-name"
+          type="button"
+          onClick={() => {
+            navigator.clipboard.writeText(name);
+          }}
+        >
+          {COPY_COL_NAME_LABEL}
+        </button>
+        <button
+          className="btn btn-default"
+          id="copy-col-link"
+          type="button"
+          onClick={() => {
+            const link = getColumnLink(tableParams, name);
+            navigator.clipboard.writeText(link);
+          }}
+        >
+          {COPY_COL_LINK_LABEL}
+        </button>
+      </div>
+      {badges.length > 0 && (
+        <div className="metadata-section">
+          <BadgeList badges={badges} />
+        </div>
+      )}
+      {shouldRenderDescription(columnDetails) && (
+        <EditableSection
+          title={EDITABLE_SECTION_TITLE}
+          readOnly={!isEditable}
+          editText={editText || undefined}
+          editUrl={editUrl || undefined}
+        >
+          <ColumnDescEditableText
+            columnIndex={col_index}
+            editable={isEditable}
+            maxLength={getMaxLength('columnDescLength')}
+            value={content.description}
+          />
+        </EditableSection>
+      )}
+      {normalStats && normalStats.length > 0 && (
+        <div className="metadata-section">
+          <ColumnStats stats={normalStats} singleColumnDisplay />
+        </div>
+      )}
+      {uniqueValueStats && uniqueValueStats.length > 0 && (
+        <div className="metadata-section">
+          <ExpandableUniqueValues uniqueValues={uniqueValueStats} />
+        </div>
+      )}
+      {isColumnListLineageEnabled() && (
+        <div className="metadata-section">
+          <ColumnLineage columnName={name} />
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default ColumnDetailsPanel;

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnStats/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnStats/index.spec.tsx
@@ -4,8 +4,8 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 
-import ColumnStats, { ColumnStatsProps } from '.';
 import TestDataBuilder from './testDataBuilder';
+import ColumnStats, { ColumnStatsProps } from '.';
 
 const dataBuilder = new TestDataBuilder();
 
@@ -68,6 +68,14 @@ describe('ColumnStats', () => {
         const { wrapper } = setup({ stats });
         const expected = stats.length;
         const actual = wrapper.find('.column-stat-row').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('renders one column when singleColumnDisplay is set', () => {
+        const { wrapper } = setup({ stats, singleColumnDisplay: true });
+        const expected = 1;
+        const actual = wrapper.find('.column-stats-column').length;
 
         expect(actual).toEqual(expected);
       });

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnStats/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnStats/index.tsx
@@ -14,6 +14,7 @@ import './styles.scss';
 
 export interface ColumnStatsProps {
   stats: TableColumnStats[];
+  singleColumnDisplay?: boolean;
 }
 
 type ColumnStatRowProps = {
@@ -36,7 +37,10 @@ const ColumnStatRow: React.FC<ColumnStatRowProps> = ({
 const getStart = ({ start_epoch }) => start_epoch;
 const getEnd = ({ end_epoch }) => end_epoch;
 
-const ColumnStats: React.FC<ColumnStatsProps> = ({ stats }) => {
+const ColumnStats: React.FC<ColumnStatsProps> = ({
+  stats,
+  singleColumnDisplay,
+}) => {
   if (stats.length === 0) {
     return null;
   }
@@ -52,7 +56,7 @@ const ColumnStats: React.FC<ColumnStatsProps> = ({ stats }) => {
       <div className="column-stats-table">
         <div className="column-stats-column">
           {stats.map((stat, index) => {
-            if (index % 2 === 0) {
+            if (singleColumnDisplay || index % 2 === 0) {
               return (
                 <ColumnStatRow
                   key={stat.stat_type}
@@ -65,21 +69,23 @@ const ColumnStats: React.FC<ColumnStatsProps> = ({ stats }) => {
             return null;
           })}
         </div>
-        <div className="column-stats-column">
-          {stats.map((stat, index) => {
-            if (index % 2 === 1) {
-              return (
-                <ColumnStatRow
-                  key={stat.stat_type}
-                  stat_type={stat.stat_type}
-                  stat_val={stat.stat_val}
-                />
-              );
-            }
+        {!singleColumnDisplay && (
+          <div className="column-stats-column">
+            {stats.map((stat, index) => {
+              if (index % 2 === 1) {
+                return (
+                  <ColumnStatRow
+                    key={stat.stat_type}
+                    stat_type={stat.stat_type}
+                    stat_val={stat.stat_val}
+                  />
+                );
+              }
 
-            return null;
-          })}
-        </div>
+              return null;
+            })}
+          </div>
+        )}
       </div>
     </article>
   );

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -47,6 +47,7 @@ const setup = (propOverrides?: Partial<ColumnListProps>) => {
     openRequestDescriptionDialog: jest.fn(),
     toggleRightPanel: jest.fn(),
     preExpandRightPanel: jest.fn(),
+    hideSomeColumnMetadata: false,
     ...propOverrides,
   };
   // Update state
@@ -120,6 +121,14 @@ describe('ColumnList', () => {
       it('should render the usage column', () => {
         const { wrapper } = setup({ columns });
         const expected = columns.length;
+        const actual = wrapper.find('.table-detail-table .usage-value').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render the usage column when the side panel is open', () => {
+        const { wrapper } = setup({ columns, hideSomeColumnMetadata: true });
+        const expected = 0;
         const actual = wrapper.find('.table-detail-table .usage-value').length;
 
         expect(actual).toEqual(expected);
@@ -350,6 +359,14 @@ describe('ColumnList', () => {
       it('should render the badge column', () => {
         const { wrapper } = setup({ columns });
         const expected = columns.length;
+        const actual = wrapper.find('.badge-list').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should not render the badge column when the side panel is open', () => {
+        const { wrapper } = setup({ columns, hideSomeColumnMetadata: true });
+        const expected = 0;
         const actual = wrapper.find('.badge-list').length;
 
         expect(actual).toEqual(expected);

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -113,7 +113,7 @@ describe('ColumnList', () => {
 
       it('should trigger the right side panel when a column name is clicked', () => {
         const { props, wrapper } = setup({ columns });
-        wrapper.find('.column-name-link').first().simulate('click');
+        wrapper.find('.column-name-button').first().simulate('click');
 
         expect(props.toggleRightPanel).toHaveBeenCalled();
       });

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -46,6 +46,7 @@ const setup = (propOverrides?: Partial<ColumnListProps>) => {
     },
     openRequestDescriptionDialog: jest.fn(),
     toggleRightPanel: jest.fn(),
+    preExpandRightPanel: jest.fn(),
     ...propOverrides,
   };
   // Update state

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -12,11 +12,11 @@ import { BadgeStyle } from 'config/config-types';
 import * as ConfigUtils from 'config/config-utils';
 
 import globalState from 'fixtures/globalState';
-import ColumnList, { ColumnListProps } from '.';
 import ColumnType from './ColumnType';
 import { EMPTY_MESSAGE } from './constants';
 
 import TestDataBuilder from './testDataBuilder';
+import ColumnList, { ColumnListProps } from '.';
 
 jest.mock('config/config-utils');
 
@@ -45,6 +45,7 @@ const setup = (propOverrides?: Partial<ColumnListProps>) => {
       schema: 'schema',
     },
     openRequestDescriptionDialog: jest.fn(),
+    toggleRightPanel: jest.fn(),
     ...propOverrides,
   };
   // Update state
@@ -85,7 +86,7 @@ describe('ColumnList', () => {
     describe('when empty columns are passed', () => {
       const { columns } = dataBuilder.withEmptyColumns().build();
 
-      it('should render the custom empty messagee', () => {
+      it('should render the custom empty message', () => {
         const { wrapper } = setup({ columns });
         const expected = EMPTY_MESSAGE;
         const actual = wrapper
@@ -106,6 +107,13 @@ describe('ColumnList', () => {
           .length;
 
         expect(actual).toEqual(expected);
+      });
+
+      it('should trigger the right side panel when a column name is clicked', () => {
+        const { props, wrapper } = setup({ columns });
+        wrapper.find('.column-name-link').first().simulate('click');
+
+        expect(props.toggleRightPanel).toHaveBeenCalled();
       });
 
       it('should render the usage column', () => {
@@ -346,7 +354,7 @@ describe('ColumnList', () => {
         expect(actual).toEqual(expected);
       });
 
-      describe('number of bages', () => {
+      describe('number of badges', () => {
         it('should render no badges in the first cell', () => {
           const { wrapper } = setup({ columns });
           const expected = 0;

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -48,6 +48,7 @@ const setup = (propOverrides?: Partial<ColumnListProps>) => {
     toggleRightPanel: jest.fn(),
     preExpandRightPanel: jest.fn(),
     hideSomeColumnMetadata: false,
+    currentSelectedIndex: -1,
     ...propOverrides,
   };
   // Update state

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -76,6 +76,7 @@ export interface ComponentProps {
   tableParams: TablePageParams;
   toggleRightPanel: (newColumnDetails: FormattedDataType, event: any) => void;
   preExpandRightPanel: (columnDetails: FormattedDataType) => void;
+  hideSomeColumnMetadata: boolean;
 }
 
 export interface DispatchFromProps {
@@ -252,6 +253,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
   getColumnLineageDispatch,
   toggleRightPanel,
   preExpandRightPanel,
+  hideSomeColumnMetadata,
 }: ColumnListProps) => {
   let selectedIndex;
   const hasColumnBadges = hasColumnWithBadge(columns);
@@ -390,7 +392,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
     },
   ];
 
-  if (hasUsageStat) {
+  if (hasUsageStat && !hideSomeColumnMetadata) {
     formattedColumns = [
       ...formattedColumns,
       {
@@ -404,7 +406,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
     ];
   }
 
-  if (hasColumnBadges) {
+  if (hasColumnBadges && !hideSomeColumnMetadata) {
     formattedColumns = [
       ...formattedColumns,
       {

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -74,7 +74,10 @@ export interface ComponentProps {
   selectedColumn?: string;
   sortBy?: SortCriteria;
   tableParams: TablePageParams;
-  toggleRightPanel: (newColumnDetails: FormattedDataType, event: any) => void;
+  toggleRightPanel: (
+    newColumnDetails: FormattedDataType | undefined,
+    event: any
+  ) => void;
   preExpandRightPanel: (columnDetails: FormattedDataType) => void;
   hideSomeColumnMetadata: boolean;
 }
@@ -344,6 +347,10 @@ const ColumnList: React.FC<ColumnListProps> = ({
           columnMetadataIcons = [...columnMetadataIcons, hasStatsIcon];
         }
 
+        const handleColumnNameClick = (e) => {
+          toggleRightPanel(columnDetails, e);
+        };
+
         return (
           <>
             {nestedLevel > 0 && (
@@ -357,15 +364,13 @@ const ColumnList: React.FC<ColumnListProps> = ({
             <div className="column-name-container">
               <div className="column-name-with-icons">
                 {columnDetails.isExpandable ? (
-                  <span
-                    className="column-name-link"
-                    role="button"
-                    tabIndex={0}
-                    onClick={toggleRightPanel.bind(null, columnDetails)}
-                    onKeyDown={toggleRightPanel.bind(null, columnDetails)}
+                  <button
+                    className="column-name-button"
+                    type="button"
+                    onClick={handleColumnNameClick}
                   >
                     <h3 className="column-name">{title}</h3>
-                  </span>
+                  </button>
                 ) : (
                   <h3 className="column-name text-primary">{title}</h3>
                 )}

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -75,6 +75,7 @@ export interface ComponentProps {
   sortBy?: SortCriteria;
   tableParams: TablePageParams;
   toggleRightPanel: (newColumnDetails: FormattedDataType, event: any) => void;
+  preExpandRightPanel: (columnDetails: FormattedDataType) => void;
 }
 
 export interface DispatchFromProps {
@@ -250,6 +251,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
   tableParams,
   getColumnLineageDispatch,
   toggleRightPanel,
+  preExpandRightPanel,
 }: ColumnListProps) => {
   let selectedIndex;
   const hasColumnBadges = hasColumnWithBadge(columns);
@@ -317,6 +319,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
   flattenedData.forEach((item, index) => {
     if (item.name === selectedColumn) {
       selectedIndex = index;
+      preExpandRightPanel(item);
     }
   });
 
@@ -351,14 +354,19 @@ const ColumnList: React.FC<ColumnListProps> = ({
             )}
             <div className="column-name-container">
               <div className="column-name-with-icons">
-                <span
-                  className="column-name-link"
-                  role="button"
-                  onClick={toggleRightPanel.bind(null, columnDetails)}
-                  onKeyDown={toggleRightPanel.bind(null, columnDetails)}
-                >
-                  <h3 className="column-name">{title}</h3>
-                </span>
+                {columnDetails.isExpandable ? (
+                  <span
+                    className="column-name-link"
+                    role="button"
+                    tabIndex={0}
+                    onClick={toggleRightPanel.bind(null, columnDetails)}
+                    onKeyDown={toggleRightPanel.bind(null, columnDetails)}
+                  >
+                    <h3 className="column-name">{title}</h3>
+                  </span>
+                ) : (
+                  <h3 className="column-name text-primary">{title}</h3>
+                )}
                 {columnMetadataIcons}
               </div>
               <p className="column-desc truncated">{description}</p>

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -12,7 +12,6 @@ import Table, {
   TableColumn as ReusableTableColumn,
   TextAlignmentValues,
 } from 'components/Table';
-import { TAB_URL_PARAM } from 'components/TabsComponent/constants';
 import {
   getMaxLength,
   getMaxNestedColumns,
@@ -39,9 +38,12 @@ import {
   Badge,
   IconSizes,
 } from 'interfaces';
-import { TABLE_TAB } from 'pages/TableDetailPage/constants';
 import { logAction } from 'utils/analytics';
-import { buildTableKey, TablePageParams } from 'utils/navigationUtils';
+import {
+  buildTableKey,
+  getColumnLink,
+  TablePageParams,
+} from 'utils/navigationUtils';
 import { getUniqueValues, filterOutUniqueValues } from 'utils/stats';
 
 import { GraphIcon } from 'components/SVGIcons/GraphIcon';
@@ -72,6 +74,7 @@ export interface ComponentProps {
   selectedColumn?: string;
   sortBy?: SortCriteria;
   tableParams: TablePageParams;
+  toggleRightPanel: (newColumnDetails: FormattedDataType, event: any) => void;
 }
 
 export interface DispatchFromProps {
@@ -101,7 +104,7 @@ type ActionType = {
   isActionEnabled: boolean;
 };
 
-type FormattedDataType = {
+export type FormattedDataType = {
   content: ContentType;
   type: DatatypeType;
   usage: number | null;
@@ -176,15 +179,6 @@ const getUsageStat = (item) => {
   return null;
 };
 
-const getColumnLink = (tableParams: TablePageParams, columnName: string) => {
-  const { cluster, database, schema, table } = tableParams;
-  return (
-    window.location.origin +
-    `/table_detail/${cluster}/${database}/${schema}/${table}` +
-    `?${TAB_URL_PARAM}=${TABLE_TAB.COLUMN}&column=${columnName}`
-  );
-};
-
 const getColumnMetadataIconElement = (key, popoverText, iconElement) => (
   <OverlayTrigger
     key={key}
@@ -255,6 +249,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
   sortBy = DEFAULT_SORTING,
   tableParams,
   getColumnLineageDispatch,
+  toggleRightPanel,
 }: ColumnListProps) => {
   let selectedIndex;
   const hasColumnBadges = hasColumnWithBadge(columns);
@@ -329,12 +324,11 @@ const ColumnList: React.FC<ColumnListProps> = ({
     {
       title: 'Name',
       field: 'content',
-      component: ({
-        title,
-        description,
-        nestedLevel,
-        hasStats,
-      }: ContentType) => {
+      component: (
+        { title, description, nestedLevel, hasStats }: ContentType,
+        index,
+        columnDetails: FormattedDataType
+      ) => {
         let columnMetadataIcons: React.ReactNode[] = [];
         if (hasStats) {
           const hasStatsIcon = getColumnMetadataIconElement(
@@ -357,7 +351,14 @@ const ColumnList: React.FC<ColumnListProps> = ({
             )}
             <div className="column-name-container">
               <div className="column-name-with-icons">
-                <h3 className="column-name">{title}</h3>
+                <span
+                  className="column-name-link"
+                  role="button"
+                  onClick={toggleRightPanel.bind(null, columnDetails)}
+                  onKeyDown={toggleRightPanel.bind(null, columnDetails)}
+                >
+                  <h3 className="column-name">{title}</h3>
+                </span>
                 {columnMetadataIcons}
               </div>
               <p className="column-desc truncated">{description}</p>

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -71,15 +71,16 @@ export interface ComponentProps {
   database: string;
   editText?: string;
   editUrl?: string;
-  selectedColumn?: string;
+  columnToPreExpand?: string;
   sortBy?: SortCriteria;
   tableParams: TablePageParams;
+  preExpandRightPanel: (columnDetails: FormattedDataType) => void;
   toggleRightPanel: (
     newColumnDetails: FormattedDataType | undefined,
     event: any
   ) => void;
-  preExpandRightPanel: (columnDetails: FormattedDataType) => void;
   hideSomeColumnMetadata: boolean;
+  currentSelectedIndex: number;
 }
 
 export interface DispatchFromProps {
@@ -250,13 +251,14 @@ const ColumnList: React.FC<ColumnListProps> = ({
   editText,
   editUrl,
   openRequestDescriptionDialog,
-  selectedColumn,
+  columnToPreExpand,
   sortBy = DEFAULT_SORTING,
   tableParams,
   getColumnLineageDispatch,
-  toggleRightPanel,
   preExpandRightPanel,
+  toggleRightPanel,
   hideSomeColumnMetadata,
+  currentSelectedIndex,
 }: ColumnListProps) => {
   let selectedIndex;
   const hasColumnBadges = hasColumnWithBadge(columns);
@@ -322,7 +324,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
     : flattenData(orderedData);
 
   flattenedData.forEach((item, index) => {
-    if (item.name === selectedColumn) {
+    if (item.name === columnToPreExpand) {
       selectedIndex = index;
       preExpandRightPanel(item);
     }
@@ -501,6 +503,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
         onExpand: handleRowExpand,
         tableClassName: 'table-detail-table',
         preExpandRow: selectedIndex,
+        currentSelectedIndex,
       }}
     />
   );

--- a/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
@@ -80,6 +80,12 @@ $nested-arrow-spacer-max: $nested-arrow-spacer * 4;
     gap: $spacer-1;
   }
 
+  .column-name-link:hover {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: $column-name-color;
+  }
+
   .ams-table-header {
     background-color: white;
   }

--- a/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
@@ -80,10 +80,16 @@ $nested-arrow-spacer-max: $nested-arrow-spacer * 4;
     gap: $spacer-1;
   }
 
-  .column-name-link:hover {
-    cursor: pointer;
-    text-decoration: underline;
-    text-decoration-color: $column-name-color;
+  .column-name-button {
+    padding: 0;
+    border: none;
+    background: none;
+
+    &:hover {
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-color: $column-name-color;
+    }
   }
 
   .ams-table-header {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -32,7 +32,8 @@ import {
 } from 'config/config-utils';
 
 import BadgeList from 'features/BadgeList';
-import ColumnList from 'features/ColumnList';
+import ColumnList, { FormattedDataType } from 'features/ColumnList';
+import ColumnDetailsView from 'features/ColumnList/ColumnDetailsPanel';
 
 import Alert from 'components/Alert';
 import BookmarkIcon from 'components/Bookmark/BookmarkIcon';
@@ -139,6 +140,9 @@ const ErrorMessage = () => (
 export interface StateProps {
   sortedBy: SortCriteria;
   currentTab: string;
+  isRightPanelOpen: boolean;
+  selectedColumnIndex: number;
+  selectedColumnDetails?: FormattedDataType;
 }
 
 export class TableDetail extends React.Component<
@@ -152,6 +156,9 @@ export class TableDetail extends React.Component<
   state = {
     sortedBy: SORT_CRITERIAS.sort_order,
     currentTab: this.getDefaultTab(),
+    isRightPanelOpen: false,
+    selectedColumnIndex: -1,
+    selectedColumnDetails: undefined,
   };
 
   componentDidMount() {
@@ -242,6 +249,24 @@ export class TableDetail extends React.Component<
     }
   };
 
+  toggleRightPanel = (newColumnDetails: FormattedDataType, event) => {
+    const { isRightPanelOpen, selectedColumnIndex } = this.state;
+
+    let colIndex = -1;
+    if (newColumnDetails) {
+      ({ col_index: colIndex } = newColumnDetails);
+    }
+
+    if (!isRightPanelOpen && event) {
+      logClick(event);
+    }
+    this.setState({
+      isRightPanelOpen: colIndex !== selectedColumnIndex || !isRightPanelOpen,
+      selectedColumnIndex: colIndex,
+      selectedColumnDetails: newColumnDetails,
+    });
+  };
+
   renderTabs(editText, editUrl) {
     const tabInfo: TabInfo[] = [];
     const {
@@ -272,6 +297,7 @@ export class TableDetail extends React.Component<
           editUrl={editUrl}
           sortBy={sortedBy}
           selectedColumn={selectedColumn}
+          toggleRightPanel={this.toggleRightPanel}
         />
       ),
       key: Constants.TABLE_TAB.COLUMN,
@@ -390,7 +416,7 @@ export class TableDetail extends React.Component<
 
   render() {
     const { isLoading, statusCode, tableData } = this.props;
-    const { currentTab } = this.state;
+    const { currentTab, isRightPanelOpen, selectedColumnDetails } = this.state;
     let innerContent;
 
     // We want to avoid rendering the previous table's metadata before new data is fetched in componentDidMount
@@ -563,6 +589,12 @@ export class TableDetail extends React.Component<
               )}
               {this.renderTabs(editText, editUrl)}
             </main>
+            {isRightPanelOpen && selectedColumnDetails && (
+              <ColumnDetailsView
+                columnDetails={selectedColumnDetails!}
+                togglePanel={this.toggleRightPanel}
+              />
+            )}
           </div>
         </div>
       );

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -280,9 +280,12 @@ export class TableDetail extends React.Component<
     if (!isRightPanelOpen && event) {
       logClick(event);
     }
+
+    const shouldPanelOpen =
+      (colIndex >= 0 && colIndex !== selectedColumnIndex) || !isRightPanelOpen;
     this.setState({
-      isRightPanelOpen: colIndex !== selectedColumnIndex || !isRightPanelOpen,
-      selectedColumnIndex: colIndex,
+      isRightPanelOpen: shouldPanelOpen,
+      selectedColumnIndex: shouldPanelOpen ? colIndex : -1,
       selectedColumnDetails: newColumnDetails,
     });
   };
@@ -296,7 +299,7 @@ export class TableDetail extends React.Component<
       openRequestDescriptionDialog,
       tableLineage,
     } = this.props;
-    const { sortedBy, currentTab } = this.state;
+    const { sortedBy, currentTab, isRightPanelOpen } = this.state;
     const tableParams: TablePageParams = {
       cluster: tableData.cluster,
       database: tableData.database,
@@ -319,6 +322,7 @@ export class TableDetail extends React.Component<
           selectedColumn={selectedColumn}
           toggleRightPanel={this.toggleRightPanel}
           preExpandRightPanel={this.preExpandRightPanel}
+          hideSomeColumnMetadata={isRightPanelOpen}
         />
       ),
       key: Constants.TABLE_TAB.COLUMN,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -141,6 +141,7 @@ export interface StateProps {
   sortedBy: SortCriteria;
   currentTab: string;
   isRightPanelOpen: boolean;
+  isRightPanelPreExpanded: boolean;
   selectedColumnIndex: number;
   selectedColumnDetails?: FormattedDataType;
 }
@@ -157,6 +158,7 @@ export class TableDetail extends React.Component<
     sortedBy: SORT_CRITERIAS.sort_order,
     currentTab: this.getDefaultTab(),
     isRightPanelOpen: false,
+    isRightPanelPreExpanded: false,
     selectedColumnIndex: -1,
     selectedColumnDetails: undefined,
   };
@@ -249,6 +251,24 @@ export class TableDetail extends React.Component<
     }
   };
 
+  preExpandRightPanel = (columnDetails: FormattedDataType) => {
+    const { isRightPanelPreExpanded } = this.state;
+
+    let colIndex = -1;
+    if (columnDetails) {
+      ({ col_index: colIndex } = columnDetails);
+    }
+
+    if (!isRightPanelPreExpanded && colIndex >= 0) {
+      this.setState({
+        isRightPanelOpen: true,
+        isRightPanelPreExpanded: true,
+        selectedColumnIndex: colIndex,
+        selectedColumnDetails: columnDetails,
+      });
+    }
+  };
+
   toggleRightPanel = (newColumnDetails: FormattedDataType, event) => {
     const { isRightPanelOpen, selectedColumnIndex } = this.state;
 
@@ -298,6 +318,7 @@ export class TableDetail extends React.Component<
           sortBy={sortedBy}
           selectedColumn={selectedColumn}
           toggleRightPanel={this.toggleRightPanel}
+          preExpandRightPanel={this.preExpandRightPanel}
         />
       ),
       key: Constants.TABLE_TAB.COLUMN,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -275,13 +275,13 @@ export class TableDetail extends React.Component<
   ) => {
     const { isRightPanelOpen, selectedColumnIndex } = this.state;
 
+    if (event) {
+      logClick(event);
+    }
+
     let colIndex = -1;
     if (newColumnDetails) {
       ({ col_index: colIndex } = newColumnDetails);
-    }
-
-    if (!isRightPanelOpen && event) {
-      logClick(event);
     }
 
     const shouldPanelOpen =
@@ -302,7 +302,12 @@ export class TableDetail extends React.Component<
       openRequestDescriptionDialog,
       tableLineage,
     } = this.props;
-    const { sortedBy, currentTab, isRightPanelOpen } = this.state;
+    const {
+      sortedBy,
+      currentTab,
+      isRightPanelOpen,
+      selectedColumnIndex,
+    } = this.state;
     const tableParams: TablePageParams = {
       cluster: tableData.cluster,
       database: tableData.database,
@@ -322,10 +327,11 @@ export class TableDetail extends React.Component<
           editText={editText}
           editUrl={editUrl}
           sortBy={sortedBy}
-          selectedColumn={selectedColumn}
-          toggleRightPanel={this.toggleRightPanel}
+          columnToPreExpand={selectedColumn}
           preExpandRightPanel={this.preExpandRightPanel}
           hideSomeColumnMetadata={isRightPanelOpen}
+          toggleRightPanel={this.toggleRightPanel}
+          currentSelectedIndex={selectedColumnIndex}
         />
       ),
       key: Constants.TABLE_TAB.COLUMN,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -269,7 +269,10 @@ export class TableDetail extends React.Component<
     }
   };
 
-  toggleRightPanel = (newColumnDetails: FormattedDataType, event) => {
+  toggleRightPanel = (
+    newColumnDetails: FormattedDataType | undefined,
+    event
+  ) => {
     const { isRightPanelOpen, selectedColumnIndex } = this.state;
 
     let colIndex = -1;

--- a/frontend/amundsen_application/static/js/utils/index.spec.ts
+++ b/frontend/amundsen_application/static/js/utils/index.spec.ts
@@ -289,6 +289,21 @@ describe('navigationUtils', () => {
       expect(replaceStateSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('getColumnLink', () => {
+    it('picks up url params and constructs a url link to a specific column', () => {
+      const testParams = {
+        cluster: 'cluster',
+        database: 'database',
+        schema: 'schema',
+        table: 'table',
+      };
+      const expected = `${window.location.origin}/table_detail/cluster/database/schema/table?tab=columns&column=column`;
+      const actual = NavigationUtils.getColumnLink(testParams, 'column');
+
+      expect(actual).toEqual(expected);
+    });
+  });
 });
 
 describe('dateUtils', () => {

--- a/frontend/amundsen_application/static/js/utils/navigationUtils.ts
+++ b/frontend/amundsen_application/static/js/utils/navigationUtils.ts
@@ -2,6 +2,8 @@ import * as qs from 'simple-query-string';
 import { createBrowserHistory } from 'history';
 
 import { ResourceType, TableMetadata } from 'interfaces';
+import { TAB_URL_PARAM } from 'components/TabsComponent/constants';
+import { TABLE_TAB } from 'pages/TableDetailPage/constants';
 
 // https://github.com/ReactTraining/react-router/issues/3972#issuecomment-264805667
 export const BrowserHistory = createBrowserHistory();
@@ -138,3 +140,15 @@ export function setUrlParam(key: string, value: string) {
   const queryString = qs.stringify(params);
   BrowserHistory.replace(`${location.pathname}?${queryString}`);
 }
+
+export const getColumnLink = (
+  tableParams: TablePageParams,
+  columnName: string
+) => {
+  const { cluster, database, schema, table } = tableParams;
+  return (
+    window.location.origin +
+    `/table_detail/${cluster}/${database}/${schema}/${table}` +
+    `?${TAB_URL_PARAM}=${TABLE_TAB.COLUMN}&column=${columnName}`
+  );
+};


### PR DESCRIPTION
### Summary of Changes

This change adds in a right side panel to the table details page. When a column name is clicked, a panel on the right side of the page is expanded to display column details that have previously been displayed in the dropdown underneath the column name. This change is meant to free up the use of the dropdown for future nested columns work that is coming soon. See [this RFC](https://github.com/amundsen-io/rfcs/blob/master/rfcs/046-column-details-access-and-side-panels.md) for further details around design decisions for this feature.

When a column name is selected and the panel is expanded, that row is highlighted so it is easy to see which column name the current panel contents relate to. In addition, to save space within the main column table, when the panel is open the badges and usage columns are removed since that info is visible in the side panel.

For now, the existing drop down to display column details is not being removed to transition into the new usage.

<img width="1112" alt="Screen Shot 2022-04-27 at 11 14 48 AM" src="https://user-images.githubusercontent.com/6732445/165592922-a036af17-4ddb-4b90-89ad-ec528e85714d.png">

### Tests

JS tests were added to test the rendering of the right side panel and to test that the toggle panel function is called when a column name is clicked.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
