### PR TITLE
fix: better behavior for search filters

### DIFF
--- a/search/search_service/proxy/es_search_proxy.py
+++ b/search/search_service/proxy/es_search_proxy.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 from typing import (
     Any, Dict, List, Union,
@@ -198,21 +199,24 @@ class ElasticsearchProxy():
         filter_queries: List = []
 
         for filter in filters:
-            filter_name = mapping.get(filter.name) if mapping is not None \
-                and mapping.get(filter.name) is not None else filter.name
+            if mapping is not None and mapping.get(filter.name):
+                # only apply filter to query if field exists for the given resource
+                filter_name = mapping.get(filter.name)
 
-            queries_per_term = [Q(WILDCARD_QUERY, **{filter_name: term}) for term in filter.values]
+                queries_per_term = [Q(WILDCARD_QUERY, **{filter_name: term}) for term in filter.values]
 
-            if filter.operation == 'OR':
-                filter_queries.append(Q(BOOL_QUERY, should=queries_per_term, minimum_should_match=1))
+                if filter.operation == 'OR':
+                    filter_queries.append(Q(BOOL_QUERY, should=queries_per_term, minimum_should_match=1))
 
-            elif filter.operation == 'AND':
-                for q in queries_per_term:
-                    filter_queries.append(q)
+                elif filter.operation == 'AND':
+                    for q in queries_per_term:
+                        filter_queries.append(q)
 
+                else:
+                    msg = f"Invalid operation {filter.operation} for filter {filter_name} with values {filter.values}"
+                    raise ValueError(msg)
             else:
-                msg = f"Invalid operation {filter.operation} for filter {filter_name} with values {filter.values}"
-                raise ValueError(msg)
+                LOGGER.info("Filter {filter.name} does not apply to {resource}")
 
         return filter_queries
 
@@ -291,13 +295,13 @@ class ElasticsearchProxy():
         for resource in queries.keys():
             query_for_resource = queries.get(resource)
             search = Search(index=self.get_index_for_resource(resource_type=resource)).query(query_for_resource)
-            LOGGER.info(search.to_dict())
+
             # pagination
             start_from = page_index * results_per_page
             end = results_per_page * (page_index + 1)
 
             search = search[start_from:end]
-
+            LOGGER.info(json.dumps(search.to_dict()))
             multisearch = multisearch.add(search)
         try:
             response = multisearch.execute()

--- a/search/search_service/proxy/es_search_proxy.py
+++ b/search/search_service/proxy/es_search_proxy.py
@@ -199,7 +199,7 @@ class ElasticsearchProxy():
         filter_queries: List = []
 
         for filter in filters:
-            if mapping is not None and mapping.get(filter.name):
+            if mapping is not None and mapping.get(filter.name) is not None:
                 # only apply filter to query if field exists for the given resource
                 filter_name = mapping.get(filter.name)
 


### PR DESCRIPTION
Change filters so if the field is not mapped for the resource the filter won't be applied to the query for that resource