### PR TITLE
feat: Nested columns special type rows and expand by default

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -467,11 +467,9 @@ exports[`eslint`] = {
     "js/features/ColumnList/ColumnStats/columnStats.story.tsx:2552692472": [
       [9, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
     ],
-    "js/features/ColumnList/ColumnType/index.tsx:2472856984": [
-      [34, 2, 30, "nestedType should be placed after constructor", "1117758211"],
-      [105, 6, 36, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3801508926"],
-      [105, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"],
-      [123, 16, 20, "Must use destructuring state assignment", "2976153148"]
+    "js/features/ColumnList/ColumnType/index.tsx:1333623377": [
+      [106, 6, 36, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3801508926"],
+      [106, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"]
     ],
     "js/features/ColumnList/ColumnType/parser.ts:4274243564": [
       [58, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -65,22 +65,22 @@ exports[`eslint`] = {
       [118, 19, 20, "Must use destructuring state assignment", "3067028466"],
       [126, 10, 137, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3965651236"]
     ],
-    "js/components/EditableText/index.tsx:2818784014": [
-      [50, 2, 21, "textAreaRef should be placed after componentDidUpdate", "3072052035"],
-      [71, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [79, 10, 25, "Must use destructuring props assignment", "793704523"],
-      [80, 8, 25, "Must use destructuring props assignment", "793704523"],
-      [82, 32, 16, "Must use destructuring state assignment", "3998965439"],
-      [82, 53, 21, "Must use destructuring state assignment", "1159122654"],
-      [84, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [89, 4, 22, "Must use destructuring props assignment", "2225424112"],
-      [93, 4, 22, "Must use destructuring props assignment", "2225424112"],
-      [97, 27, 23, "Must use destructuring props assignment", "2982501243"],
-      [100, 23, 23, "Must use destructuring props assignment", "2982501243"],
-      [108, 6, 22, "Must use destructuring props assignment", "2225424112"],
-      [115, 4, 24, "Must use destructuring props assignment", "3049746099"],
-      [131, 19, 20, "Script URL is a form of eval.", "3373049033"],
-      [143, 8, 207, "A control must be associated with a text label.", "2914986446"]
+    "js/components/EditableText/index.tsx:2168483193": [
+      [51, 2, 21, "textAreaRef should be placed after componentDidUpdate", "3072052035"],
+      [72, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
+      [80, 10, 25, "Must use destructuring props assignment", "793704523"],
+      [81, 8, 25, "Must use destructuring props assignment", "793704523"],
+      [83, 32, 16, "Must use destructuring state assignment", "3998965439"],
+      [83, 53, 21, "Must use destructuring state assignment", "1159122654"],
+      [85, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
+      [90, 4, 22, "Must use destructuring props assignment", "2225424112"],
+      [94, 4, 22, "Must use destructuring props assignment", "2225424112"],
+      [98, 27, 23, "Must use destructuring props assignment", "2982501243"],
+      [101, 23, 23, "Must use destructuring props assignment", "2982501243"],
+      [109, 6, 22, "Must use destructuring props assignment", "2225424112"],
+      [116, 4, 24, "Must use destructuring props assignment", "3049746099"],
+      [134, 19, 20, "Script URL is a form of eval.", "3373049033"],
+      [146, 8, 207, "A control must be associated with a text label.", "2914986446"]
     ],
     "js/components/EntityCard/EntityCardSection/index.tsx:474926744": [
       [25, 2, 55, "editButton should be placed after constructor", "2479426463"],
@@ -679,7 +679,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:1654932239": [
+    "js/pages/TableDetailPage/index.tsx:953038643": [
       [160, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [206, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/css/_typography-default.scss
+++ b/frontend/amundsen_application/static/css/_typography-default.scss
@@ -365,6 +365,12 @@ body {
   color: $column-name-color;
 }
 
+.column-type-label {
+  @extend %text-title-w3;
+
+  color: $text-primary;
+}
+
 .resource-type {
   @extend %text-subtitle-w3;
 

--- a/frontend/amundsen_application/static/js/components/Table/constants.ts
+++ b/frontend/amundsen_application/static/js/components/Table/constants.ts
@@ -3,3 +3,17 @@
 
 export const COLUMN_NAME_REGEX = '\\/(\\w+)'; // '/' followed by one or more word characters
 export const TYPE_METADATA_REGEX = '\\/type\\/(\\w+)'; // '/type/' followed by one or more word characters
+
+export const ARRAY_KIND = 'array';
+export const MAP_KIND = 'map';
+export const MAP_KEY_NAME = '_map_key';
+export const MAP_VALUE_NAME = '_map_value';
+export const MAP_KEY_DISPLAY_NAME = 'map key';
+export const MAP_VALUE_DISPLAY_NAME = 'map value';
+
+export const ARRAY_LABEL = 'array';
+export const ARRAY_OPENER = ' [';
+export const ARRAY_CLOSER = '] ';
+export const MAP_LABEL = 'map';
+export const MAP_OPENER = ' {';
+export const MAP_CLOSER = '} ';

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -20,6 +20,7 @@ jest.mock('config/config-utils', () => {
 });
 const formatChildrenDataMock = jest.fn().mockImplementation((rowValue) => ({
   key: rowValue.key,
+  name: rowValue.name,
   isExpandable: rowValue.isExpandable,
   kind: rowValue.kind,
   children: rowValue.children,

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 
 import { FormattedDataType } from 'interfaces/ColumnList';
-import { getMaxNestedColumns } from 'config/config-utils';
 
 import ShimmeringResourceLoader from '../ShimmeringResourceLoader';
 import { UpIcon, DownIcon } from '../SVGIcons';
@@ -76,6 +75,8 @@ export interface TableOptions {
   formatChildrenData?: (item: any, index: number) => FormattedDataType;
   /** Function used to pre expand the right panel with the designated details */
   preExpandRightPanel?: (columnDetails: FormattedDataType) => void;
+  /** Expand all child rows by default if the total number of rows does not exceed this value */
+  maxNumRows?: number;
 }
 
 export interface TableProps {
@@ -190,6 +191,7 @@ const updateMapDisplayNames = (childrenData) =>
 
     return { ...child, content: { ...child.content, title: displayName } };
   });
+
 const getAllColumnKeys = (columns) =>
   columns.reduce((prevKeys, col: FormattedDataType) => {
     let childKeys = [];
@@ -226,10 +228,15 @@ const getKeysToExpand = (preExpandPanelKey, tableKey) => {
   return keysToExpand;
 };
 
-const getInitialExpandedRows = (data, preExpandPanelKey, tableKey) => {
+const getInitialExpandedRows = (
+  data,
+  maxNumRows,
+  preExpandPanelKey,
+  tableKey
+) => {
   const allColumnKeys = getAllColumnKeys(data);
 
-  return allColumnKeys.length <= getMaxNestedColumns()
+  return allColumnKeys.length <= maxNumRows
     ? allColumnKeys
     : getKeysToExpand(preExpandPanelKey, tableKey);
 };
@@ -665,12 +672,13 @@ const Table: React.FC<TableProps> = ({
     tableKey,
     formatChildrenData,
     preExpandRightPanel,
+    maxNumRows,
   } = options;
   const fields = columns.map(({ field }) => field);
   const rowStyles = { height: `${rowHeight}px` };
 
   const [expandedRows, setExpandedRows] = React.useState<RowKey[]>(
-    getInitialExpandedRows(data, preExpandPanelKey, tableKey)
+    getInitialExpandedRows(data, maxNumRows, preExpandPanelKey, tableKey)
   );
   const expandRowRef = React.useRef<HTMLTableRowElement>(null);
   React.useEffect(() => {

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -73,9 +73,15 @@ $selected-row-color: $gray15;
     background-color: $nested-column-row-color;
     border-bottom: 1px solid $nested-column-bottom-border-color;
   }
+
+  &.is-specific-type-row {
+    height: 25px;
+  }
+
   &.is-selected-row {
     background-color: $selected-row-color;
   }
+
   &.has-child-expanded {
     border-bottom: 0;
   }

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -7,6 +7,7 @@
 
 $table-header-height: 33px;
 $table-header-border-width: 2px;
+$specific-type-row-height: 25px;
 
 $shimmer-block-height: 16px;
 $shimmer-block-width: 40%;
@@ -75,7 +76,7 @@ $selected-row-color: $gray15;
   }
 
   &.is-specific-type-row {
-    height: 25px;
+    height: $specific-type-row-height;
   }
 
   &.is-selected-row {

--- a/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/testDataBuilder.tsx
@@ -132,30 +132,67 @@ function TestDataBuilder(config = {}) {
           key: 'database://cluster.schema/table/rowName',
           isExpandable: true,
           typeMetadata: {
-            kind: 'struct',
+            kind: 'array',
             name: 'rowName',
             key: 'database://cluster.schema/table/rowName/type/rowName',
+            isExpandable: true,
             description: 'description',
-            data_type: 'struct<col1:int,col2:string>',
+            data_type: 'array<struct<col1:array<int>,col2:map<string,string>>>',
             sort_order: 0,
             children: [
               {
-                kind: 'scalar',
-                name: 'col1',
+                kind: 'struct',
+                name: '_inner_',
                 key:
-                  'database://cluster.schema/table/rowName/type/rowName/col1',
+                  'database://cluster.schema/table/rowName/type/rowName/_inner_',
+                isExpandable: true,
                 description: 'description',
-                data_type: 'int',
+                data_type: 'struct<col1:array<int>,col2:map<string,string>>',
                 sort_order: 0,
-              },
-              {
-                kind: 'scalar',
-                name: 'col2',
-                key:
-                  'database://cluster.schema/table/rowName/type/rowName/col2',
-                description: 'description',
-                data_type: 'string',
-                sort_order: 1,
+                children: [
+                  {
+                    kind: 'array',
+                    name: 'col1',
+                    key:
+                      'database://cluster.schema/table/rowName/type/rowName/_inner_/col1',
+                    isExpandable: false,
+                    description: 'description',
+                    data_type: 'array<int>',
+                    sort_order: 0,
+                  },
+                  {
+                    kind: 'map',
+                    name: 'col2',
+                    key:
+                      'database://cluster.schema/table/rowName/type/rowName/_inner_/col2',
+                    isExpandable: true,
+                    description: 'description',
+                    data_type: 'map<string,string>',
+                    sort_order: 1,
+                    children: [
+                      {
+                        kind: 'scalar',
+                        name: '_map_key',
+                        key:
+                          'database://cluster.schema/table/rowName/type/rowName/_inner_/col2/_map_key',
+                        isExpandable: false,
+                        description: 'description',
+                        data_type: 'string',
+                        sort_order: 0,
+                      },
+                      {
+                        kind: 'scalar',
+                        name: '_map_value',
+                        key:
+                          'database://cluster.schema/table/rowName/type/rowName/_inner_/col2/_map_value',
+                        isExpandable: false,
+                        description: 'description',
+                        data_type: 'string',
+                        sort_order: 1,
+                      },
+                    ],
+                  },
+                ],
               },
             ],
           },
@@ -170,8 +207,9 @@ function TestDataBuilder(config = {}) {
             kind: 'struct',
             name: 'rowName2',
             key: 'database://cluster.schema/table/rowName2/type/rowName2',
+            isExpandable: true,
             description: 'description',
-            data_type: 'struct<col3:int,col4:string>',
+            data_type: 'struct<col3:int,col4:array<map<string,string>>>',
             sort_order: 0,
             children: [
               {
@@ -179,18 +217,54 @@ function TestDataBuilder(config = {}) {
                 name: 'col3',
                 key:
                   'database://cluster.schema/table/rowName2/type/rowName2/col3',
+                isExpandable: false,
                 description: 'description',
                 data_type: 'int',
                 sort_order: 0,
               },
               {
-                kind: 'scalar',
+                kind: 'array',
                 name: 'col4',
                 key:
                   'database://cluster.schema/table/rowName2/type/rowName2/col4',
+                isExpandable: true,
                 description: 'description',
-                data_type: 'string',
+                data_type: 'array<map<string,string>>',
                 sort_order: 1,
+                children: [
+                  {
+                    kind: 'map',
+                    name: '_inner_',
+                    key:
+                      'database://cluster.schema/table/rowName2/type/rowName2/col4/_inner_',
+                    isExpandable: true,
+                    description: 'description',
+                    data_type: 'map<string,string>',
+                    sort_order: 0,
+                    children: [
+                      {
+                        kind: 'scalar',
+                        name: '_map_key',
+                        key:
+                          'database://cluster.schema/table/rowName2/type/rowName2/col4/_inner_/_map_key',
+                        isExpandable: false,
+                        description: 'description',
+                        data_type: 'string',
+                        sort_order: 0,
+                      },
+                      {
+                        kind: 'scalar',
+                        name: '_map_value',
+                        key:
+                          'database://cluster.schema/table/rowName2/type/rowName2/col4/_inner_/_map_value',
+                        isExpandable: false,
+                        description: 'description',
+                        data_type: 'string',
+                        sort_order: 1,
+                      },
+                    ],
+                  },
+                ],
               },
             ],
           },

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -71,7 +71,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
   return (
     <aside className="right-panel">
       <div className="panel-header">
-        <h2 className="panel-title">{name}</h2>
+        <h2 className="panel-title">{content.title}</h2>
         <button
           type="button"
           className="btn btn-close"

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnType/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnType/index.tsx
@@ -32,8 +32,6 @@ export class ColumnType extends React.Component<
   ColumnTypeProps,
   ColumnTypeState
 > {
-  nestedType: NestedType | null;
-
   constructor(props) {
     super(props);
 
@@ -41,6 +39,8 @@ export class ColumnType extends React.Component<
       showModal: false,
     };
   }
+
+  nestedType: NestedType | null;
 
   hideModal = (e) => {
     this.stopPropagation(e);
@@ -88,6 +88,7 @@ export class ColumnType extends React.Component<
   };
 
   render = () => {
+    const { showModal } = this.state;
     const { columnName, database, type } = this.props;
     this.nestedType = parseNestedType(type, database);
     if (this.nestedType === null) {
@@ -121,12 +122,12 @@ export class ColumnType extends React.Component<
         </OverlayTrigger>
         <Modal
           className="column-type-modal"
-          show={this.state.showModal}
+          show={showModal}
           onHide={this.hideModal}
         >
           <Modal.Header closeButton>
             <Modal.Title>
-              <h5 className="main-title">{MODAL_TITLE}</h5>
+              <div className="main-title">{MODAL_TITLE}</div>
               <div className="sub-title">{columnName}</div>
             </Modal.Title>
           </Modal.Header>

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -434,6 +434,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
         preExpandPanelKey,
         currentSelectedKey,
         tableKey,
+        maxNumRows: getMaxNestedColumns(),
       }}
     />
   );

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -417,6 +417,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
     tableParams,
     index,
     isNestedColumn: true,
+    kind: item.kind,
   });
 
   return (

--- a/frontend/amundsen_application/static/js/interfaces/ColumnList.ts
+++ b/frontend/amundsen_application/static/js/interfaces/ColumnList.ts
@@ -31,7 +31,7 @@ export type FormattedDataType = {
   type: DatatypeType;
   usage: number | null;
   stats: TableColumnStats[] | null;
-  children: TableColumn[];
+  children: TableColumn[] | TypeMetadata[];
   action: ActionType;
   editText: string | null;
   editUrl: string | null;
@@ -45,4 +45,5 @@ export type FormattedDataType = {
   badges: Badge[];
   typeMetadata?: TypeMetadata;
   isNestedColumn?: boolean;
+  kind?: string;
 };


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This work builds on the nested columns changes outlined in this [RFC](https://github.com/amundsen-io/rfcs/blob/master/rfcs/047-nested-columns.md). The changes included here are disabled for now until the nested columns dropdown behavior is enabled.

1. Smaller height rows are included in the table to clearly show which types are nested arrays and/or maps. This is to help distinguish from structs, which previously were the only ones being displayed since they had named nested columns.
2. The nested column rows will be expanded by default, unless a configured threshold is reached. This config is the same that has been used for the frontend parsing of nested columns.

Examples of the special type rows:

Array of structs
![Screen Shot 2022-05-24 at 2 51 45 PM](https://user-images.githubusercontent.com/6732445/170140868-0a24392d-b833-499e-92af-38472f77c857.png)

Map
![Screen Shot 2022-05-24 at 2 48 13 PM](https://user-images.githubusercontent.com/6732445/170140888-eb984514-2e31-4156-ad04-933651432d7d.png)

Array of maps
![Screen Shot 2022-05-24 at 2 49 25 PM](https://user-images.githubusercontent.com/6732445/170140903-3af26224-d9e1-41b8-84f4-cf973e41dc7d.png)

### Tests

- Check that columns are expanded by default if the total number of columns is less than or equal to than the configured value
- Collapsed by default if the total is greater than the configured value
- The correct number of special type rows appear for various map or array children types

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
