### PR TITLE
fix: relax pandas version requirements for databuilder

### DIFF
--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -23,7 +23,7 @@ unicodecsv>=0.14.1,<1.0
 httplib2>=0.18.0
 unidecode
 Jinja2>=2.10.0,<4
-pandas>=0.21.0,<1.2.0
+pandas>=0.21.0,<1.5.0
 responses>=0.10.6
 
 amundsen-common>=0.16.0


### PR DESCRIPTION
### Summary of Changes

Relax the pandas version requirements for the databuilder package, which is currently limited to a version released over 2 year ago, to allow for more recent versions. This will make it possible to easily include the package in repos that use modern versions of pandas.

### Tests

Tested on pandas 1.4.2 (the current version).

Pandas usage was already tested in unit tests so no new tests are necessary.

### Documentation

Very little of the pandas API is used, essentially just `read_csv`, which is a very stable part of the API.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
