### PR TITLE
feat: Adding nested columns to be displayed in the column dropdowns as rows

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -341,9 +341,6 @@ exports[`eslint`] = {
       [60, 2, 51, "refToSelf should be placed after componentWillUnmount", "3412474606"],
       [105, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
-    "js/components/Table/index.tsx:1457853108": [
-      [314, 8, 65, "A control must be associated with a text label.", "1026764939"]
-    ],
     "js/components/Table/table.story.tsx:3074937505": [
       [8, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
     ],
@@ -684,7 +681,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:2270284782": [
+    "js/pages/TableDetailPage/index.tsx:3137356052": [
       [159, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [205, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -681,9 +681,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:3137356052": [
-      [159, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [205, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:1654932239": [
+      [160, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [206, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/js/components/Table/constants.ts
+++ b/frontend/amundsen_application/static/js/components/Table/constants.ts
@@ -1,0 +1,5 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+export const COLUMN_NAME_REGEX = '\\/(\\w+)'; // '/' followed by one or more word characters
+export const TYPE_METADATA_REGEX = '\\/type\\/(\\w+)'; // '/type/' followed by one or more word characters

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -692,7 +692,7 @@ describe('Table', () => {
               currentSelectedKey: 'database://cluster.schema/table/rowName',
             },
           });
-          const expected = 'ams-table-row undefined is-selected-row';
+          const expected = 'ams-table-row  is-selected-row';
           const actual = wrapper
             .find('.ams-table-row')
             .get(0)
@@ -707,7 +707,7 @@ describe('Table', () => {
               currentSelectedKey: 'database://cluster.schema/table/rowName',
             },
           });
-          const expected = 'ams-table-row undefined false';
+          const expected = 'ams-table-row';
           const actual = wrapper
             .find('.ams-table-row')
             .get(1)

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -10,6 +10,10 @@ import Table, { TableProps } from '.';
 
 const dataBuilder = new TestDataBuilder();
 
+const formatChildrenDataMock = jest
+  .fn()
+  .mockImplementation((rowValue) => ({ key: rowValue.key }));
+
 const setup = (propOverrides?: Partial<TableProps>) => {
   const { data, columns } = dataBuilder.build();
   const props = {
@@ -202,7 +206,7 @@ describe('Table', () => {
       });
     });
 
-    describe('colums', () => {
+    describe('columns', () => {
       describe('when horizontal alignment is passed', () => {
         const { columns, data } = dataBuilder.withAlignedColumns().build();
 
@@ -566,22 +570,14 @@ describe('Table', () => {
         });
       });
 
-      describe('when expandRow is passed', () => {
+      describe('when a row is expandable', () => {
         const { columns, data } = dataBuilder.withCollapsedRow().build();
-        const expandRowComponent = (rowValue, index) => (
-          <strong>
-            {index}:{rowValue.value}
-          </strong>
-        );
 
         describe('table header', () => {
           it('renders a table header', () => {
             const { wrapper } = setup({
               data,
               columns,
-              options: {
-                expandRow: expandRowComponent,
-              },
             });
             const expected = 1;
             const actual = wrapper.find('.ams-table-header').length;
@@ -589,15 +585,12 @@ describe('Table', () => {
             expect(actual).toEqual(expected);
           });
 
-          it('renders one cell more than columns length inside the header', () => {
+          it('renders the same amount of cells equal to columns length inside the header', () => {
             const { wrapper } = setup({
               data,
               columns,
-              options: {
-                expandRow: expandRowComponent,
-              },
             });
-            const expected = columns.length + 1;
+            const expected = columns.length;
             const actual = wrapper.find(
               '.ams-table-header .ams-table-heading-cell'
             ).length;
@@ -607,31 +600,13 @@ describe('Table', () => {
         });
 
         describe('table body', () => {
-          it('renders the first column as a expansion cell', () => {
+          it('renders expansion buttons for rows that are expandable', () => {
             const { wrapper } = setup({
               data,
               columns,
-              options: {
-                expandRow: expandRowComponent,
-              },
             });
-            const expected = data.length;
-            const actual = wrapper.find(
-              '.ams-table-body .ams-table-expanding-cell'
-            ).length;
-
-            expect(actual).toEqual(expected);
-          });
-
-          it('renders buttons for expansion', () => {
-            const { wrapper } = setup({
-              data,
-              columns,
-              options: {
-                expandRow: expandRowComponent,
-              },
-            });
-            const expected = data.length;
+            const expected = data.filter((item) => item.isExpandable === true)
+              .length;
             const actual = wrapper.find(
               '.ams-table-body .ams-table-expanding-button'
             ).length;
@@ -640,34 +615,14 @@ describe('Table', () => {
           });
 
           describe('expanded row', () => {
-            it('renders it with multiple colspan', () => {
-              const { wrapper } = setup({
-                data,
-                columns,
-                options: {
-                  expandRow: expandRowComponent,
-                },
-              });
-              const expected = columns.length + 1;
-              const actual = wrapper
-                .find('.ams-table-body .ams-table-expanded-row .ams-table-cell')
-                .get(1).props.colSpan;
-
-              expect(actual).toEqual(expected);
-            });
-
             it('renders hidden by default', () => {
               const { wrapper } = setup({
                 data,
                 columns,
-                options: {
-                  expandRow: expandRowComponent,
-                },
               });
-              const expected = 0;
-              const actual = wrapper.find(
-                '.ams-table-body .ams-table-expanded-row.is-expanded'
-              ).length;
+              const expected = data.length;
+              const actual = wrapper.find('.ams-table-body .ams-table-row')
+                .length;
 
               expect(actual).toEqual(expected);
             });
@@ -737,7 +692,7 @@ describe('Table', () => {
               currentSelectedKey: 'database://cluster.schema/table/rowName',
             },
           });
-          const expected = 'ams-table-row is-selected-row';
+          const expected = 'ams-table-row undefined is-selected-row';
           const actual = wrapper
             .find('.ams-table-row')
             .get(0)
@@ -752,7 +707,7 @@ describe('Table', () => {
               currentSelectedKey: 'database://cluster.schema/table/rowName',
             },
           });
-          const expected = 'ams-table-row false';
+          const expected = 'ams-table-row undefined false';
           const actual = wrapper
             .find('.ams-table-row')
             .get(1)
@@ -761,37 +716,76 @@ describe('Table', () => {
           expect(actual).toEqual(expected);
         });
       });
-    });
-  });
 
-  describe('lifetime', () => {
-    describe('when expandRow is passed', () => {
-      const { columns, data } = dataBuilder.withCollapsedRow().build();
-      const expandRowComponent = (rowValue, index) => (
-        <strong>
-          {index}:{rowValue.value}
-        </strong>
-      );
+      describe('when preExpandPanelKey is passed', () => {
+        const { columns, data } = dataBuilder.withCollapsedRow().build();
+        const preExpandRightPanelSpy = jest.fn();
+        window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
-      describe('when clicking on expand button', () => {
-        it('shows the expand row', () => {
+        it('preexpands the row that corresponds to the key', () => {
           const { wrapper } = setup({
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
+              tableKey: 'database://cluster.schema/table',
+              preExpandPanelKey: 'database://cluster.schema/table/rowName',
+              preExpandRightPanel: preExpandRightPanelSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
-          const expected = 1;
+
+          // The first row has two child rows when preexpanded
+          const expected = data.length + 2;
+          const actual = wrapper.find('.ams-table-body .ams-table-row').length;
+
+          expect(actual).toEqual(expected);
+        });
+
+        it('preexpands the row and all the parent rows that correspond to the key', () => {
+          const { wrapper } = setup({
+            data,
+            columns,
+            options: {
+              tableKey: 'database://cluster.schema/table',
+              preExpandPanelKey:
+                'database://cluster.schema/table/rowName/type/rowName/col1',
+              preExpandRightPanel: preExpandRightPanelSpy,
+              formatChildrenData: formatChildrenDataMock,
+            },
+          });
+
+          // The first row has two child rows when preexpanded
+          const expected = data.length + 2;
+          const actual = wrapper.find('.ams-table-body .ams-table-row').length;
+
+          expect(actual).toEqual(expected);
+        });
+      });
+    });
+  });
+
+  describe('lifetime', () => {
+    describe('when expanding and collapsing rows', () => {
+      const { columns, data } = dataBuilder.withCollapsedRow().build();
+
+      describe('when clicking on expand button', () => {
+        it('shows the expanded rows', () => {
+          const { wrapper } = setup({
+            data,
+            columns,
+            options: {
+              formatChildrenData: formatChildrenDataMock,
+            },
+          });
+          // The first row has two child rows when expanded
+          const expected = data.length + 2;
 
           wrapper
             .find('.ams-table-body .ams-table-expanding-button')
             .at(0)
             .simulate('click');
 
-          const actual = wrapper.find(
-            '.ams-table-body .ams-table-expanded-row.is-expanded'
-          ).length;
+          const actual = wrapper.find('.ams-table-body .ams-table-row').length;
 
           expect(actual).toEqual(expected);
         });
@@ -802,10 +796,10 @@ describe('Table', () => {
               data,
               columns,
               options: {
-                expandRow: expandRowComponent,
+                formatChildrenData: formatChildrenDataMock,
               },
             });
-            const expected = 0;
+            const expected = data.length;
 
             wrapper
               .find('.ams-table-body .ams-table-expanding-button')
@@ -813,9 +807,8 @@ describe('Table', () => {
               .simulate('click')
               .simulate('click');
 
-            const actual = wrapper.find(
-              '.ams-table-body .ams-table-expanded-row.is-expanded'
-            ).length;
+            const actual = wrapper.find('.ams-table-body .ams-table-row')
+              .length;
 
             expect(actual).toEqual(expected);
           });
@@ -823,15 +816,16 @@ describe('Table', () => {
       });
 
       describe('when clicking on multiple expand buttons', () => {
-        it('shows all those expand rows', () => {
+        it('shows all the expanded rows', () => {
           const { wrapper } = setup({
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
-          const expected = 2;
+          // The first two rows have four total child rows when both expanded
+          const expected = data.length + 4;
 
           wrapper
             .find('.ams-table-body .ams-table-expanding-button')
@@ -842,9 +836,7 @@ describe('Table', () => {
             .at(1)
             .simulate('click');
 
-          const actual = wrapper.find(
-            '.ams-table-body .ams-table-expanded-row.is-expanded'
-          ).length;
+          const actual = wrapper.find('.ams-table-body .ams-table-row').length;
 
           expect(actual).toEqual(expected);
         });
@@ -853,12 +845,6 @@ describe('Table', () => {
 
     describe('when onExpand is passed', () => {
       const { columns, data } = dataBuilder.withCollapsedRow().build();
-      const expandRowComponent = (rowValue, index) => (
-        <strong>
-          {index}:{rowValue.value}
-        </strong>
-      );
-
       describe('when clicking on expand button', () => {
         it('calls the onExpand handler', () => {
           const onExpandSpy = jest.fn();
@@ -866,8 +852,8 @@ describe('Table', () => {
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onExpand: onExpandSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
           const expected = 1;
@@ -882,17 +868,17 @@ describe('Table', () => {
           expect(actual).toEqual(expected);
         });
 
-        it('calls the onExpand handler with the row values and the index', () => {
+        it('calls the onExpand handler with the row values and the key', () => {
           const onExpandSpy = jest.fn();
           const { wrapper } = setup({
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onExpand: onExpandSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
-          const expected = [data[0], 0];
+          const expected = [data[0], data[0].key];
 
           wrapper
             .find('.ams-table-body .ams-table-expanding-button')
@@ -911,8 +897,8 @@ describe('Table', () => {
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onExpand: onExpandSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
           const expected = 2;
@@ -939,8 +925,8 @@ describe('Table', () => {
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onExpand: onExpandSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
           const expected = 1;
@@ -963,11 +949,6 @@ describe('Table', () => {
 
     describe('when onCollapse is passed', () => {
       const { columns, data } = dataBuilder.withCollapsedRow().build();
-      const expandRowComponent = (rowValue, index) => (
-        <strong>
-          {index}:{rowValue.value}
-        </strong>
-      );
 
       describe('when clicking on expand button', () => {
         it('does not call the onCollapse handler', () => {
@@ -976,8 +957,8 @@ describe('Table', () => {
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onCollapse: onCollapseSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
           const expected = 0;
@@ -1000,8 +981,8 @@ describe('Table', () => {
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onCollapse: onCollapseSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
           const expected = 1;
@@ -1020,17 +1001,17 @@ describe('Table', () => {
           expect(actual).toEqual(expected);
         });
 
-        it('calls the onCollapse handler with the row values and the index', () => {
+        it('calls the onCollapse handler with the row values and the key', () => {
           const onCollapseSpy = jest.fn();
           const { wrapper } = setup({
             data,
             columns,
             options: {
-              expandRow: expandRowComponent,
               onCollapse: onCollapseSpy,
+              formatChildrenData: formatChildrenDataMock,
             },
           });
-          const expected = [data[0], 0];
+          const expected = [data[0], data[0].key];
 
           wrapper
             .find('.ams-table-body .ams-table-expanding-button')

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -3,6 +3,8 @@
 
 import * as React from 'react';
 
+import { FormattedDataType } from 'features/ColumnList';
+
 import ShimmeringResourceLoader from '../ShimmeringResourceLoader';
 import { UpIcon, DownIcon } from '../SVGIcons';
 
@@ -37,18 +39,34 @@ export interface TableOptions {
   isLoading?: boolean;
   numLoadingBlocks?: number;
   rowHeight?: number;
-  preExpandRow?: number;
-  expandRow?: (rowValue: any, index: number) => React.ReactNode;
-  onExpand?: (rowValues: any, index: number) => void;
-  onCollapse?: (rowValues: any, index: number) => void;
+  preExpandPanelKey?: string;
+  onExpand?: (rowValues: any, key: string) => void;
+  onCollapse?: (rowValues: any, key: string) => void;
   emptyMessage?: string;
   currentSelectedKey?: string;
+  tableKey?: string;
+  formatChildrenData?: (item: any, index: number) => FormattedDataType;
+  preExpandRightPanel?: (columnDetails: FormattedDataType) => void;
 }
 
 export interface TableProps {
   data: RowData[];
   columns: TableColumn[];
   options?: TableOptions;
+}
+
+export interface TableRowProps {
+  columnKey: string;
+  currentSelectedKey?: string;
+  columns: TableColumn[];
+  rowValues: ValidData;
+  rowStyles: { height: string };
+  onExpand?: (rowValues: any, key: string) => void;
+  onCollapse?: (rowValues: any, key: string) => void;
+  expandRowRef?: React.RefObject<HTMLTableRowElement>;
+  expandedRows: RowKey[];
+  setExpandedRows: (key) => void;
+  nestedLevel: number;
 }
 
 type RowStyles = {
@@ -67,7 +85,10 @@ const INVALID_DATA_ERROR_MESSAGE =
   'Invalid data! Your data does not contain the fields specified on the columns property.';
 const DEFAULT_LOADING_ITEMS = 3;
 const DEFAULT_ROW_HEIGHT = 30;
-const EXPANDING_CELL_WIDTH = '70px';
+const EXPANDING_BUTTON_WIDTH = 60;
+const NESTED_EXPANDING_BUTTON_WIDTH = 40;
+const FIRST_LEVEL_INDENTATION_WIDTH = 50;
+const INDENTATION_WIDTH = 25;
 const DEFAULT_TEXT_ALIGNMENT = TextAlignmentValues.left;
 const DEFAULT_CELL_WIDTH = 'auto';
 const ALIGNEMENT_TO_CLASS_MAP = {
@@ -78,6 +99,22 @@ const ALIGNEMENT_TO_CLASS_MAP = {
 
 const getCellAlignmentClass = (alignment: TextAlignmentValues) =>
   ALIGNEMENT_TO_CLASS_MAP[alignment];
+
+const getExpandingButtonWidth = (nestedLevel) =>
+  nestedLevel === 0 ? EXPANDING_BUTTON_WIDTH : NESTED_EXPANDING_BUTTON_WIDTH;
+
+const getIndentationPaddingSize = (nestedLevel, isExpandable) => {
+  let indentationLevelPadding = 0;
+  if (nestedLevel > 0) {
+    indentationLevelPadding =
+      FIRST_LEVEL_INDENTATION_WIDTH + INDENTATION_WIDTH * (nestedLevel - 1);
+  }
+  const expandingButtonPlaceholder = !isExpandable
+    ? getExpandingButtonWidth(nestedLevel)
+    : 0;
+
+  return `${indentationLevelPadding + expandingButtonPlaceholder}px`;
+};
 
 const fieldIsDefined = (field, row) => row[field] !== undefined;
 
@@ -130,61 +167,227 @@ const ShimmeringBody: React.FC<ShimmeringBodyProps> = ({
   </tr>
 );
 
-type ExpandingCellProps = {
-  index: number;
-  expandedRows: RowIndex[];
+type ExpandingButtonProps = {
+  rowKey: string;
+  expandedRows: RowKey[];
   rowValues: any;
   onClick: (index) => void;
-  onExpand?: (rowValues: any, index: number) => void;
-  onCollapse?: (rowValues: any, index: number) => void;
+  onExpand?: (rowValues: any, key: string) => void;
+  onCollapse?: (rowValues: any, key: string) => void;
   isSelectedRow: boolean;
+  nestedLevel: number;
 };
-const ExpandingCell: React.FC<ExpandingCellProps> = ({
-  index,
+const ExpandingButton: React.FC<ExpandingButtonProps> = ({
+  rowKey,
   onClick,
   onExpand,
   onCollapse,
   rowValues,
   expandedRows,
   isSelectedRow,
-}: ExpandingCellProps) => {
-  const isExpanded = expandedRows.includes(index);
-  const cellStyling = { width: EXPANDING_CELL_WIDTH };
+  nestedLevel,
+}: ExpandingButtonProps) => {
+  const isExpanded = expandedRows.includes(rowKey);
+  const buttonContainerStyle = {
+    width: `${getExpandingButtonWidth(nestedLevel)}px`,
+  };
 
   return (
-    <td
-      className="ams-table-cell ams-table-expanding-cell"
-      key={`expandingIndex:${index}`}
-      style={cellStyling}
+    <span
+      className="ams-table-expanding-button-container"
+      style={buttonContainerStyle}
     >
       <button
+        key={rowKey}
         type="button"
         className={`btn ams-table-expanding-button ${
-          isSelectedRow && 'is-selected-row'
-        }`}
+          rowValues.isNestedColumn && 'is-nested-column-row'
+        } ${isSelectedRow && 'is-selected-row'}`}
         onClick={() => {
           const newExpandedRows = isExpanded
-            ? expandedRows.filter((i) => i !== index)
-            : [...expandedRows, index];
+            ? expandedRows.filter((k) => k !== rowKey)
+            : [...expandedRows, rowKey];
 
           onClick(newExpandedRows);
 
           if (!isExpanded && onExpand) {
-            onExpand(rowValues, index);
+            onExpand(rowValues, rowKey);
           }
           if (isExpanded && onCollapse) {
-            onCollapse(rowValues, index);
+            onCollapse(rowValues, rowKey);
           }
         }}
       >
         <span className="sr-only">{EXPAND_ROW_TEXT}</span>
         {isExpanded ? <UpIcon /> : <DownIcon />}
       </button>
-    </td>
+    </span>
   );
 };
 
-type RowIndex = number;
+const TableRow: React.FC<TableRowProps> = ({
+  columnKey,
+  currentSelectedKey,
+  columns,
+  rowValues,
+  rowStyles,
+  onExpand,
+  onCollapse,
+  expandRowRef,
+  expandedRows,
+  setExpandedRows,
+  nestedLevel,
+}: TableRowProps) => {
+  const fields = columns.map(({ field }) => field);
+  const expandingButton = (
+    <ExpandingButton
+      rowKey={columnKey}
+      expandedRows={expandedRows}
+      onExpand={onExpand}
+      onCollapse={onCollapse}
+      rowValues={rowValues}
+      onClick={setExpandedRows}
+      isSelectedRow={currentSelectedKey === columnKey}
+      nestedLevel={nestedLevel}
+    />
+  );
+
+  return (
+    <React.Fragment key={columnKey}>
+      <tr
+        className={`ams-table-row ${
+          rowValues.isNestedColumn && 'is-nested-column-row'
+        } ${currentSelectedKey === columnKey && 'is-selected-row'}`}
+        key={columnKey}
+        style={rowStyles}
+        ref={expandRowRef}
+      >
+        <>
+          {Object.entries(rowValues)
+            .filter(([key]) => fields.includes(key))
+            .map(([key, value], rowIndex) => {
+              const columnInfo = columns.find(({ field }) => field === key);
+              const horAlign: TextAlignmentValues = columnInfo
+                ? columnInfo.horAlign || DEFAULT_TEXT_ALIGNMENT
+                : DEFAULT_TEXT_ALIGNMENT;
+              const width =
+                columnInfo && columnInfo.width
+                  ? `${columnInfo.width}px`
+                  : DEFAULT_CELL_WIDTH;
+              // TODO: Improve the typing of this
+              let cellContent: React.ReactNode | typeof value = value;
+              if (columnInfo && columnInfo.component) {
+                cellContent = columnInfo.component(value, rowIndex, rowValues);
+              }
+
+              const isFirstCell =
+                fields.findIndex((field) => field === key) === 0;
+              const hasExpandingButton = isFirstCell && rowValues.isExpandable;
+
+              let cellStyle;
+              if (isFirstCell) {
+                cellStyle = {
+                  width,
+                  paddingLeft: getIndentationPaddingSize(
+                    nestedLevel,
+                    rowValues.isExpandable
+                  ),
+                };
+              } else {
+                cellStyle = { width };
+              }
+
+              return (
+                <td
+                  className={`ams-table-cell ${getCellAlignmentClass(
+                    horAlign
+                  )}`}
+                  key={`index:${rowIndex}`}
+                  style={cellStyle}
+                >
+                  <span
+                    className={`${
+                      isFirstCell && 'ams-table-first-cell-contents'
+                    }`}
+                  >
+                    {hasExpandingButton && expandingButton}
+                    {cellContent}
+                  </span>
+                </td>
+              );
+            })}
+        </>
+      </tr>
+    </React.Fragment>
+  );
+};
+
+type RowKey = string;
+
+const getTableRows = (
+  data,
+  columns,
+  currentSelectedKey,
+  preExpandPanelKey,
+  rowStyles,
+  onExpand,
+  onCollapse,
+  expandRowRef,
+  expandedRows,
+  setExpandedRows,
+  formatChildrenData,
+  preExpandRightPanel,
+  nestedLevel
+) =>
+  data.reduce((prevRows, item) => {
+    if (item.key && item.key === preExpandPanelKey) {
+      preExpandRightPanel(item);
+    }
+
+    const parentRow = (
+      <TableRow
+        key={item.key}
+        columnKey={item.key}
+        currentSelectedKey={currentSelectedKey}
+        columns={columns}
+        rowValues={item}
+        rowStyles={rowStyles}
+        onExpand={onExpand}
+        onCollapse={onCollapse}
+        expandRowRef={
+          item.key && item.key === preExpandPanelKey ? expandRowRef : undefined
+        }
+        expandedRows={expandedRows}
+        setExpandedRows={setExpandedRows}
+        nestedLevel={nestedLevel}
+      />
+    );
+
+    if (item.isExpandable && expandedRows.includes(item.key)) {
+      return [
+        ...prevRows,
+        parentRow,
+        ...getTableRows(
+          item.typeMetadata
+            ? item.typeMetadata.children.map(formatChildrenData)
+            : item.children.map(formatChildrenData),
+          columns,
+          currentSelectedKey,
+          preExpandPanelKey,
+          rowStyles,
+          onExpand,
+          onCollapse,
+          expandRowRef,
+          expandedRows,
+          setExpandedRows,
+          formatChildrenData,
+          preExpandRightPanel,
+          nestedLevel + 1
+        ),
+      ];
+    }
+    return [...prevRows, parentRow];
+  }, []);
 
 const Table: React.FC<TableProps> = ({
   data,
@@ -196,23 +399,44 @@ const Table: React.FC<TableProps> = ({
     isLoading = false,
     numLoadingBlocks = DEFAULT_LOADING_ITEMS,
     rowHeight = DEFAULT_ROW_HEIGHT,
-    expandRow = null,
     emptyMessage,
     onExpand,
     onCollapse,
-    preExpandRow,
+    preExpandPanelKey,
     currentSelectedKey,
+    tableKey,
+    formatChildrenData,
+    preExpandRightPanel,
   } = options;
   const fields = columns.map(({ field }) => field);
   const rowStyles = { height: `${rowHeight}px` };
-  const [expandedRows, setExpandedRows] = React.useState<RowIndex[]>([]);
-  const expandRowRef = React.useRef(null);
+  const expandRowRef = React.useRef<HTMLTableRowElement>(null);
   React.useEffect(() => {
     if (expandRowRef.current !== null) {
-      // @ts-ignore
       expandRowRef.current.scrollIntoView();
     }
   }, []);
+
+  // If the key to preexpand is a nested column, need to add each key level to the expanded row list
+  let keysToExpand: string[] = [];
+  if (preExpandPanelKey) {
+    const columnKeyRegex = tableKey + '\\/(\\w+)';
+    const columnKey = preExpandPanelKey.match(columnKeyRegex);
+    if (columnKey) {
+      keysToExpand = [columnKey[0]];
+    }
+
+    let nextKeyRegex = columnKeyRegex + '\\/type\\/(\\w+)';
+    let nextKey = preExpandPanelKey.match(nextKeyRegex);
+    while (nextKey) {
+      keysToExpand = [...keysToExpand, nextKey[0]];
+      nextKeyRegex += '\\/(\\w+)';
+      nextKey = preExpandPanelKey.match(nextKeyRegex);
+    }
+  }
+  const [expandedRows, setExpandedRows] = React.useState<RowKey[]>(
+    keysToExpand
+  );
 
   let body: React.ReactNode = (
     <EmptyRow
@@ -227,93 +451,25 @@ const Table: React.FC<TableProps> = ({
       throw new Error(INVALID_DATA_ERROR_MESSAGE);
     }
 
-    body = data.map((item, index) => (
-      <React.Fragment key={`index:${index}`}>
-        <tr
-          className={`ams-table-row ${
-            currentSelectedKey === item.key && 'is-selected-row'
-          } ${
-            expandRow && expandedRows.includes(index)
-              ? 'has-child-expanded'
-              : ''
-          }`}
-          key={`index:${index}`}
-          style={rowStyles}
-          ref={index === preExpandRow ? expandRowRef : null}
-        >
-          <>
-            {expandRow &&
-            (item.isExpandable || item.isExpandable === undefined) ? (
-              <ExpandingCell
-                index={index}
-                expandedRows={expandedRows}
-                onExpand={onExpand}
-                onCollapse={onCollapse}
-                rowValues={item}
-                onClick={setExpandedRows}
-                isSelectedRow={currentSelectedKey === item.key}
-              />
-            ) : (
-              <td />
-            )}
-            {Object.entries(item)
-              .filter(([key]) => fields.includes(key))
-              .map(([key, value], rowIndex) => {
-                const columnInfo = columns.find(({ field }) => field === key);
-                const horAlign: TextAlignmentValues = columnInfo
-                  ? columnInfo.horAlign || DEFAULT_TEXT_ALIGNMENT
-                  : DEFAULT_TEXT_ALIGNMENT;
-                const width =
-                  columnInfo && columnInfo.width
-                    ? `${columnInfo.width}px`
-                    : DEFAULT_CELL_WIDTH;
-                const cellStyle = {
-                  width,
-                };
-                // TODO: Improve the typing of this
-                let cellContent: React.ReactNode | typeof value = value;
-                if (columnInfo && columnInfo.component) {
-                  cellContent = columnInfo.component(value, rowIndex, item);
-                }
-
-                return (
-                  <td
-                    className={`ams-table-cell ${getCellAlignmentClass(
-                      horAlign
-                    )}`}
-                    key={`index:${rowIndex}`}
-                    style={cellStyle}
-                  >
-                    {cellContent}
-                  </td>
-                );
-              })}
-          </>
-        </tr>
-        {expandRow ? (
-          <tr
-            className={`ams-table-expanded-row ${
-              expandedRows.includes(index) ? 'is-expanded' : ''
-            }`}
-            key={`expandedIndex:${index}`}
-          >
-            <td className="ams-table-cell">
-              {/* Placeholder for the collapse/expand cell */}
-            </td>
-            <td className="ams-table-cell" colSpan={fields.length + 1}>
-              {expandRow(item, index)}
-            </td>
-          </tr>
-        ) : null}
-      </React.Fragment>
-    ));
+    body = getTableRows(
+      data,
+      columns,
+      currentSelectedKey,
+      preExpandPanelKey,
+      rowStyles,
+      onExpand,
+      onCollapse,
+      expandRowRef,
+      expandedRows,
+      setExpandedRows,
+      formatChildrenData,
+      preExpandRightPanel,
+      0
+    );
   }
 
   let header: React.ReactNode = (
     <tr>
-      {expandRow && (
-        <th key="emptyTableHeading" className="ams-table-heading-cell" />
-      )}
       {columns.map(
         ({ title, horAlign = DEFAULT_TEXT_ALIGNMENT, width = null }, index) => {
           const cellStyle = {

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -14,6 +14,9 @@ $shimmer-block-width: 40%;
 $table-header-bottom-border-color: $gray15;
 $table-header-background-color: $gray5;
 $row-bottom-border-color: $gray10;
+$nested-column-row-color: $gray5;
+$nested-column-bottom-border-color: $gray15;
+$selected-row-color: $gray15;
 
 .ams-table {
   width: 100%;
@@ -66,8 +69,12 @@ $row-bottom-border-color: $gray10;
   border-bottom: 1px solid $row-bottom-border-color;
 
   &.is-empty,
+  &.is-nested-column-row {
+    background-color: $nested-column-row-color;
+    border-bottom: 1px solid $nested-column-bottom-border-color;
+  }
   &.is-selected-row {
-    background-color: $gray10;
+    background-color: $selected-row-color;
   }
   &.has-child-expanded {
     border-bottom: 0;
@@ -104,27 +111,35 @@ $row-bottom-border-color: $gray10;
     padding-right: $spacer-1;
   }
 
-  &:first-child {
-    padding-left: $spacer-3;
-  }
-
   &:last-child {
     padding-right: $spacer-3;
   }
+}
+
+.ams-table-first-cell-contents {
+  display: flex;
+  align-items: center;
+}
+
+.ams-table-expanding-button-container {
+  text-align: center;
 }
 
 .ams-table-expanding-button {
   border: 0;
   padding: 0;
   background-color: white;
-  margin-right: $spacer-2;
 
   svg {
     vertical-align: bottom;
   }
 
+  &.is-nested-column-row {
+    background-color: $nested-column-row-color;
+  }
+
   &.is-selected-row {
-    background-color: $gray10;
+    background-color: $selected-row-color;
   }
 
   &:hover svg use {

--- a/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
@@ -62,9 +62,24 @@ function TestDataBuilder(config = {}) {
   this.withWrongData = () => {
     const attr = {
       data: [
-        { name: 'rowName', type: 'rowType', value: 1 },
-        { name: 'rowName2', type: 'rowType2', value: 2 },
-        { name: 'rowName3', type: 'rowType3', value: 3 },
+        {
+          name: 'rowName',
+          type: 'rowType',
+          value: 1,
+          key: 'database://cluster.schema/table/rowName',
+        },
+        {
+          name: 'rowName2',
+          type: 'rowType2',
+          value: 2,
+          key: 'database://cluster.schema/table/rowName2',
+        },
+        {
+          name: 'rowName3',
+          type: 'rowType3',
+          value: 3,
+          key: 'database://cluster.schema/table/rowName3',
+        },
       ],
       columns: [
         {
@@ -93,7 +108,13 @@ function TestDataBuilder(config = {}) {
     const attr = {
       data: [
         ...this.config.data,
-        { name: 'usageRow', type: 'usageRowType', value: 4, usage: 44 },
+        {
+          name: 'usageRow',
+          type: 'usageRowType',
+          value: 4,
+          key: 'database://cluster.schema/table/usageRow',
+          usage: 44,
+        },
       ],
       columns: [...this.config.columns, { title: 'Usage', field: 'usage' }],
     };
@@ -104,9 +125,91 @@ function TestDataBuilder(config = {}) {
   this.withCollapsedRow = () => {
     const attr = {
       data: [
-        { name: 'rowName', type: 'rowType', value: 1 },
-        { name: 'rowName2', type: 'rowType2', value: 2 },
-        { name: 'rowName3', type: 'rowType3', value: 3 },
+        {
+          name: 'rowName',
+          type: 'rowType',
+          value: 1,
+          key: 'database://cluster.schema/table/rowName',
+          isExpandable: true,
+          typeMetadata: {
+            kind: 'struct',
+            name: 'rowName',
+            key: 'database://cluster.schema/table/rowName/type/rowName',
+            description: 'description',
+            data_type: 'struct<col1:int,col2:string>',
+            sort_order: 0,
+            children: [
+              {
+                kind: 'scalar',
+                name: 'col1',
+                key:
+                  'database://cluster.schema/table/rowName/type/rowName/col1',
+                description: 'description',
+                data_type: 'int',
+                sort_order: 0,
+              },
+              {
+                kind: 'scalar',
+                name: 'col2',
+                key:
+                  'database://cluster.schema/table/rowName/type/rowName/col2',
+                description: 'description',
+                data_type: 'string',
+                sort_order: 1,
+              },
+            ],
+          },
+        },
+        {
+          name: 'rowName2',
+          type: 'rowType2',
+          value: 2,
+          key: 'database://cluster.schema/table/rowName2',
+          isExpandable: true,
+          typeMetadata: {
+            kind: 'struct',
+            name: 'rowName2',
+            key: 'database://cluster.schema/table/rowName2/type/rowName2',
+            description: 'description',
+            data_type: 'struct<col3:int,col4:string>',
+            sort_order: 0,
+            children: [
+              {
+                kind: 'scalar',
+                name: 'col3',
+                key:
+                  'database://cluster.schema/table/rowName2/type/rowName2/col3',
+                description: 'description',
+                data_type: 'int',
+                sort_order: 0,
+              },
+              {
+                kind: 'scalar',
+                name: 'col4',
+                key:
+                  'database://cluster.schema/table/rowName2/type/rowName2/col4',
+                description: 'description',
+                data_type: 'string',
+                sort_order: 1,
+              },
+            ],
+          },
+        },
+        {
+          name: 'rowName3',
+          type: 'rowType3',
+          value: 3,
+          key: 'database://cluster.schema/table/rowName3',
+          isExpandable: false,
+          typeMetadata: {
+            kind: 'scalar',
+            name: 'rowName3',
+            key: 'database://cluster.schema/table/rowName3/type/rowName3',
+            description: 'description',
+            data_type: 'string',
+            sort_order: 0,
+          },
+        },
       ],
       columns: [
         {
@@ -149,9 +252,24 @@ function TestDataBuilder(config = {}) {
   this.withActionCell = () => {
     const attr = {
       data: [
-        { name: 'rowName', type: 'rowType', value: 'Action Text' },
-        { name: 'rowName2', type: 'rowType2', value: 'Action Text' },
-        { name: 'rowName3', type: 'rowType3', value: 'Action Text' },
+        {
+          name: 'rowName',
+          type: 'rowType',
+          value: 'Action Text',
+          key: 'database://cluster.schema/table/rowName',
+        },
+        {
+          name: 'rowName2',
+          type: 'rowType2',
+          value: 'Action Text',
+          key: 'database://cluster.schema/table/rowName2',
+        },
+        {
+          name: 'rowName3',
+          type: 'rowType3',
+          value: 'Action Text',
+          key: 'database://cluster.schema/table/rowName3',
+        },
       ],
       columns: [
         {
@@ -192,9 +310,24 @@ function TestDataBuilder(config = {}) {
   this.withMultipleComponentsColumn = () => {
     const attr = {
       data: [
-        { name: 'rowName', type: 'rowType', value: [1] },
-        { name: 'rowName2', type: 'rowType2', value: [2, 3] },
-        { name: 'rowName3', type: 'rowType3', value: [4, 5, 6] },
+        {
+          name: 'rowName',
+          type: 'rowType',
+          value: [1],
+          key: 'database://cluster.schema/table/rowName',
+        },
+        {
+          name: 'rowName2',
+          type: 'rowType2',
+          value: [2, 3],
+          key: 'database://cluster.schema/table/rowName2',
+        },
+        {
+          name: 'rowName3',
+          type: 'rowType3',
+          value: [4, 5, 6],
+          key: 'database://cluster.schema/table/rowName3',
+        },
       ],
       columns: [
         {
@@ -245,9 +378,27 @@ function TestDataBuilder(config = {}) {
   this.withFourColumns = () => {
     const attr = {
       data: [
-        { name: 'rowName', type: 'rowType', value: 1, usage: 4 },
-        { name: 'rowName2', type: 'rowType2', value: 2, usage: 12 },
-        { name: 'rowName3', type: 'rowType3', value: 3, usage: 7 },
+        {
+          name: 'rowName',
+          type: 'rowType',
+          value: 1,
+          key: 'database://cluster.schema/table/rowName',
+          usage: 4,
+        },
+        {
+          name: 'rowName2',
+          type: 'rowType2',
+          value: 2,
+          key: 'database://cluster.schema/table/rowName2',
+          usage: 12,
+        },
+        {
+          name: 'rowName3',
+          type: 'rowType3',
+          value: 3,
+          key: 'database://cluster.schema/table/rowName3',
+          usage: 7,
+        },
       ],
       columns: [
         {
@@ -320,6 +471,7 @@ function TestDataBuilder(config = {}) {
           name: 'extraName',
           type: 'extraRowType',
           value: 4,
+          key: 'database://cluster.schema/table/extraName',
           usage: 44,
           extraValue: 3,
         },

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -28,6 +28,7 @@ const mockColumnDetails = {
       stat_val: '111',
     },
   ],
+  children: [],
   action: { name: 'column_name', isActionEnabled: true },
   editText: 'Click to edit description in the data source site',
   editUrl: 'https://test.datasource.site/table',

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -49,6 +49,14 @@ const mockColumnDetails = {
       category: 'column',
     },
   ],
+  typeMetadata: {
+    kind: 'scalar',
+    name: 'column_name',
+    key: 'database://cluster.schema/table/column_name/type/column_name',
+    description: 'description',
+    data_type: 'string',
+    sort_order: 0,
+  },
 };
 
 Object.defineProperty(navigator, 'clipboard', {

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -8,10 +8,10 @@ import ColumnDescEditableText from 'features/ColumnList/ColumnDescEditableText';
 import ColumnLineage from 'features/ColumnList/ColumnLineage';
 import ColumnStats from 'features/ColumnList/ColumnStats';
 import ExpandableUniqueValues from 'features/ExpandableUniqueValues';
+import { FormattedDataType } from 'interfaces/ColumnList';
 import { getMaxLength, isColumnListLineageEnabled } from 'config/config-utils';
 import { buildTableKey, getColumnLink } from 'utils/navigationUtils';
 import { filterOutUniqueValues, getUniqueValues } from 'utils/stats';
-import { FormattedDataType } from '..';
 import {
   COPY_COL_LINK_LABEL,
   COPY_COL_NAME_LABEL,
@@ -21,10 +21,7 @@ import {
 
 export interface ColumnDetailsPanelProps {
   columnDetails: FormattedDataType;
-  togglePanel: (
-    columnDetails: FormattedDataType | undefined,
-    event: any
-  ) => void;
+  togglePanel: (columnDetails: FormattedDataType | undefined) => void;
 }
 
 const shouldRenderDescription = (columnDetails: FormattedDataType) => {
@@ -57,8 +54,8 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
   const normalStats = stats && filterOutUniqueValues(stats);
   const uniqueValueStats = stats && getUniqueValues(stats);
 
-  const handleCloseButtonClick = (e) => {
-    togglePanel(undefined, e);
+  const handleCloseButtonClick = () => {
+    togglePanel(undefined);
   };
 
   const handleCopyNameClick = () => {

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -9,7 +9,7 @@ import ColumnLineage from 'features/ColumnList/ColumnLineage';
 import ColumnStats from 'features/ColumnList/ColumnStats';
 import ExpandableUniqueValues from 'features/ExpandableUniqueValues';
 import { getMaxLength, isColumnListLineageEnabled } from 'config/config-utils';
-import { getColumnLink } from 'utils/navigationUtils';
+import { buildTableKey, getColumnLink } from 'utils/navigationUtils';
 import { filterOutUniqueValues, getUniqueValues } from 'utils/stats';
 import { FormattedDataType } from '..';
 import {
@@ -47,6 +47,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
     stats,
     editText,
     editUrl,
+    key,
     name,
     tableParams,
     isEditable,
@@ -65,7 +66,9 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
   };
 
   const handleCopyLinkClick = () => {
-    navigator.clipboard.writeText(getColumnLink(tableParams, name));
+    const tableKey = buildTableKey(tableParams);
+    const columnNamePath = key.replace(tableKey + '/', '');
+    navigator.clipboard.writeText(getColumnLink(tableParams, columnNamePath));
   };
 
   return (

--- a/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
@@ -9,6 +9,7 @@ $description-max-width-med: 450px;
 $description-max-width-small: 300px;
 $nested-arrow-spacer: 24px;
 $nested-arrow-spacer-max: $nested-arrow-spacer * 4;
+$nested-column-row-color: $gray5;
 
 .column-list {
   margin: 0;
@@ -38,6 +39,10 @@ $nested-arrow-spacer-max: $nested-arrow-spacer * 4;
       height: 32px;
       padding: 4px;
       width: 32px;
+
+      &.is-nested-column-row {
+        background-color: $nested-column-row-color;
+      }
 
       .icon {
         background-color: $icon-bg;

--- a/frontend/amundsen_application/static/js/features/ColumnList/testDataBuilder.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/testDataBuilder.ts
@@ -7,6 +7,7 @@ const defaultConfig = {
       col_type: 'string',
       description: null,
       is_editable: true,
+      key: 'database://cluster.schema/table/simple_column_name_string',
       name: 'simple_column_name_string',
       sort_order: 0,
       stats: [
@@ -22,6 +23,7 @@ const defaultConfig = {
       col_type: 'int',
       description: null,
       is_editable: true,
+      key: 'database://cluster.schema/table/simple_column_name_int',
       name: 'simple_column_name_int',
       sort_order: 1,
       stats: [
@@ -37,6 +39,7 @@ const defaultConfig = {
       col_type: 'bigint',
       description: null,
       is_editable: true,
+      key: 'database://cluster.schema/table/simple_column_name_bigint',
       name: 'simple_column_name_bigint',
       sort_order: 2,
       stats: [
@@ -52,6 +55,7 @@ const defaultConfig = {
       col_type: 'timestamp',
       description: null,
       is_editable: true,
+      key: 'database://cluster.schema/table/simple_column_name_timestamp',
       name: 'simple_column_name_timestamp',
       sort_order: 3,
       stats: [
@@ -88,6 +92,7 @@ function TestDataBuilder(config = {}) {
             'struct<trigger_event:string,backfill:boolean,graphql_version:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_2',
           name: 'complex_column_name_2',
           sort_order: 0,
           stats: [
@@ -103,6 +108,7 @@ function TestDataBuilder(config = {}) {
           col_type: 'struct<code:string,timezone:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_3',
           name: 'complex_column_name_3',
           sort_order: 1,
           stats: [
@@ -119,6 +125,7 @@ function TestDataBuilder(config = {}) {
             'struct<route_id:string,shift:struct<shift_id:string,started_at:timestamp,ended_at:timestamp>>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_4',
           name: 'complex_column_name_4',
           sort_order: 2,
           stats: [
@@ -144,6 +151,7 @@ function TestDataBuilder(config = {}) {
             'struct<event_id:string,occurred_at:timestamp,sample_rate:double,__metadata__:struct<flattened:boolean,sending_service:string,streamcheck_selected_at:timestamp,is_priority:boolean,ingest_library_version:string,requires_field_values_as_strings:boolean,aic_time:bigint,fanner_time:bigint,send_to_realtime:boolean,origin_service:string,complex_persistence:boolean>,__debug_metadata__:struct<__is_empty_struct_set__:boolean>,enrichments:struct<is_simulated_ride:boolean>,logged_at:timestamp,source_pipeline:string,reporter_ip_address:string,reporter_hostname:string,http_request_id:string,event_name:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_1',
           name: 'complex_column_name_1',
           sort_order: 0,
           stats: [],
@@ -153,6 +161,7 @@ function TestDataBuilder(config = {}) {
             'struct<platform:string,device:string,app_name:string,app_version:string,platform_version:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_2',
           name: 'complex_column_name_2',
           sort_order: 1,
           stats: [],
@@ -171,6 +180,7 @@ function TestDataBuilder(config = {}) {
             'struct<event_id:string,occurred_at:timestamp,sample_rate:double,__metadata__:struct<flattened:boolean,sending_service:string,streamcheck_selected_at:timestamp,is_priority:boolean,ingest_library_version:string,requires_field_values_as_strings:boolean,aic_time:bigint,fanner_time:bigint,send_to_realtime:boolean,origin_service:string,complex_persistence:boolean>,__debug_metadata__:struct<__is_empty_struct_set__:boolean>,enrichments:struct<is_simulated_ride:boolean>,logged_at:timestamp,source_pipeline:string,reporter_ip_address:string,reporter_hostname:string,http_request_id:string,event_name:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_1',
           name: 'complex_column_name_1',
           sort_order: 0,
           stats: [],
@@ -180,6 +190,7 @@ function TestDataBuilder(config = {}) {
             'struct<platform:string,device:string,app_name:string,app_version:string,platform_version:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_2',
           name: 'complex_column_name_2',
           sort_order: 1,
           stats: [],
@@ -189,6 +200,7 @@ function TestDataBuilder(config = {}) {
             'struct<platform:string,device:string,app_name:string,app_version:string,platform_version:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_3',
           name: 'complex_column_name_3',
           sort_order: 2,
           stats: [
@@ -214,6 +226,7 @@ function TestDataBuilder(config = {}) {
             'struct<trigger_event:string,backfill:boolean,graphql_version:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_2',
           name: 'complex_column_name_2',
           sort_order: 0,
           stats: [
@@ -229,6 +242,7 @@ function TestDataBuilder(config = {}) {
           col_type: 'struct<code:string,timezone:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_3',
           name: 'complex_column_name_3',
           sort_order: 1,
           stats: [
@@ -251,6 +265,7 @@ function TestDataBuilder(config = {}) {
             'struct<route_id:string,shift:struct<shift_id:string,started_at:timestamp,ended_at:timestamp>>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_4',
           name: 'complex_column_name_4',
           sort_order: 2,
           stats: [
@@ -276,6 +291,7 @@ function TestDataBuilder(config = {}) {
             'struct<trigger_event:string,backfill:boolean,graphql_version:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_2',
           name: 'complex_column_name_2',
           sort_order: 0,
           stats: [
@@ -292,6 +308,7 @@ function TestDataBuilder(config = {}) {
           col_type: 'struct<code:string,timezone:string>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_3',
           name: 'complex_column_name_3',
           sort_order: 1,
           stats: [
@@ -320,6 +337,7 @@ function TestDataBuilder(config = {}) {
             'struct<route_id:string,shift:struct<shift_id:string,started_at:timestamp,ended_at:timestamp>>',
           description: null,
           is_editable: true,
+          key: 'database://cluster.schema/table/complex_column_name_4',
           name: 'complex_column_name_4',
           sort_order: 2,
           stats: [

--- a/frontend/amundsen_application/static/js/interfaces/ColumnList.ts
+++ b/frontend/amundsen_application/static/js/interfaces/ColumnList.ts
@@ -1,0 +1,48 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  TableColumn,
+  TableColumnStats,
+  TypeMetadata,
+} from 'interfaces/TableMetadata';
+import { Badge } from 'interfaces/Badges';
+import { TablePageParams } from '../utils/navigationUtils';
+
+export type ContentType = {
+  title: string;
+  description: string;
+  nestedLevel?: number;
+  hasStats: boolean;
+};
+
+type DatatypeType = {
+  name: string;
+  database: string;
+  type: string;
+};
+
+type ActionType = {
+  isActionEnabled: boolean;
+};
+
+export type FormattedDataType = {
+  content: ContentType;
+  type: DatatypeType;
+  usage: number | null;
+  stats: TableColumnStats[] | null;
+  children: TableColumn[];
+  action: ActionType;
+  editText: string | null;
+  editUrl: string | null;
+  index: number;
+  key: string;
+  name: string;
+  tableParams: TablePageParams;
+  sort_order: number;
+  isEditable: boolean;
+  isExpandable: boolean;
+  badges: Badge[];
+  typeMetadata?: TypeMetadata;
+  isNestedColumn?: boolean;
+};

--- a/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -68,7 +68,7 @@ export interface TypeMetadata {
   key: string;
   description: string;
   data_type: string;
-  sort_order: string;
+  sort_order: number;
   badges?: Badge[];
   children?: TypeMetadata[];
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -53,6 +53,14 @@ const mockColumnDetails = {
       category: 'column',
     },
   ],
+  typeMetadata: {
+    kind: 'scalar',
+    name: 'column_name',
+    key: 'database://cluster.schema/table/column_name/type/column_name',
+    description: 'description',
+    data_type: 'string',
+    sort_order: 0,
+  },
 };
 
 const setup = (
@@ -191,7 +199,7 @@ describe('TableDetail', () => {
         setStateSpy.mockClear();
         const { props, wrapper } = setup();
         wrapper.setState({ isRightPanelOpen: false });
-        wrapper.instance().toggleRightPanel(mockColumnDetails, null);
+        wrapper.instance().toggleRightPanel(mockColumnDetails);
 
         expect(props.getColumnLineageDispatch).toHaveBeenCalled();
         expect(setStateSpy).toHaveBeenCalledWith({
@@ -207,7 +215,7 @@ describe('TableDetail', () => {
         setStateSpy.mockClear();
         const { wrapper } = setup();
         wrapper.setState({ isRightPanelOpen: true });
-        wrapper.instance().toggleRightPanel(undefined, null);
+        wrapper.instance().toggleRightPanel(undefined);
 
         expect(setStateSpy).toHaveBeenCalledWith({
           isRightPanelOpen: false,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -32,6 +32,7 @@ const mockColumnDetails = {
       stat_val: '111',
     },
   ],
+  children: [],
   action: { name: 'column_name', isActionEnabled: true },
   editText: 'Click to edit description in the data source site',
   editUrl: 'https://test.datasource.site/table',

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -262,11 +262,17 @@ export class TableDetail extends React.Component<
     const { isRightPanelPreExpanded } = this.state;
     const { getColumnLineageDispatch } = this.props;
 
+    if (isRightPanelPreExpanded) {
+      return;
+    }
+
     let key = '';
     if (columnDetails) {
-      const { name, tableParams } = columnDetails;
       ({ key } = columnDetails);
-      getColumnLineageDispatch(buildTableKey(tableParams), name);
+      if (!columnDetails.isNestedColumn) {
+        const { name, tableParams } = columnDetails;
+        getColumnLineageDispatch(buildTableKey(tableParams), name);
+      }
     }
 
     if (!isRightPanelPreExpanded && key) {
@@ -279,26 +285,36 @@ export class TableDetail extends React.Component<
     }
   };
 
-  toggleRightPanel = (
-    newColumnDetails: FormattedDataType | undefined,
-    event
-  ) => {
+  toggleRightPanel = (newColumnDetails: FormattedDataType | undefined) => {
     const { isRightPanelOpen, selectedColumnKey } = this.state;
     const { getColumnLineageDispatch } = this.props;
 
-    if (event) {
-      logClick(event);
-    }
-
     let key = '';
     if (newColumnDetails) {
-      const { name, tableParams } = newColumnDetails;
       ({ key } = newColumnDetails);
-      getColumnLineageDispatch(buildTableKey(tableParams), name);
     }
 
     const shouldPanelOpen =
       (key && key !== selectedColumnKey) || !isRightPanelOpen;
+
+    if (
+      shouldPanelOpen &&
+      newColumnDetails &&
+      !newColumnDetails.isNestedColumn
+    ) {
+      const { name, tableParams } = newColumnDetails;
+      getColumnLineageDispatch(buildTableKey(tableParams), name);
+    }
+
+    if (newColumnDetails && shouldPanelOpen) {
+      logAction({
+        command: 'click',
+        label: `${newColumnDetails.key} ${newColumnDetails.type.type}`,
+        target_id: `column::${newColumnDetails.key}`,
+        target_type: 'column stats',
+      });
+    }
+
     this.setState({
       isRightPanelOpen: shouldPanelOpen,
       selectedColumnKey: shouldPanelOpen ? key : '',
@@ -340,7 +356,9 @@ export class TableDetail extends React.Component<
           editText={editText}
           editUrl={editUrl}
           sortBy={sortedBy}
-          columnToPreExpand={selectedColumn}
+          preExpandPanelKey={
+            selectedColumn ? tableData.key + '/' + selectedColumn : undefined
+          }
           preExpandRightPanel={this.preExpandRightPanel}
           hideSomeColumnMetadata={isRightPanelOpen}
           toggleRightPanel={this.toggleRightPanel}

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -35,7 +35,7 @@ import {
 } from 'config/config-utils';
 
 import BadgeList from 'features/BadgeList';
-import ColumnList, { FormattedDataType } from 'features/ColumnList';
+import ColumnList from 'features/ColumnList';
 import ColumnDetailsPanel from 'features/ColumnList/ColumnDetailsPanel';
 
 import Alert from 'components/Alert';
@@ -67,6 +67,7 @@ import {
   Lineage,
   TableApp,
 } from 'interfaces';
+import { FormattedDataType } from 'interfaces/ColumnList';
 
 import DataPreviewButton from './DataPreviewButton';
 import ExploreButton from './ExploreButton';


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

These changes repurpose the column dropdown functionality to display nested columns rather than column details. Clicking on the column names will display the details instead of the dropdown (see https://github.com/amundsen-io/amundsen/pull/1831).

This dropdown usage will only be available to those using `TypeMetadata` on the backend, where the complex types are parsed in databuilder and stored in the db. For all others, the existing frontend parsing/display behavior for nested columns has been preserved. All users regardless of `TypeMetadata` usage will no longer be able to view column details through the dropdown.

Please note that in this specific PR the changes described here have been disabled. Once the changes reach parity with the existing frontend parsing behavior, it will be enabled.

With new changes, once enabled:
![Screen Shot 2022-05-17 at 5 49 15 PM](https://user-images.githubusercontent.com/6732445/169106878-b89c6f35-b6d2-427c-93dc-1ebac17bd471.png)

Current view for all, and for those not using `TypeMetadata`:
![Screen Shot 2022-05-18 at 10 35 00 AM](https://user-images.githubusercontent.com/6732445/169106974-4c1d6dc5-7113-4fa1-a114-290a9f6368cc.png)

### Tests

New tests added to test the new dropdown functionality. Also, navigating to a column link for nested columns is being tested as well, since each intermediate column between the top level and the one being navigated to must be preexpanded.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
