### PR TITLE
fix: Handle qualified tableau datasources more gracefully

### DIFF
--- a/databuilder/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
+++ b/databuilder/databuilder/extractor/dashboard/tableau/tableau_dashboard_table_extractor.py
@@ -69,7 +69,12 @@ class TableauGraphQLDashboardTableExtractor(TableauGraphQLApiExtractor):
                     # and set the "schema" value to "wrong_schema". In every case discovered so far, the schema
                     # key is incorrect, so the "inner" schema from the table name is used instead.
                     if '.' in table['name']:
-                        schema, name = table['name'].split('.')
+                        parts = table['name'].split('.')
+                        if len(parts) == 2:
+                            schema, name = parts
+                        else:
+                            database = '.'.join(parts[:-2])
+                            schema, name = parts[-2:]
                     else:
                         schema, name = table['schema'], table['name']
                     schema = TableauDashboardUtils.sanitize_schema_name(schema)


### PR DESCRIPTION
### Summary of Changes

When unpacking tableau datasources, if a table reference had more than two parts (i.e. `database.schema.table` rather than just `table` or `schema.table`) this would raise a `KeyError` during unpacking and the script would stop abruptly.

This fix adds handling code for greater degrees of qualification and also a graceful path for dbapis which have potentially very long qualification options (e.g. `foo.bar.baz.db.schema.table`). I haven't accounted for anything more specific that _something that will work_ for now, although that would be something that could be built on at a later date. This solution solves for the most common use case where the database may be qualified in the table reference.

### Tests

No tests added as I don't believe there is an existing test which could be extended to cover this case. I'm still new to the codebase to any pointers on a sensible test to add would be excellent and I'm happy to implement one.

### Documentation

No documentation added - I believe this should be the expected behaviour.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
