### PR TITLE
refactor: Refactor various column details and add TypeMetadata to TableColumn model

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -341,7 +341,7 @@ exports[`eslint`] = {
       [60, 2, 51, "refToSelf should be placed after componentWillUnmount", "3412474606"],
       [105, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
-    "js/components/Table/index.tsx:2629931458": [
+    "js/components/Table/index.tsx:1457853108": [
       [314, 8, 65, "A control must be associated with a text label.", "1026764939"]
     ],
     "js/components/Table/table.story.tsx:3074937505": [
@@ -447,7 +447,7 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:4044823741": [
+    "js/ducks/tableMetadata/api/v0.ts:4194065289": [
       [80, 8, 23, "Use object destructuring.", "1142306891"],
       [139, 23, -4311, "Expected to return a value at the end of arrow function.", "5381"]
     ],
@@ -458,7 +458,7 @@ exports[`eslint`] = {
     "js/ducks/tableMetadata/owners/sagas.ts:3725515638": [
       [7, 0, 69, "\`../types\` import should occur before import of \`./reducer\`", "3326352266"]
     ],
-    "js/ducks/tableMetadata/reducer.ts:3872576896": [
+    "js/ducks/tableMetadata/reducer.ts:1012064960": [
       [416, 6, 93, "Unexpected lexical declaration in case block.", "4098864482"]
     ],
     "js/ducks/tags/api/v0.ts:2781466514": [
@@ -485,9 +485,6 @@ exports[`eslint`] = {
       [127, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
       [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
-    ],
-    "js/features/ColumnList/index.tsx:4269963749": [
-      [219, 2, 871, "Arrow function expected no return value.", "1083254797"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -641,12 +638,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/FrequentUsers/index.tsx:14585253": [
       [62, 11, 26, "A form label must be associated with a control.", "2816972347"]
     ],
-    "js/pages/TableDetailPage/ListSortingDropdown/index.spec.tsx:1478300175": [
-      [174, 14, 34, "Use array destructuring.", "2024515814"]
-    ],
-    "js/pages/TableDetailPage/ListSortingDropdown/index.tsx:3178023015": [
-      [62, 25, 1, "\'_\' is defined but never used.", "177658"],
-      [65, 14, 204, "A control must be associated with a text label.", "3622841199"]
+    "js/pages/TableDetailPage/ListSortingDropdown/index.tsx:286421664": [
+      [64, 25, 1, "\'_\' is defined but never used.", "177658"],
+      [67, 14, 204, "A control must be associated with a text label.", "3622841199"]
     ],
     "js/pages/TableDetailPage/ReportTableIssue/index.tsx:2627382373": [
       [168, 15, 20, "Script URL is a form of eval.", "3959800777"],
@@ -690,7 +684,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:324823146": [
+    "js/pages/TableDetailPage/index.tsx:2270284782": [
       [159, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [205, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -730,10 +730,12 @@ describe('Table', () => {
         });
       });
 
-      describe('when currentSelectedIndex is passed', () => {
+      describe('when currentSelectedKey is passed', () => {
         it('adds the selected row styling to the selected row', () => {
           const { wrapper } = setup({
-            options: { currentSelectedIndex: 0 },
+            options: {
+              currentSelectedKey: 'database://cluster.schema/table/rowName',
+            },
           });
           const expected = 'ams-table-row is-selected-row';
           const actual = wrapper
@@ -746,7 +748,9 @@ describe('Table', () => {
 
         it('does not add the selected row styling to a non selected row', () => {
           const { wrapper } = setup({
-            options: { currentSelectedIndex: 0 },
+            options: {
+              currentSelectedKey: 'database://cluster.schema/table/rowName',
+            },
           });
           const expected = 'ams-table-row false';
           const actual = wrapper

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -42,7 +42,7 @@ export interface TableOptions {
   onExpand?: (rowValues: any, index: number) => void;
   onCollapse?: (rowValues: any, index: number) => void;
   emptyMessage?: string;
-  currentSelectedIndex?: number;
+  currentSelectedKey?: string;
 }
 
 export interface TableProps {
@@ -201,7 +201,7 @@ const Table: React.FC<TableProps> = ({
     onExpand,
     onCollapse,
     preExpandRow,
-    currentSelectedIndex,
+    currentSelectedKey,
   } = options;
   const fields = columns.map(({ field }) => field);
   const rowStyles = { height: `${rowHeight}px` };
@@ -231,7 +231,7 @@ const Table: React.FC<TableProps> = ({
       <React.Fragment key={`index:${index}`}>
         <tr
           className={`ams-table-row ${
-            currentSelectedIndex === item.col_index && 'is-selected-row'
+            currentSelectedKey === item.key && 'is-selected-row'
           } ${
             expandRow && expandedRows.includes(index)
               ? 'has-child-expanded'
@@ -251,7 +251,7 @@ const Table: React.FC<TableProps> = ({
                 onCollapse={onCollapse}
                 rowValues={item}
                 onClick={setExpandedRows}
-                isSelectedRow={currentSelectedIndex === item.col_index}
+                isSelectedRow={currentSelectedKey === item.key}
               />
             ) : (
               <td />

--- a/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
@@ -5,9 +5,24 @@ import * as React from 'react';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 
 const defaultData = [
-  { name: 'rowName', type: 'rowType', value: 1, col_index: 0 },
-  { name: 'rowName2', type: 'rowType2', value: 2, col_index: 1 },
-  { name: 'rowName3', type: 'rowType3', value: 3, col_index: 2 },
+  {
+    name: 'rowName',
+    type: 'rowType',
+    value: 1,
+    key: 'database://cluster.schema/table/rowName',
+  },
+  {
+    name: 'rowName2',
+    type: 'rowType2',
+    value: 2,
+    key: 'database://cluster.schema/table/rowName2',
+  },
+  {
+    name: 'rowName3',
+    type: 'rowType3',
+    value: 3,
+    key: 'database://cluster.schema/table/rowName3',
+  },
 ];
 
 const defaultColumns = [

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.spec.ts
@@ -140,11 +140,13 @@ describe('helpers', () => {
 
   describe('parseNestedColumns', () => {
     it('Adds a children array to a column with nested columns', () => {
+      const tableKey = 'database://cluster.schema/table';
       const testColumn = [
         {
           badges: [],
           col_type: 'row(col1 varchar, col2 varchar)',
           description: '',
+          key: tableKey + '/amount',
           name: 'amount',
           sort_order: 0,
           nested_level: 0,
@@ -174,7 +176,7 @@ describe('helpers', () => {
           stats: [],
         },
       ];
-      const actual = Helpers.processColumns(testColumn);
+      const actual = Helpers.processColumns(testColumn, tableKey);
       expect(actual[0].children).toEqual(expectedChildren);
     });
   });

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -44,14 +44,15 @@ export function getRelatedDashboardSlug(key: string): string {
  */
 export function processColumns(
   columns: TableColumn[],
+  tableKey: string,
   databaseId?: string
 ): TableColumn[] {
-  return columns.map((column, index) => {
+  return columns.map((column) => {
     const nestedType = parseNestedType(column.col_type, databaseId);
 
     return {
       ...column,
-      col_index: index,
+      key: tableKey + '/' + column.name,
       children:
         nestedType && isNestedColumnsEnabled()
           ? convertNestedTypeToColumns(nestedType)
@@ -70,7 +71,11 @@ export function getTableDataFromResponseData(
     'owners',
     'tags',
   ]) as TableMetadata;
-  tableData.columns = processColumns(tableData.columns, tableData.database);
+  tableData.columns = processColumns(
+    tableData.columns,
+    tableData.key,
+    tableData.database
+  );
   return tableData;
 }
 
@@ -105,7 +110,8 @@ export function shouldSendNotification(user: PeopleUser): boolean {
  * Returns total column count, including nested columns
  */
 export function getColumnCount(columns: TableColumn[]) {
-  return columns.reduce((acc, column) => {
-    return acc + (column?.children?.length || 0);
-  }, columns.length);
+  return columns.reduce(
+    (acc, column) => acc + (column?.children?.length || 0),
+    columns.length
+  );
 }

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -146,10 +146,9 @@ export function generateOwnerUpdateRequests(
 }
 
 export function getColumnDescription(
-  columnIndex: number,
+  columnName: string,
   tableData: TableMetadata
 ) {
-  const columnName = tableData.columns[columnIndex].name;
   const tableParams = getTableQueryParams({
     key: tableData.key,
     column_name: columnName,
@@ -157,17 +156,21 @@ export function getColumnDescription(
   return axios
     .get(`${API_PATH}/get_column_description?${tableParams}`)
     .then((response: AxiosResponse<DescriptionAPI>) => {
-      tableData.columns[columnIndex].description = response.data.description;
+      const column = tableData.columns.find(
+        (column) => column.name === columnName
+      );
+      if (column) {
+        column.description = response.data.description;
+      }
       return tableData;
     });
 }
 
 export function updateColumnDescription(
   description: string,
-  columnIndex: number,
+  columnName: string,
   tableData: TableMetadata
 ) {
-  const columnName = tableData.columns[columnIndex].name;
   return axios.put(`${API_PATH}/put_column_description`, {
     description,
     column_name: columnName,

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/index.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/index.spec.ts
@@ -78,7 +78,7 @@ describe('tableMetadata ducks', () => {
   let testSource: string;
   let testTableQualityChecks: TableQualityChecks;
 
-  let columnIndex: number;
+  let columnName: string;
   let emptyPreviewData: PreviewData;
   let newDescription: string;
   let previewData: PreviewData;
@@ -114,7 +114,7 @@ describe('tableMetadata ducks', () => {
       last_run_timestamp: null,
     };
 
-    columnIndex = 2;
+    columnName = 'colName';
     emptyPreviewData = {
       columns: [],
       data: [],
@@ -208,14 +208,10 @@ describe('tableMetadata ducks', () => {
     });
 
     it('getColumnDescription - returns the action to get a column description given the index', () => {
-      const action = getColumnDescription(
-        columnIndex,
-        mockSuccess,
-        mockFailure
-      );
+      const action = getColumnDescription(columnName, mockSuccess, mockFailure);
       const { payload } = action;
       expect(action.type).toBe(GetColumnDescription.REQUEST);
-      expect(payload.columnIndex).toBe(columnIndex);
+      expect(payload.columnName).toBe(columnName);
       expect(payload.onSuccess).toBe(mockSuccess);
       expect(payload.onFailure).toBe(mockFailure);
     });
@@ -237,14 +233,14 @@ describe('tableMetadata ducks', () => {
     it('updateColumnDescription - returns the action to update the table description', () => {
       const action = updateColumnDescription(
         newDescription,
-        columnIndex,
+        columnName,
         mockSuccess,
         mockFailure
       );
       const { payload } = action;
       expect(action.type).toBe(UpdateColumnDescription.REQUEST);
       expect(payload.newValue).toBe(newDescription);
-      expect(payload.columnIndex).toBe(columnIndex);
+      expect(payload.columnName).toBe(columnName);
       expect(payload.onSuccess).toBe(mockSuccess);
       expect(payload.onFailure).toBe(mockFailure);
     });
@@ -585,18 +581,18 @@ describe('tableMetadata ducks', () => {
               .next(globalState)
               .call(
                 API.getColumnDescription,
-                action.payload.columnIndex,
+                action.payload.columnName,
                 globalState.tableMetadata.tableData
               )
               .next(mockNewTableData)
               .put(getColumnDescriptionSuccess(mockNewTableData));
         });
         it('without success callback', () => {
-          sagaTest(getColumnDescription(columnIndex)).next().isDone();
+          sagaTest(getColumnDescription(columnName)).next().isDone();
         });
 
         it('with success callback', () => {
-          sagaTest(getColumnDescription(columnIndex, mockSuccess, mockFailure))
+          sagaTest(getColumnDescription(columnName, mockSuccess, mockFailure))
             .next()
             .call(mockSuccess)
             .next()
@@ -618,11 +614,11 @@ describe('tableMetadata ducks', () => {
               );
         });
         it('without failure callback', () => {
-          sagaTest(getColumnDescription(columnIndex)).next().isDone();
+          sagaTest(getColumnDescription(columnName)).next().isDone();
         });
 
         it('with failure callback', () => {
-          sagaTest(getColumnDescription(columnIndex, mockSuccess, mockFailure))
+          sagaTest(getColumnDescription(columnName, mockSuccess, mockFailure))
             .next()
             .call(mockFailure)
             .next()
@@ -653,7 +649,7 @@ describe('tableMetadata ducks', () => {
               updateColumnDescriptionWorker,
               updateColumnDescription(
                 newDescription,
-                columnIndex,
+                columnName,
                 mockSuccess,
                 undefined
               )
@@ -664,7 +660,7 @@ describe('tableMetadata ducks', () => {
               .call(
                 API.updateColumnDescription,
                 newDescription,
-                columnIndex,
+                columnName,
                 globalState.tableMetadata.tableData
               );
         });
@@ -685,7 +681,7 @@ describe('tableMetadata ducks', () => {
               updateColumnDescriptionWorker,
               updateColumnDescription(
                 newDescription,
-                columnIndex,
+                columnName,
                 undefined,
                 mockFailure
               )

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -195,7 +195,7 @@ export function updateTableDescription(
 }
 
 export function getColumnDescription(
-  columnIndex: number,
+  columnName: string,
   onSuccess?: () => any,
   onFailure?: () => any
 ): GetColumnDescriptionRequest {
@@ -203,7 +203,7 @@ export function getColumnDescription(
     payload: {
       onSuccess,
       onFailure,
-      columnIndex,
+      columnName,
     },
     type: GetColumnDescription.REQUEST,
   };
@@ -231,14 +231,14 @@ export function getColumnDescriptionSuccess(
 
 export function updateColumnDescription(
   newValue: string,
-  columnIndex: number,
+  columnName: string,
   onSuccess?: () => any,
   onFailure?: () => any
 ): UpdateColumnDescriptionRequest {
   return {
     payload: {
       newValue,
-      columnIndex,
+      columnName,
       onSuccess,
       onFailure,
     },

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -120,7 +120,7 @@ export function* getColumnDescriptionWorker(
   try {
     tableData = yield call(
       API.getColumnDescription,
-      payload.columnIndex,
+      payload.columnName,
       state.tableMetadata.tableData
     );
     yield put(getColumnDescriptionSuccess(tableData));
@@ -147,7 +147,7 @@ export function* updateColumnDescriptionWorker(
     yield call(
       API.updateColumnDescription,
       payload.newValue,
-      payload.columnIndex,
+      payload.columnName,
       state.tableMetadata.tableData
     );
     if (payload.onSuccess) {

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/types.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/types.ts
@@ -88,7 +88,7 @@ export enum GetColumnDescription {
 export interface GetColumnDescriptionRequest {
   type: GetColumnDescription.REQUEST;
   payload: {
-    columnIndex: number;
+    columnName: string;
     onSuccess?: () => any;
     onFailure?: () => any;
   };
@@ -109,7 +109,7 @@ export interface UpdateColumnDescriptionRequest {
   type: UpdateColumnDescription.REQUEST;
   payload: {
     newValue: string;
-    columnIndex: number;
+    columnName: string;
     onSuccess?: () => any;
     onFailure?: () => any;
   };

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDescEditableText/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDescEditableText/index.tsx
@@ -17,15 +17,16 @@ import EditableText, {
 } from 'components/EditableText';
 
 interface ContainerOwnProps {
-  columnIndex: number;
+  columnName: string;
 }
 
 export const mapStateToProps = (
   state: GlobalState,
   ownProps: ContainerOwnProps
 ) => ({
-  refreshValue:
-    state.tableMetadata.tableData.columns[ownProps.columnIndex].description,
+  refreshValue: state.tableMetadata.tableData.columns.find(
+    (column) => column.name === ownProps.columnName
+  )?.description,
 });
 
 export const mapDispatchToProps = (
@@ -33,12 +34,12 @@ export const mapDispatchToProps = (
   ownProps: ContainerOwnProps
 ) => {
   const getLatestValue = function (onSuccess, onFailure) {
-    return getColumnDescription(ownProps.columnIndex, onSuccess, onFailure);
+    return getColumnDescription(ownProps.columnName, onSuccess, onFailure);
   };
   const onSubmitValue = function (newValue, onSuccess, onFailure) {
     return updateColumnDescription(
       newValue,
-      ownProps.columnIndex,
+      ownProps.columnName,
       onSuccess,
       onFailure
     );

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -31,8 +31,8 @@ const mockColumnDetails = {
   action: { name: 'column_name', isActionEnabled: true },
   editText: 'Click to edit description in the data source site',
   editUrl: 'https://test.datasource.site/table',
-  col_index: 0,
   index: 0,
+  key: 'database://cluster.schema/table/column_name',
   name: 'column_name',
   tableParams: {
     database: 'database',

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -47,7 +47,6 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
     stats,
     editText,
     editUrl,
-    col_index,
     name,
     tableParams,
     isEditable,
@@ -112,7 +111,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
           editUrl={editUrl || undefined}
         >
           <ColumnDescEditableText
-            columnIndex={col_index}
+            columnName={name}
             editable={isEditable}
             maxLength={getMaxLength('columnDescLength')}
             value={content.description}

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -48,7 +48,7 @@ const setup = (propOverrides?: Partial<ColumnListProps>) => {
     toggleRightPanel: jest.fn(),
     preExpandRightPanel: jest.fn(),
     hideSomeColumnMetadata: false,
-    currentSelectedIndex: -1,
+    currentSelectedKey: '',
     ...propOverrides,
   };
   // Update state

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -80,7 +80,7 @@ export interface ComponentProps {
     event: any
   ) => void;
   hideSomeColumnMetadata: boolean;
-  currentSelectedIndex: number;
+  currentSelectedKey: string;
 }
 
 export interface DispatchFromProps {
@@ -119,8 +119,8 @@ export type FormattedDataType = {
   action: ActionType;
   editText: string | null;
   editUrl: string | null;
-  col_index: number;
   index: number;
+  key: string;
   name: string;
   tableParams: TablePageParams;
   sort_order: number;
@@ -201,7 +201,7 @@ const ExpandedRowComponent: React.FC<ExpandedRowProps> = (
   rowValue: FormattedDataType
 ) => {
   if (!rowValue.isExpandable) {
-    return;
+    return null;
   }
   const shouldRenderDescription = () => {
     const { content, editText, editUrl, isEditable } = rowValue;
@@ -227,7 +227,7 @@ const ExpandedRowComponent: React.FC<ExpandedRowProps> = (
           editUrl={rowValue.editUrl || undefined}
         >
           <ColumnDescEditableText
-            columnIndex={rowValue.col_index}
+            columnName={rowValue.name}
             editable={rowValue.isEditable}
             maxLength={getMaxLength('columnDescLength')}
             value={rowValue.content.description}
@@ -258,7 +258,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
   preExpandRightPanel,
   toggleRightPanel,
   hideSomeColumnMetadata,
-  currentSelectedIndex,
+  currentSelectedKey,
 }: ColumnListProps) => {
   let selectedIndex;
   const hasColumnBadges = hasColumnWithBadge(columns);
@@ -277,7 +277,6 @@ const ColumnList: React.FC<ColumnListProps> = ({
         name: item.name,
         database,
       },
-      col_index: item.col_index,
       children: item.children,
       sort_order: item.sort_order,
       usage: getUsageStat(item),
@@ -286,6 +285,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
         name: item.name,
         isActionEnabled: !item.nested_level,
       },
+      key: item.key,
       name: item.name,
       isEditable: item.is_editable,
       isExpandable: !item.nested_level,
@@ -503,7 +503,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
         onExpand: handleRowExpand,
         tableClassName: 'table-detail-table',
         preExpandRow: selectedIndex,
-        currentSelectedIndex,
+        currentSelectedKey,
       }}
     />
   );

--- a/frontend/amundsen_application/static/js/features/ColumnList/testDataBuilder.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/testDataBuilder.ts
@@ -9,7 +9,6 @@ const defaultConfig = {
       is_editable: true,
       name: 'simple_column_name_string',
       sort_order: 0,
-      col_index: 0,
       stats: [
         {
           end_epoch: 1600473600,
@@ -25,7 +24,6 @@ const defaultConfig = {
       is_editable: true,
       name: 'simple_column_name_int',
       sort_order: 1,
-      col_index: 1,
       stats: [
         {
           end_epoch: 1600473600,
@@ -41,7 +39,6 @@ const defaultConfig = {
       is_editable: true,
       name: 'simple_column_name_bigint',
       sort_order: 2,
-      col_index: 2,
       stats: [
         {
           end_epoch: 1600473600,
@@ -57,7 +54,6 @@ const defaultConfig = {
       is_editable: true,
       name: 'simple_column_name_timestamp',
       sort_order: 3,
-      col_index: 3,
       stats: [
         {
           end_epoch: 1600473600,
@@ -94,7 +90,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_2',
           sort_order: 0,
-          col_index: 0,
           stats: [
             {
               end_epoch: 1600473600,
@@ -110,7 +105,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_3',
           sort_order: 1,
-          col_index: 1,
           stats: [
             {
               end_epoch: 1600473600,
@@ -127,7 +121,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_4',
           sort_order: 2,
-          col_index: 2,
           stats: [
             {
               end_epoch: 1600473600,
@@ -153,7 +146,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_1',
           sort_order: 0,
-          col_index: 0,
           stats: [],
         },
         {
@@ -163,7 +155,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_2',
           sort_order: 1,
-          col_index: 1,
           stats: [],
         },
       ],
@@ -182,7 +173,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_1',
           sort_order: 0,
-          col_index: 0,
           stats: [],
         },
         {
@@ -192,7 +182,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_2',
           sort_order: 1,
-          col_index: 1,
           stats: [],
         },
         {
@@ -202,7 +191,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_3',
           sort_order: 2,
-          col_index: 2,
           stats: [
             {
               end_epoch: 1600473600,
@@ -228,7 +216,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_2',
           sort_order: 0,
-          col_index: 0,
           stats: [
             {
               end_epoch: 1600473600,
@@ -244,7 +231,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_3',
           sort_order: 1,
-          col_index: 1,
           stats: [
             {
               end_epoch: 1600473600,
@@ -267,7 +253,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_4',
           sort_order: 2,
-          col_index: 2,
           stats: [
             {
               end_epoch: 1600473600,
@@ -293,7 +278,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_2',
           sort_order: 0,
-          col_index: 0,
           stats: [
             {
               end_epoch: 1600473600,
@@ -310,7 +294,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_3',
           sort_order: 1,
-          col_index: 1,
           stats: [
             {
               end_epoch: 1600473600,
@@ -339,7 +322,6 @@ function TestDataBuilder(config = {}) {
           is_editable: true,
           name: 'complex_column_name_4',
           sort_order: 2,
-          col_index: 2,
           stats: [
             {
               end_epoch: 1600473600,

--- a/frontend/amundsen_application/static/js/fixtures/metadata/table.ts
+++ b/frontend/amundsen_application/static/js/fixtures/metadata/table.ts
@@ -20,6 +20,7 @@ export const tableMetadata: TableMetadata = {
       description: 'Test Value',
       is_editable: true,
       sort_order: 0,
+      key: 'hive://gold.base/rides/ride_id',
       name: 'ride_id',
       stats: [
         {
@@ -49,6 +50,7 @@ export const tableMetadata: TableMetadata = {
         'ds will be the date part of requested_at ds will be the date part of requested_at ds will be the date part of requested_at ds will be the date part of requested_at ds will be the date part of requested_at ds will be the date part of requested_at ds w',
       is_editable: true,
       sort_order: 1,
+      key: 'hive://gold.base/rides/ds',
       name: 'ds',
       stats: [],
       badges: [],
@@ -58,6 +60,7 @@ export const tableMetadata: TableMetadata = {
       description: 'Route_id Description',
       is_editable: true,
       sort_order: 2,
+      key: 'hive://gold.base/rides/route_id',
       name: 'route_id',
       stats: [
         {

--- a/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -48,19 +48,29 @@ export interface TablePreviewQueryParams {
   cluster: string;
 }
 
-export type TableColumnType = TableColumn | NestedTableColumn;
-
 export interface TableColumn {
   badges: Badge[];
   col_type: string;
-  col_index?: number;
   children?: NestedTableColumn[];
   description: string;
   is_editable: boolean;
+  key?: string;
   name: string;
+  type_metadata?: TypeMetadata;
   sort_order: number;
   stats: TableColumnStats[];
   nested_level?: number;
+}
+
+export interface TypeMetadata {
+  kind: string;
+  name: string;
+  key: string;
+  description: string;
+  data_type: string;
+  sort_order: string;
+  badges?: Badge[];
+  children?: TypeMetadata[];
 }
 
 export interface NestedTableColumn {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ListSortingDropdown/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ListSortingDropdown/index.spec.tsx
@@ -118,6 +118,22 @@ describe('ListSortingDropdown', () => {
         expect(actual).toEqual(expected);
       });
     });
+
+    describe('when a selection is passed', () => {
+      it('selects the passed option', () => {
+        const { wrapper } = setup({
+          currentSelection: USAGE_SORTING.usage,
+          options: { ...DEFAULT_SORTING, ...USAGE_SORTING },
+        });
+        const expected = true;
+        const actual = wrapper
+          .find('.list-sorting-dropdown .radio-label input')
+          .at(1)
+          .prop('checked');
+
+        expect(actual).toEqual(expected);
+      });
+    });
   });
 
   describe('lifetime', () => {
@@ -172,7 +188,7 @@ describe('ListSortingDropdown', () => {
           .at(1)
           .simulate('change', { target: { value: 'usage' } });
 
-        const actual = onChangeSpy.mock.calls[0];
+        const [actual] = onChangeSpy.mock.calls;
 
         expect(actual).toEqual(expected);
       });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/ListSortingDropdown/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/ListSortingDropdown/index.tsx
@@ -14,6 +14,7 @@ type Criterias = { [key: string]: SortCriteria };
 
 export interface ListSortingDropdownProps {
   options: Criterias;
+  currentSelection?: SortCriteria;
   onChange?: (value) => void;
 }
 
@@ -21,11 +22,12 @@ type OptionType = string;
 
 const TableReportsDropdown: React.FC<ListSortingDropdownProps> = ({
   options,
+  currentSelection,
   onChange,
 }: ListSortingDropdownProps) => {
   const criterias = Object.entries(options);
   const [selectedOption, setSelectedOption] = React.useState<OptionType>(
-    criterias?.[0]?.[1]?.key
+    currentSelection ? currentSelection.key : criterias?.[0]?.[1]?.key
   );
   const [isOpen, setOpen] = React.useState(false);
 

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -35,8 +35,8 @@ const mockColumnDetails = {
   action: { name: 'column_name', isActionEnabled: true },
   editText: 'Click to edit description in the data source site',
   editUrl: 'https://test.datasource.site/table',
-  col_index: 0,
   index: 0,
+  key: 'database://cluster.schema/table/column_name',
   name: 'column_name',
   tableParams: {
     database: 'database',
@@ -180,7 +180,7 @@ describe('TableDetail', () => {
         expect(setStateSpy).toHaveBeenCalledWith({
           isRightPanelPreExpanded: true,
           isRightPanelOpen: true,
-          selectedColumnIndex: 0,
+          selectedColumnKey: 'database://cluster.schema/table/column_name',
           selectedColumnDetails: mockColumnDetails,
         });
       });
@@ -196,7 +196,7 @@ describe('TableDetail', () => {
         expect(props.getColumnLineageDispatch).toHaveBeenCalled();
         expect(setStateSpy).toHaveBeenCalledWith({
           isRightPanelOpen: true,
-          selectedColumnIndex: 0,
+          selectedColumnKey: 'database://cluster.schema/table/column_name',
           selectedColumnDetails: mockColumnDetails,
         });
       });
@@ -211,7 +211,7 @@ describe('TableDetail', () => {
 
         expect(setStateSpy).toHaveBeenCalledWith({
           isRightPanelOpen: false,
-          selectedColumnIndex: -1,
+          selectedColumnKey: '',
           selectedColumnDetails: undefined,
         });
       });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -36,7 +36,7 @@ import {
 
 import BadgeList from 'features/BadgeList';
 import ColumnList, { FormattedDataType } from 'features/ColumnList';
-import ColumnDetailsView from 'features/ColumnList/ColumnDetailsPanel';
+import ColumnDetailsPanel from 'features/ColumnList/ColumnDetailsPanel';
 
 import Alert from 'components/Alert';
 import BookmarkIcon from 'components/Bookmark/BookmarkIcon';
@@ -149,7 +149,7 @@ export interface StateProps {
   currentTab: string;
   isRightPanelOpen: boolean;
   isRightPanelPreExpanded: boolean;
-  selectedColumnIndex: number;
+  selectedColumnKey: string;
   selectedColumnDetails?: FormattedDataType;
 }
 
@@ -166,7 +166,7 @@ export class TableDetail extends React.Component<
     currentTab: this.getDefaultTab(),
     isRightPanelOpen: false,
     isRightPanelPreExpanded: false,
-    selectedColumnIndex: -1,
+    selectedColumnKey: '',
     selectedColumnDetails: undefined,
   };
 
@@ -262,18 +262,18 @@ export class TableDetail extends React.Component<
     const { isRightPanelPreExpanded } = this.state;
     const { getColumnLineageDispatch } = this.props;
 
-    let colIndex = -1;
+    let key = '';
     if (columnDetails) {
       const { name, tableParams } = columnDetails;
-      ({ col_index: colIndex } = columnDetails);
+      ({ key } = columnDetails);
       getColumnLineageDispatch(buildTableKey(tableParams), name);
     }
 
-    if (!isRightPanelPreExpanded && colIndex >= 0) {
+    if (!isRightPanelPreExpanded && key) {
       this.setState({
         isRightPanelOpen: true,
         isRightPanelPreExpanded: true,
-        selectedColumnIndex: colIndex,
+        selectedColumnKey: key,
         selectedColumnDetails: columnDetails,
       });
     }
@@ -283,25 +283,25 @@ export class TableDetail extends React.Component<
     newColumnDetails: FormattedDataType | undefined,
     event
   ) => {
-    const { isRightPanelOpen, selectedColumnIndex } = this.state;
+    const { isRightPanelOpen, selectedColumnKey } = this.state;
     const { getColumnLineageDispatch } = this.props;
 
     if (event) {
       logClick(event);
     }
 
-    let colIndex = -1;
+    let key = '';
     if (newColumnDetails) {
       const { name, tableParams } = newColumnDetails;
-      ({ col_index: colIndex } = newColumnDetails);
+      ({ key } = newColumnDetails);
       getColumnLineageDispatch(buildTableKey(tableParams), name);
     }
 
     const shouldPanelOpen =
-      (colIndex >= 0 && colIndex !== selectedColumnIndex) || !isRightPanelOpen;
+      (key && key !== selectedColumnKey) || !isRightPanelOpen;
     this.setState({
       isRightPanelOpen: shouldPanelOpen,
-      selectedColumnIndex: shouldPanelOpen ? colIndex : -1,
+      selectedColumnKey: shouldPanelOpen ? key : '',
       selectedColumnDetails: newColumnDetails,
     });
   };
@@ -319,7 +319,7 @@ export class TableDetail extends React.Component<
       sortedBy,
       currentTab,
       isRightPanelOpen,
-      selectedColumnIndex,
+      selectedColumnKey,
     } = this.state;
     const tableParams: TablePageParams = {
       cluster: tableData.cluster,
@@ -344,7 +344,7 @@ export class TableDetail extends React.Component<
           preExpandRightPanel={this.preExpandRightPanel}
           hideSomeColumnMetadata={isRightPanelOpen}
           toggleRightPanel={this.toggleRightPanel}
-          currentSelectedIndex={selectedColumnIndex}
+          currentSelectedKey={selectedColumnKey}
         />
       ),
       key: Constants.TABLE_TAB.COLUMN,
@@ -463,7 +463,12 @@ export class TableDetail extends React.Component<
 
   render() {
     const { isLoading, statusCode, tableData } = this.props;
-    const { currentTab, isRightPanelOpen, selectedColumnDetails } = this.state;
+    const {
+      sortedBy,
+      currentTab,
+      isRightPanelOpen,
+      selectedColumnDetails,
+    } = this.state;
     let innerContent;
 
     // We want to avoid rendering the previous table's metadata before new data is fetched in componentDidMount
@@ -632,13 +637,14 @@ export class TableDetail extends React.Component<
                 !isRightPanelOpen && (
                   <ListSortingDropdown
                     options={SORT_CRITERIAS}
+                    currentSelection={sortedBy}
                     onChange={this.handleSortingChange}
                   />
                 )}
               {this.renderTabs(editText, editUrl)}
             </main>
             {isRightPanelOpen && selectedColumnDetails && (
-              <ColumnDetailsView
+              <ColumnDetailsPanel
                 columnDetails={selectedColumnDetails!}
                 togglePanel={this.toggleRightPanel}
               />


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

These changes are made in anticipation of the upcoming work to add in nested columns retrieved from the backend rather than frontend parsing outlined [here](https://github.com/amundsen-io/rfcs/blob/master/rfcs/047-nested-columns.md). This removes the dependence on the columns' indices around descriptions and side panel column details, and now relies on names and keys to be able to extend the same usage to nested columns.

- Add `TypeMetadata` in frontend model as an optional `TableColumn` field - this data was already being retrieved from the metadata API so now it is being populated
- Use the column `name` directly for getting/setting column descriptions rather than its index
- Add column `key` field to `TableColumn`s to be used to keep track of which column is currently selected when the right side column details panel is open
- Remove the now unnecessary extra `col_index` field in `TableColumn`
- Also fixed the `ListSortingDropdown` to maintain the correct previous selection after the right side panel opens and closes

### Tests

General cleanup of tests for changes outlined above, and added a test for the `ListSortingDropdown` to make sure it selects the new prop for the currently selected option

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
