### PR TITLE
fix: avoid extra load url search call when default filters are applied

### DIFF
--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
@@ -56,12 +56,15 @@ export function getDefaultFiltersForResource(
     filterCategories
       ?.filter(({ defaultValue }) => defaultValue && defaultValue.length > 0)
       .reduce((acc, currentFilter) => {
+        var filterOptions: {[k: string]: any} = {
+          value: currentFilter.defaultValue?.join(),
+        };
+        if (currentFilter.allowableOperation){
+          filterOptions.filterOperation = currentFilter.allowableOperation
+        }
         return {
           ...acc,
-          [currentFilter.categoryId]: {
-            value: currentFilter.defaultValue?.join(),
-            filterOperation: currentFilter.allowableOperation,
-          },
+          [currentFilter.categoryId]: filterOptions,
         };
       }, initialValue) || {};
   return defaultFilters;

--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
@@ -56,7 +56,7 @@ export function getDefaultFiltersForResource(
     filterCategories
       ?.filter(({ defaultValue }) => defaultValue && defaultValue.length > 0)
       .reduce((acc, currentFilter) => {
-        var filterOptions: { [k: string]: any } = {
+        let filterOptions: { [k: string]: any } = {
           value: currentFilter.defaultValue?.join(),
         };
         if (currentFilter.allowableOperation) {

--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
@@ -56,7 +56,7 @@ export function getDefaultFiltersForResource(
     filterCategories
       ?.filter(({ defaultValue }) => defaultValue && defaultValue.length > 0)
       .reduce((acc, currentFilter) => {
-        let filterOptions: { [k: string]: any } = {
+        const filterOptions: { [k: string]: any } = {
           value: currentFilter.defaultValue?.join(),
         };
         if (currentFilter.allowableOperation) {

--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
@@ -56,11 +56,11 @@ export function getDefaultFiltersForResource(
     filterCategories
       ?.filter(({ defaultValue }) => defaultValue && defaultValue.length > 0)
       .reduce((acc, currentFilter) => {
-        var filterOptions: {[k: string]: any} = {
+        var filterOptions: { [k: string]: any } = {
           value: currentFilter.defaultValue?.join(),
         };
-        if (currentFilter.allowableOperation){
-          filterOptions.filterOperation = currentFilter.allowableOperation
+        if (currentFilter.allowableOperation) {
+          filterOptions.filterOperation = currentFilter.allowableOperation;
         }
         return {
           ...acc,


### PR DESCRIPTION
Before this change when default filters were configured we would make an extra load url search request which is not necessary.