### PR TITLE
fix: Loading/display for column lineage in column details panel

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -690,12 +690,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.spec.tsx:1320221888": [
-      [64, 6, 25, "Use object destructuring.", "1230260048"]
-    ],
-    "js/pages/TableDetailPage/index.tsx:1575870806": [
-      [152, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [198, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:324823146": [
+      [159, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [205, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -131,7 +131,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
       )}
       {isColumnListLineageEnabled() && (
         <div className="metadata-section">
-          <ColumnLineage columnName={name} />
+          <ColumnLineage columnName={name} singleColumnDisplay />
         </div>
       )}
     </aside>

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnLineage/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnLineage/index.tsx
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 import { GlobalState } from 'ducks/rootReducer';
 import { initialLineageState } from 'ducks/lineage/reducer';
@@ -19,12 +20,14 @@ import {
   COLUMN_LINEAGE_DOWNSTREAM_TITLE,
   COLUMN_LINEAGE_UPSTREAM_TITLE,
   COLUMN_LINEAGE_MORE_TEXT,
+  DELAY_SHOW_POPOVER_MS,
 } from '../constants';
 
 import './styles.scss';
 
 interface ColumnLineageListOwnProps {
   columnName: string;
+  singleColumnDisplay?: boolean;
 }
 
 interface StateFromProps {
@@ -56,20 +59,31 @@ const renderLineageLinks = (entity, index, direction) => {
   if (index >= COLUMN_LINEAGE_LIST_SIZE) {
     return null;
   }
+  const lineageDisplayText = entity.schema + '.' + entity.name;
   return (
-    <div>
-      <a
-        href={getLink(entity, direction)}
-        className="body-link"
-        target="_blank"
-        rel="noreferrer"
-        onClick={(e) =>
-          logClick(e, { target_id: `column_lineage`, value: direction })
-        }
-      >
-        {entity.schema}.{entity.name}
-      </a>
-    </div>
+    <OverlayTrigger
+      key={lineageDisplayText}
+      trigger={['hover', 'focus']}
+      placement="top"
+      delayShow={DELAY_SHOW_POPOVER_MS}
+      overlay={
+        <Popover id="popover-trigger-hover-focus">{lineageDisplayText}</Popover>
+      }
+    >
+      <div className="column-lineage-item">
+        <a
+          href={getLink(entity, direction)}
+          className="body-link"
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e) =>
+            logClick(e, { target_id: `column_lineage`, value: direction })
+          }
+        >
+          {lineageDisplayText}
+        </a>
+      </div>
+    </OverlayTrigger>
   );
 };
 
@@ -105,6 +119,7 @@ const LineageList: React.FC<LineageListProps> = ({
 
 export const ColumnLineageList: React.FC<ColumnLineageListProps> = ({
   columnName,
+  singleColumnDisplay,
   columnLineage,
   tableData,
   isLoading,
@@ -118,7 +133,11 @@ export const ColumnLineageList: React.FC<ColumnLineageListProps> = ({
     return null;
   }
   return (
-    <article className="column-lineage-wrapper">
+    <article
+      className={`column-lineage-wrapper ${
+        singleColumnDisplay && 'single-column-display'
+      }`}
+    >
       {upstream_entities.length !== 0 && (
         <LineageList
           direction="upstream"

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnLineage/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnLineage/styles.scss
@@ -11,6 +11,11 @@ article.column-lineage-wrapper {
   display: flex;
   max-width: $column-lineage-max-width;
 
+  &.single-column-display {
+    flex-direction: column;
+    gap: $spacer-3;
+  }
+
   .column-lineage-title {
     @extend %text-title-w3;
 
@@ -26,5 +31,11 @@ article.column-lineage-wrapper {
     &:first-child {
       margin-right: $spacer-2;
     }
+  }
+
+  .column-lineage-item {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
@@ -9,3 +9,4 @@ export const COLUMN_LINEAGE_UPSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} Up
 export const COLUMN_LINEAGE_MORE_TEXT = 'See More';
 export const COPY_COLUMN_LINK_TEXT = 'Copy Column Link';
 export const HAS_COLUMN_STATS_TEXT = 'Column stats available';
+export const DELAY_SHOW_POPOVER_MS = 500;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -47,6 +47,7 @@ const setup = (
     tableData: tableMetadata,
     getTableData: jest.fn(),
     getTableLineageDispatch: jest.fn(),
+    getColumnLineageDispatch: jest.fn(),
     openRequestDescriptionDialog: jest.fn(),
     searchSchema: jest.fn(),
     ...routerProps,
@@ -62,7 +63,7 @@ describe('TableDetail', () => {
   describe('renderTabs', () => {
     let wrapper;
     beforeAll(() => {
-      wrapper = setup().wrapper;
+      ({ wrapper } = setup());
     });
     it('does not render dashboard tab when disabled', () => {
       mocked(indexDashboardsEnabled).mockImplementation(() => false);

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -3,8 +3,7 @@
 
 import * as React from 'react';
 import * as History from 'history';
-import { mount, shallow } from 'enzyme';
-import { mocked } from 'ts-jest/utils';
+import { shallow } from 'enzyme';
 
 import { getMockRouterProps } from 'fixtures/mockRouter';
 import { tableMetadata, tableLineage } from 'fixtures/metadata/table';
@@ -12,18 +11,49 @@ import { tableMetadata, tableLineage } from 'fixtures/metadata/table';
 import LoadingSpinner from 'components/LoadingSpinner';
 import TabsComponent from 'components/TabsComponent';
 
-import {
-  indexDashboardsEnabled,
-  isTableListLineageEnabled,
-} from 'config/config-utils';
+import * as ConfigUtils from 'config/config-utils';
 import { TABLE_TAB } from './constants';
 import { TableDetail, TableDetailProps, MatchProps } from '.';
 
-jest.mock('config/config-utils', () => ({
-  indexDashboardsEnabled: jest.fn(),
-  isTableListLineageEnabled: jest.fn(),
-  getTableSortCriterias: jest.fn(),
-}));
+const mockColumnDetails = {
+  content: {
+    title: 'column_name',
+    description: 'description',
+    nestedLevel: 0,
+    hasStats: true,
+  },
+  type: { name: 'column_name', database: 'database', type: 'string' },
+  usage: 0,
+  stats: [
+    {
+      end_epoch: 1600473600,
+      start_epoch: 1597881600,
+      stat_type: 'column_usage',
+      stat_val: '111',
+    },
+  ],
+  action: { name: 'column_name', isActionEnabled: true },
+  editText: 'Click to edit description in the data source site',
+  editUrl: 'https://test.datasource.site/table',
+  col_index: 0,
+  index: 0,
+  name: 'column_name',
+  tableParams: {
+    database: 'database',
+    cluster: 'cluster',
+    schema: 'schema',
+    table: 'table',
+  },
+  sort_order: 0,
+  isEditable: true,
+  isExpandable: false,
+  badges: [
+    {
+      badge_name: 'Badge Name 1',
+      category: 'column',
+    },
+  ],
+};
 
 const setup = (
   propOverrides?: Partial<TableDetailProps>,
@@ -54,7 +84,7 @@ const setup = (
     ...propOverrides,
   };
   // eslint-disable-next-line react/jsx-props-no-spreading
-  const wrapper = mount<TableDetail>(<TableDetail {...props} />);
+  const wrapper = shallow<TableDetail>(<TableDetail {...props} />);
 
   return { props, wrapper };
 };
@@ -66,7 +96,9 @@ describe('TableDetail', () => {
       ({ wrapper } = setup());
     });
     it('does not render dashboard tab when disabled', () => {
-      mocked(indexDashboardsEnabled).mockImplementation(() => false);
+      jest
+        .spyOn(ConfigUtils, 'indexDashboardsEnabled')
+        .mockImplementation(() => false);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
       expect(
@@ -75,7 +107,9 @@ describe('TableDetail', () => {
     });
 
     it('renders two tabs when dashboards are enabled', () => {
-      mocked(indexDashboardsEnabled).mockImplementation(() => true);
+      jest
+        .spyOn(ConfigUtils, 'indexDashboardsEnabled')
+        .mockImplementation(() => true);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
       expect(
@@ -83,7 +117,9 @@ describe('TableDetail', () => {
       ).toBeTruthy();
     });
     it('does not render upstream and downstream tabs when disabled', () => {
-      mocked(isTableListLineageEnabled).mockImplementation(() => false);
+      jest
+        .spyOn(ConfigUtils, 'isTableListLineageEnabled')
+        .mockImplementation(() => false);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
       expect(tabInfo.find((tab) => tab.key === TABLE_TAB.UPSTREAM)).toBeFalsy();
@@ -92,7 +128,9 @@ describe('TableDetail', () => {
       ).toBeFalsy();
     });
     it('renders upstream and downstream tabs when enabled', () => {
-      mocked(isTableListLineageEnabled).mockImplementation(() => true);
+      jest
+        .spyOn(ConfigUtils, 'isTableListLineageEnabled')
+        .mockImplementation(() => true);
       const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
       const tabInfo = content.find(TabsComponent).props().tabs;
       expect(
@@ -121,6 +159,7 @@ describe('TableDetail', () => {
   });
 
   describe('lifecycle', () => {
+    const setStateSpy = jest.spyOn(TableDetail.prototype, 'setState');
     describe('when mounted', () => {
       it('calls loadDashboard with uri from state', () => {
         const { props } = setup();
@@ -128,6 +167,53 @@ describe('TableDetail', () => {
         const actual = (props.getTableData as jest.Mock).mock.calls.length;
 
         expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when preExpandRightPanel is called when a column is preselected', () => {
+      it('column lineage is populated and selected column details are set in the state', () => {
+        setStateSpy.mockClear();
+        const { props, wrapper } = setup();
+        wrapper.instance().preExpandRightPanel(mockColumnDetails);
+
+        expect(props.getColumnLineageDispatch).toHaveBeenCalled();
+        expect(setStateSpy).toHaveBeenCalledWith({
+          isRightPanelPreExpanded: true,
+          isRightPanelOpen: true,
+          selectedColumnIndex: 0,
+          selectedColumnDetails: mockColumnDetails,
+        });
+      });
+    });
+
+    describe('when toggleRightPanel is called while the panel is closed', () => {
+      it('column lineage is populated and selected column details are set in the state', () => {
+        setStateSpy.mockClear();
+        const { props, wrapper } = setup();
+        wrapper.setState({ isRightPanelOpen: false });
+        wrapper.instance().toggleRightPanel(mockColumnDetails, null);
+
+        expect(props.getColumnLineageDispatch).toHaveBeenCalled();
+        expect(setStateSpy).toHaveBeenCalledWith({
+          isRightPanelOpen: true,
+          selectedColumnIndex: 0,
+          selectedColumnDetails: mockColumnDetails,
+        });
+      });
+    });
+
+    describe('when toggleRightPanel is called while the panel is open', () => {
+      it('the panel is closed and the column details state is cleared', () => {
+        setStateSpy.mockClear();
+        const { wrapper } = setup();
+        wrapper.setState({ isRightPanelOpen: true });
+        wrapper.instance().toggleRightPanel(undefined, null);
+
+        expect(setStateSpy).toHaveBeenCalledWith({
+          isRightPanelOpen: false,
+          selectedColumnIndex: -1,
+          selectedColumnDetails: undefined,
+        });
       });
     });
   });


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

An extra call needed to be made to retrieve the table column lineage when the column details side panel is opened. This change makes the call and also makes it so the layout of the upstream and downstream lineage is displayed in one column rather than two. In addition, the Sort By controls in the top right will be hidden when the panel is open to save space in the header for smaller screens.

<img width="1367" alt="Screen Shot 2022-04-28 at 1 37 18 PM" src="https://user-images.githubusercontent.com/6732445/165841465-9da76651-8a89-4611-a821-3dfebff71815.png">

### Tests

Added some `TableDetailPage` tests to check the state changes and that the lineage loads when the side panel is toggled.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
