### PR TITLE
feat: Use type metadata description get/update apis

### DIFF
--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -5,7 +5,7 @@ import logging
 
 from dataclasses import dataclass
 from marshmallow import EXCLUDE
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from amundsen_common.models.dashboard import DashboardSummary, DashboardSummarySchema
 from amundsen_common.models.feature import Feature, FeatureSchema
@@ -102,10 +102,11 @@ def is_table_editable(schema_name: str, table_name: str, cfg: Any = None) -> boo
     return True
 
 
-def _set_type_metadata_is_editable(type_metadata: TypeMetadata, is_editable: bool) -> None:
-    type_metadata['is_editable'] = is_editable
-    for tm in type_metadata['children']:
-        _set_type_metadata_is_editable(tm, is_editable)
+def _recursive_set_type_metadata_is_editable(type_metadata: Optional[TypeMetadata], is_editable: bool) -> None:
+    if type_metadata is not None:
+        type_metadata['is_editable'] = is_editable
+        for tm in type_metadata['children']:
+            _recursive_set_type_metadata_is_editable(tm, is_editable)
 
 
 def marshall_table_full(table_dict: Dict) -> Dict:
@@ -134,8 +135,7 @@ def marshall_table_full(table_dict: Dict) -> Dict:
     for col in columns:
         # Set editable state
         col['is_editable'] = is_editable
-        if col['type_metadata']:
-            _set_type_metadata_is_editable(col['type_metadata'], is_editable)
+        _recursive_set_type_metadata_is_editable(col['type_metadata'], is_editable)
         # If order is provided, we sort the column based on the pre-defined order
         if app.config['COLUMN_STAT_ORDER']:
             # the stat_type isn't defined in COLUMN_STAT_ORDER, we just use the max index for sorting

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -433,8 +433,8 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:1365865963": [
-      [140, 23, -4339, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:3505354085": [
+      [140, 23, -4358, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/owners/index.spec.ts:655040122": [
       [15, 0, 91, "\`../reducer\` import should occur before import of \`./reducer\`", "2216296793"],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -65,22 +65,11 @@ exports[`eslint`] = {
       [118, 19, 20, "Must use destructuring state assignment", "3067028466"],
       [126, 10, 137, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3965651236"]
     ],
-    "js/components/EditableText/index.tsx:2168483193": [
+    "js/components/EditableText/index.tsx:1961540365": [
       [51, 2, 21, "textAreaRef should be placed after componentDidUpdate", "3072052035"],
-      [72, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [80, 10, 25, "Must use destructuring props assignment", "793704523"],
-      [81, 8, 25, "Must use destructuring props assignment", "793704523"],
-      [83, 32, 16, "Must use destructuring state assignment", "3998965439"],
-      [83, 53, 21, "Must use destructuring state assignment", "1159122654"],
-      [85, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [90, 4, 22, "Must use destructuring props assignment", "2225424112"],
-      [94, 4, 22, "Must use destructuring props assignment", "2225424112"],
-      [98, 27, 23, "Must use destructuring props assignment", "2982501243"],
-      [101, 23, 23, "Must use destructuring props assignment", "2982501243"],
-      [109, 6, 22, "Must use destructuring props assignment", "2225424112"],
-      [116, 4, 24, "Must use destructuring props assignment", "3049746099"],
-      [134, 19, 20, "Script URL is a form of eval.", "3373049033"],
-      [146, 8, 207, "A control must be associated with a text label.", "2914986446"]
+      [78, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
+      [95, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
+      [148, 19, 20, "Script URL is a form of eval.", "3373049033"]
     ],
     "js/components/EntityCard/EntityCardSection/index.tsx:474926744": [
       [25, 2, 55, "editButton should be placed after constructor", "2479426463"],
@@ -444,9 +433,8 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:4194065289": [
-      [80, 8, 23, "Use object destructuring.", "1142306891"],
-      [139, 23, -4311, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:1365865963": [
+      [140, 23, -4339, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/owners/index.spec.ts:655040122": [
       [15, 0, 91, "\`../reducer\` import should occur before import of \`./reducer\`", "2216296793"],
@@ -455,8 +443,8 @@ exports[`eslint`] = {
     "js/ducks/tableMetadata/owners/sagas.ts:3725515638": [
       [7, 0, 69, "\`../types\` import should occur before import of \`./reducer\`", "3326352266"]
     ],
-    "js/ducks/tableMetadata/reducer.ts:1012064960": [
-      [416, 6, 93, "Unexpected lexical declaration in case block.", "4098864482"]
+    "js/ducks/tableMetadata/reducer.ts:3842494077": [
+      [480, 6, 93, "Unexpected lexical declaration in case block.", "4098864482"]
     ],
     "js/ducks/tags/api/v0.ts:2781466514": [
       [21, 16, -605, "Expected to return a value at the end of function \'getResourceTags\'.", "5381"]

--- a/frontend/amundsen_application/static/js/components/EditableText/index.tsx
+++ b/frontend/amundsen_application/static/js/components/EditableText/index.tsx
@@ -68,9 +68,15 @@ class EditableText extends React.Component<
   }
 
   componentDidUpdate(prevProps) {
-    const { value, isEditing, refreshValue } = this.props;
-    if (prevProps.value !== value) {
-      this.setState({ value });
+    const { value: stateValue, isDisabled } = this.state;
+    const {
+      value: propValue,
+      isEditing,
+      refreshValue,
+      getLatestValue,
+    } = this.props;
+    if (prevProps.value !== propValue) {
+      this.setState({ value: propValue });
     } else if (isEditing && !prevProps.isEditing) {
       const textArea = this.textAreaRef.current;
       if (textArea) {
@@ -78,43 +84,51 @@ class EditableText extends React.Component<
         textArea.focus();
       }
 
-      if (this.props.getLatestValue) {
-        this.props.getLatestValue();
+      if (getLatestValue) {
+        getLatestValue();
       }
-    } else if (refreshValue !== this.state.value && !this.state.isDisabled) {
+    } else if (
+      (refreshValue || stateValue) &&
+      refreshValue !== stateValue &&
+      !isDisabled
+    ) {
       // disable the component if a refresh is needed
       this.setState({ isDisabled: true });
     }
   }
 
   exitEditMode = () => {
-    this.props.setEditMode?.(false);
+    const { setEditMode } = this.props;
+    setEditMode?.(false);
   };
 
   enterEditMode = () => {
-    this.props.setEditMode?.(true);
+    const { setEditMode } = this.props;
+    setEditMode?.(true);
   };
 
   refreshText = () => {
-    this.setState({ value: this.props.refreshValue, isDisabled: false });
+    const { refreshValue } = this.props;
+    this.setState({ value: refreshValue, isDisabled: false });
     const textArea = this.textAreaRef.current;
     if (textArea) {
-      textArea.value = this.props.refreshValue;
+      textArea.value = refreshValue;
       autosize.update(textArea);
     }
   };
 
   updateText = () => {
+    const { setEditMode, onSubmitValue } = this.props;
     const newValue = this.textAreaRef.current.value;
     const onSuccessCallback = () => {
-      this.props.setEditMode?.(false);
+      setEditMode?.(false);
       this.setState({ value: newValue });
     };
     const onFailureCallback = () => {
       this.exitEditMode();
     };
 
-    this.props.onSubmitValue?.(newValue, onSuccessCallback, onFailureCallback);
+    onSubmitValue?.(newValue, onSuccessCallback, onFailureCallback);
   };
 
   render() {
@@ -151,6 +165,7 @@ class EditableText extends React.Component<
           ref={this.textAreaRef}
           defaultValue={value}
           disabled={isDisabled}
+          aria-label="Editable text area"
         />
         <div className="editable-textarea-controls">
           {isDisabled && (

--- a/frontend/amundsen_application/static/js/ducks/rootSaga.ts
+++ b/frontend/amundsen_application/static/js/ducks/rootSaga.ts
@@ -59,10 +59,12 @@ import { updateTableOwnerWatcher } from './tableMetadata/owners/sagas';
 import {
   getTableDataWatcher,
   getColumnDescriptionWatcher,
+  getTypeMetadataDescriptionWatcher,
   getPreviewDataWatcher,
   getTableDescriptionWatcher,
   getTableQualityChecksWatcher,
   updateColumnDescriptionWatcher,
+  updateTypeMetadataDescriptionWatcher,
   updateTableDescriptionWatcher,
 } from './tableMetadata/sagas';
 
@@ -132,13 +134,13 @@ export default function* rootSaga() {
     updateResourceTagsWatcher(),
     // TableDetail
     getTableDataWatcher(),
-
     getColumnDescriptionWatcher(),
-
+    getTypeMetadataDescriptionWatcher(),
     getPreviewDataWatcher(),
     getTableDescriptionWatcher(),
     getTableQualityChecksWatcher(),
     updateColumnDescriptionWatcher(),
+    updateTypeMetadataDescriptionWatcher(),
     updateTableDescriptionWatcher(),
     updateTableOwnerWatcher(),
     // LastIndexed

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -115,3 +115,29 @@ export function getColumnCount(columns: TableColumn[]) {
     columns.length
   );
 }
+
+/**
+ * Given a type metadata key, returns the associated type metadata object
+ */
+export function getTypeMetadataFromKey(
+  tmKey: string,
+  tableData: TableMetadata
+) {
+  const tmNamePath = tmKey.replace(tableData.key + '/', '');
+
+  const [
+    columnName,
+    typeConstant, // eslint-disable-line @typescript-eslint/no-unused-vars
+    topLevelTmName, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ...tmNames
+  ] = tmNamePath.split('/');
+
+  const column = tableData.columns.find((column) => column.name === columnName);
+
+  let typeMetadata = column?.type_metadata;
+  tmNames.forEach((name) => {
+    typeMetadata = typeMetadata?.children?.find((child) => child.name === name);
+  });
+
+  return typeMetadata;
+}

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -135,8 +135,12 @@ export function getTypeMetadataFromKey(
   const column = tableData.columns.find((column) => column.name === columnName);
 
   let typeMetadata = column?.type_metadata;
-  tmNames.forEach((name) => {
-    typeMetadata = typeMetadata?.children?.find((child) => child.name === name);
+  // Find the TypeMetadata object at each level corresponding to its name from the key path
+  tmNames.forEach((nextLevelTmName) => {
+    const nextTmObject = typeMetadata?.children?.find(
+      (child) => child.name === nextLevelTmName
+    );
+    typeMetadata = nextTmObject;
   });
 
   return typeMetadata;

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -25,6 +25,7 @@ import {
   getTableDataFromResponseData,
   createOwnerNotificationData,
   shouldSendNotification,
+  getTypeMetadataFromKey,
 } from './helpers';
 
 export const API_PATH = '/api/metadata/v0';
@@ -78,7 +79,7 @@ export function getTableDashboards(tableKey: string) {
       const { response } = e;
       let msg = '';
       if (response && response.data && response.data.msg) {
-        msg = response.data.msg;
+        ({ msg } = response.data);
       }
 
       return Promise.reject({ msg, dashboards: [] });
@@ -146,18 +147,18 @@ export function generateOwnerUpdateRequests(
 }
 
 export function getColumnDescription(
-  columnName: string,
+  columnKey: string,
   tableData: TableMetadata
 ) {
   const tableParams = getTableQueryParams({
     key: tableData.key,
-    column_name: columnName,
+    column_name: columnKey.substring(columnKey.lastIndexOf('/') + 1),
   });
   return axios
     .get(`${API_PATH}/get_column_description?${tableParams}`)
     .then((response: AxiosResponse<DescriptionAPI>) => {
       const column = tableData.columns.find(
-        (column) => column.name === columnName
+        (column) => column.key === columnKey
       );
       if (column) {
         column.description = response.data.description;
@@ -168,13 +169,43 @@ export function getColumnDescription(
 
 export function updateColumnDescription(
   description: string,
-  columnName: string,
+  columnKey: string,
   tableData: TableMetadata
 ) {
   return axios.put(`${API_PATH}/put_column_description`, {
     description,
-    column_name: columnName,
+    column_name: columnKey.substring(columnKey.lastIndexOf('/') + 1),
     key: tableData.key,
+    source: 'user',
+  });
+}
+
+export function getTypeMetadataDescription(
+  typeMetadataKey: string,
+  tableData: TableMetadata
+) {
+  return axios
+    .get(
+      `${API_PATH}/get_type_metadata_description?type_metadata_key=${typeMetadataKey}`
+    )
+    .then((response: AxiosResponse<DescriptionAPI>) => {
+      const typeMetadata = getTypeMetadataFromKey(typeMetadataKey, tableData);
+      if (typeMetadata) {
+        typeMetadata.description = response.data.description;
+      }
+      return tableData;
+    });
+}
+
+export function updateTypeMetadataDescription(
+  description: string,
+  typeMetadataKey: string,
+  tableData: TableMetadata
+) {
+  return axios.put(`${API_PATH}/put_type_metadata_description`, {
+    description,
+    type_metadata_key: typeMetadataKey,
+    table_key: tableData.key,
     source: 'user',
   });
 }

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -45,6 +45,9 @@ export type RelatedDashboardDataAPI = {
 export type LineageAPI = { lineage: Lineage } & MessageAPI;
 export type TableQualityChecksAPI = { checks: TableQualityChecks } & MessageAPI;
 
+const extractColumnName = (columnKey) =>
+  columnKey.substring(columnKey.lastIndexOf('/') + 1);
+
 export function getTableData(key: string, index?: string, source?: string) {
   const tableQueryParams = getTableQueryParams({ key, index, source });
   const tableURL = `${API_PATH}/table?${tableQueryParams}`;
@@ -77,10 +80,7 @@ export function getTableDashboards(tableKey: string) {
     )
     .catch((e: AxiosError<RelatedDashboardDataAPI>) => {
       const { response } = e;
-      let msg = '';
-      if (response && response.data && response.data.msg) {
-        ({ msg } = response.data);
-      }
+      const msg = response?.data?.msg || '';
 
       return Promise.reject({ msg, dashboards: [] });
     });
@@ -152,7 +152,7 @@ export function getColumnDescription(
 ) {
   const tableParams = getTableQueryParams({
     key: tableData.key,
-    column_name: columnKey.substring(columnKey.lastIndexOf('/') + 1),
+    column_name: extractColumnName(columnKey),
   });
   return axios
     .get(`${API_PATH}/get_column_description?${tableParams}`)
@@ -174,7 +174,7 @@ export function updateColumnDescription(
 ) {
   return axios.put(`${API_PATH}/put_column_description`, {
     description,
-    column_name: columnKey.substring(columnKey.lastIndexOf('/') + 1),
+    column_name: extractColumnName(columnKey),
     key: tableData.key,
     source: 'user',
   });

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -14,6 +14,9 @@ import {
   GetColumnDescription,
   GetColumnDescriptionRequest,
   GetColumnDescriptionResponse,
+  GetTypeMetadataDescription,
+  GetTypeMetadataDescriptionRequest,
+  GetTypeMetadataDescriptionResponse,
   GetPreviewData,
   GetPreviewDataRequest,
   GetPreviewDataResponse,
@@ -30,6 +33,8 @@ import {
   GetTableQualityChecksResponse,
   UpdateColumnDescription,
   UpdateColumnDescriptionRequest,
+  UpdateTypeMetadataDescription,
+  UpdateTypeMetadataDescriptionRequest,
   UpdateTableDescription,
   UpdateTableDescriptionRequest,
   UpdateTableOwner,
@@ -195,7 +200,7 @@ export function updateTableDescription(
 }
 
 export function getColumnDescription(
-  columnName: string,
+  columnKey: string,
   onSuccess?: () => any,
   onFailure?: () => any
 ): GetColumnDescriptionRequest {
@@ -203,7 +208,7 @@ export function getColumnDescription(
     payload: {
       onSuccess,
       onFailure,
-      columnName,
+      columnKey,
     },
     type: GetColumnDescription.REQUEST,
   };
@@ -231,18 +236,70 @@ export function getColumnDescriptionSuccess(
 
 export function updateColumnDescription(
   newValue: string,
-  columnName: string,
+  columnKey: string,
   onSuccess?: () => any,
   onFailure?: () => any
 ): UpdateColumnDescriptionRequest {
   return {
     payload: {
       newValue,
-      columnName,
+      columnKey,
       onSuccess,
       onFailure,
     },
     type: UpdateColumnDescription.REQUEST,
+  };
+}
+
+export function getTypeMetadataDescription(
+  typeMetadataKey: string,
+  onSuccess?: () => any,
+  onFailure?: () => any
+): GetTypeMetadataDescriptionRequest {
+  return {
+    payload: {
+      onSuccess,
+      onFailure,
+      typeMetadataKey,
+    },
+    type: GetTypeMetadataDescription.REQUEST,
+  };
+}
+export function getTypeMetadataDescriptionFailure(
+  tableMetadata: TableMetadata
+): GetTypeMetadataDescriptionResponse {
+  return {
+    type: GetTypeMetadataDescription.FAILURE,
+    payload: {
+      tableMetadata,
+    },
+  };
+}
+export function getTypeMetadataDescriptionSuccess(
+  tableMetadata: TableMetadata
+): GetTypeMetadataDescriptionResponse {
+  return {
+    type: GetTypeMetadataDescription.SUCCESS,
+    payload: {
+      tableMetadata,
+    },
+  };
+}
+
+export function updateTypeMetadataDescription(
+  newValue: string,
+  typeMetadataKey: string,
+  onSuccess?: () => any,
+  onFailure?: () => any
+): UpdateTypeMetadataDescriptionRequest {
+  return {
+    payload: {
+      newValue,
+      typeMetadataKey,
+      onSuccess,
+      onFailure,
+    },
+    type: UpdateTypeMetadataDescription.REQUEST,
   };
 }
 
@@ -392,6 +449,13 @@ export default function reducer(
       return {
         ...state,
         tableData: (<GetColumnDescriptionResponse>action).payload.tableMetadata,
+      };
+    case GetTypeMetadataDescription.FAILURE:
+    case GetTypeMetadataDescription.SUCCESS:
+      return {
+        ...state,
+        tableData: (<GetTypeMetadataDescriptionResponse>action).payload
+          .tableMetadata,
       };
     case GetPreviewData.FAILURE:
     case GetPreviewData.SUCCESS:

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -11,6 +11,8 @@ import {
   getTableDescriptionSuccess,
   getColumnDescriptionFailure,
   getColumnDescriptionSuccess,
+  getTypeMetadataDescriptionFailure,
+  getTypeMetadataDescriptionSuccess,
   getPreviewDataFailure,
   getPreviewDataSuccess,
   getTableQualityChecksSuccess,
@@ -24,10 +26,14 @@ import {
   GetTableDataRequest,
   GetColumnDescription,
   GetColumnDescriptionRequest,
+  GetTypeMetadataDescription,
+  GetTypeMetadataDescriptionRequest,
   GetTableDescription,
   GetTableDescriptionRequest,
   UpdateColumnDescription,
   UpdateColumnDescriptionRequest,
+  UpdateTypeMetadataDescription,
+  UpdateTypeMetadataDescriptionRequest,
   UpdateTableDescription,
   UpdateTableDescriptionRequest,
   GetTableQualityChecksRequest,
@@ -120,7 +126,7 @@ export function* getColumnDescriptionWorker(
   try {
     tableData = yield call(
       API.getColumnDescription,
-      payload.columnName,
+      payload.columnKey,
       state.tableMetadata.tableData
     );
     yield put(getColumnDescriptionSuccess(tableData));
@@ -147,7 +153,7 @@ export function* updateColumnDescriptionWorker(
     yield call(
       API.updateColumnDescription,
       payload.newValue,
-      payload.columnName,
+      payload.columnKey,
       state.tableMetadata.tableData
     );
     if (payload.onSuccess) {
@@ -163,6 +169,64 @@ export function* updateColumnDescriptionWatcher(): SagaIterator {
   yield takeEvery(
     UpdateColumnDescription.REQUEST,
     updateColumnDescriptionWorker
+  );
+}
+
+export function* getTypeMetadataDescriptionWorker(
+  action: GetTypeMetadataDescriptionRequest
+): SagaIterator {
+  const { payload } = action;
+  const state = yield select();
+  let { tableData } = state.tableMetadata;
+  try {
+    tableData = yield call(
+      API.getTypeMetadataDescription,
+      payload.typeMetadataKey,
+      state.tableMetadata.tableData
+    );
+    yield put(getTypeMetadataDescriptionSuccess(tableData));
+    if (payload.onSuccess) {
+      yield call(payload.onSuccess);
+    }
+  } catch (e) {
+    yield put(getTypeMetadataDescriptionFailure(tableData));
+    if (payload.onFailure) {
+      yield call(payload.onFailure);
+    }
+  }
+}
+export function* getTypeMetadataDescriptionWatcher(): SagaIterator {
+  yield takeEvery(
+    GetTypeMetadataDescription.REQUEST,
+    getTypeMetadataDescriptionWorker
+  );
+}
+
+export function* updateTypeMetadataDescriptionWorker(
+  action: UpdateTypeMetadataDescriptionRequest
+): SagaIterator {
+  const { payload } = action;
+  const state = yield select();
+  try {
+    yield call(
+      API.updateTypeMetadataDescription,
+      payload.newValue,
+      payload.typeMetadataKey,
+      state.tableMetadata.tableData
+    );
+    if (payload.onSuccess) {
+      yield call(payload.onSuccess);
+    }
+  } catch (e) {
+    if (payload.onFailure) {
+      yield call(payload.onFailure);
+    }
+  }
+}
+export function* updateTypeMetadataDescriptionWatcher(): SagaIterator {
+  yield takeEvery(
+    UpdateTypeMetadataDescription.REQUEST,
+    updateTypeMetadataDescriptionWorker
   );
 }
 

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/types.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/types.ts
@@ -88,7 +88,7 @@ export enum GetColumnDescription {
 export interface GetColumnDescriptionRequest {
   type: GetColumnDescription.REQUEST;
   payload: {
-    columnName: string;
+    columnKey: string;
     onSuccess?: () => any;
     onFailure?: () => any;
   };
@@ -109,13 +109,53 @@ export interface UpdateColumnDescriptionRequest {
   type: UpdateColumnDescription.REQUEST;
   payload: {
     newValue: string;
-    columnName: string;
+    columnKey: string;
     onSuccess?: () => any;
     onFailure?: () => any;
   };
 }
 export interface UpdateColumnDescriptionResponse {
   type: UpdateColumnDescription.SUCCESS | UpdateColumnDescription.FAILURE;
+}
+
+export enum GetTypeMetadataDescription {
+  REQUEST = 'amundsen/tableMetadata/GET_TYPE_METADATA_DESCRIPTION_REQUEST',
+  SUCCESS = 'amundsen/tableMetadata/GET_TYPE_METADATA_DESCRIPTION_SUCCESS',
+  FAILURE = 'amundsen/tableMetadata/GET_TYPE_METADATA_DESCRIPTION_FAILURE',
+}
+export interface GetTypeMetadataDescriptionRequest {
+  type: GetTypeMetadataDescription.REQUEST;
+  payload: {
+    typeMetadataKey: string;
+    onSuccess?: () => any;
+    onFailure?: () => any;
+  };
+}
+export interface GetTypeMetadataDescriptionResponse {
+  type: GetTypeMetadataDescription.SUCCESS | GetTypeMetadataDescription.FAILURE;
+  payload: {
+    tableMetadata: TableMetadata;
+  };
+}
+
+export enum UpdateTypeMetadataDescription {
+  REQUEST = 'amundsen/tableMetadata/UPDATE_TYPE_METADATA_DESCRIPTION_REQUEST',
+  SUCCESS = 'amundsen/tableMetadata/UPDATE_TYPE_METADATA_DESCRIPTION_SUCCESS',
+  FAILURE = 'amundsen/tableMetadata/UPDATE_TYPE_METADATA_DESCRIPTION_FAILURE',
+}
+export interface UpdateTypeMetadataDescriptionRequest {
+  type: UpdateTypeMetadataDescription.REQUEST;
+  payload: {
+    newValue: string;
+    typeMetadataKey: string;
+    onSuccess?: () => any;
+    onFailure?: () => any;
+  };
+}
+export interface UpdateTypeMetadataDescriptionResponse {
+  type:
+    | UpdateTypeMetadataDescription.SUCCESS
+    | UpdateTypeMetadataDescription.FAILURE;
 }
 
 export enum GetPreviewData {

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDescEditableText/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDescEditableText/index.spec.tsx
@@ -1,0 +1,95 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GlobalState } from 'ducks/rootReducer';
+
+import globalState from 'fixtures/globalState';
+import { ContainerOwnProps, mapDispatchToProps, mapStateToProps } from '.';
+
+describe('mapStateToProps', () => {
+  let result;
+  let expectedItemProps;
+  let mockState: GlobalState;
+  let mockProps: ContainerOwnProps;
+  beforeAll(() => {
+    mockState = {
+      ...globalState,
+      tableMetadata: {
+        ...globalState.tableMetadata,
+        tableData: {
+          ...globalState.tableMetadata.tableData,
+          key: 'database://cluster.schema/table',
+          columns: [
+            {
+              badges: [],
+              col_type: 'struct<col1:string,col2:int>',
+              description: 'column description',
+              is_editable: true,
+              key: 'database://cluster.schema/table/column',
+              name: 'column',
+              type_metadata: {
+                kind: 'struct',
+                name: 'column',
+                key: 'database://cluster.schema/table/column/type/column',
+                description: 'type metadata description',
+                data_type: 'struct<col1:string,col2:int>',
+                sort_order: 0,
+                is_editable: true,
+              },
+              sort_order: 0,
+              stats: [],
+            },
+          ],
+        },
+      },
+    };
+  });
+
+  it('returns expected props for a column', () => {
+    mockProps = {
+      columnKey: 'database://cluster.schema/table/column',
+      isNestedColumn: false,
+    };
+    result = mapStateToProps(mockState, mockProps);
+    expectedItemProps =
+      mockState.tableMetadata.tableData.columns[0].description;
+    expect(result.refreshValue).toEqual(expectedItemProps);
+  });
+
+  it('returns expected props for a nested column', () => {
+    mockProps = {
+      columnKey: 'database://cluster.schema/table/column/type/column',
+      isNestedColumn: true,
+    };
+    result = mapStateToProps(mockState, mockProps);
+    expectedItemProps =
+      mockState.tableMetadata.tableData.columns[0].type_metadata?.description;
+    expect(result.refreshValue).toEqual(expectedItemProps);
+  });
+});
+
+describe('mapDispatchToProps', () => {
+  let dispatch;
+  let result;
+  let mockProps: ContainerOwnProps;
+  beforeAll(() => {
+    dispatch = jest.fn(() => Promise.resolve());
+  });
+
+  it('sets getLatestValue props to trigger desired action', () => {
+    mockProps = {
+      columnKey: 'database://cluster.schema/table/column',
+      isNestedColumn: false,
+    };
+    result = mapDispatchToProps(dispatch, mockProps);
+    expect(result.getLatestValue).toBeInstanceOf(Function);
+  });
+  it('sets onSubmitValue props to trigger desired action', () => {
+    mockProps = {
+      columnKey: 'database://cluster.schema/table/column/type/column',
+      isNestedColumn: true,
+    };
+    result = mapDispatchToProps(dispatch, mockProps);
+    expect(result.onSubmitValue).toBeInstanceOf(Function);
+  });
+});

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -57,6 +57,7 @@ const mockColumnDetails = {
     description: 'description',
     data_type: 'string',
     sort_order: 0,
+    is_editable: true,
   },
 };
 

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -49,6 +49,7 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
     tableParams,
     isEditable,
     badges,
+    isNestedColumn,
   } = columnDetails;
 
   const normalStats = stats && filterOutUniqueValues(stats);
@@ -111,7 +112,8 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
           editUrl={editUrl || undefined}
         >
           <ColumnDescEditableText
-            columnName={name}
+            columnKey={key}
+            isNestedColumn={isNestedColumn || false}
             editable={isEditable}
             maxLength={getMaxLength('columnDescLength')}
             value={content.description}

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -26,6 +26,7 @@ import {
   SortCriteria,
   SortDirection,
   IconSizes,
+  TypeMetadata,
 } from 'interfaces';
 import { FormattedDataType, ContentType } from 'interfaces/ColumnList';
 import { logAction } from 'utils/analytics';
@@ -99,12 +100,23 @@ const getSortingFunction = (
     : stringSortingFunction;
 };
 
+const hasTypeMetadataWithBadge = (typeMetadata: TypeMetadata[]) =>
+  typeMetadata.some((tm) => {
+    if (tm.badges?.length) {
+      return true;
+    }
+    return hasTypeMetadataWithBadge(tm.children || []);
+  });
+
 const hasColumnWithBadge = (columns: TableColumn[]) =>
   columns.some((col) => {
-    if (col.badges) {
-      return col.badges.length > 0;
+    if (col.badges?.length) {
+      return true;
     }
-    return false;
+    return (
+      col.type_metadata?.badges?.length ||
+      hasTypeMetadataWithBadge(col.type_metadata?.children || [])
+    );
   });
 
 const getUsageStat = (item) => {
@@ -410,10 +422,10 @@ const ColumnList: React.FC<ColumnListProps> = ({
     },
     key: item.key,
     name: item.name,
-    isEditable: false,
+    isEditable: item.is_editable,
     isExpandable: item.children?.length > 0,
-    editText: null,
-    editUrl: null,
+    editText: editText || null,
+    editUrl: editUrl || null,
     tableParams,
     index,
     isNestedColumn: true,

--- a/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/frontend/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -71,6 +71,7 @@ export interface TypeMetadata {
   sort_order: number;
   badges?: Badge[];
   children?: TypeMetadata[];
+  is_editable: boolean;
 }
 
 export interface NestedTableColumn {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -61,6 +61,7 @@ const mockColumnDetails = {
     description: 'description',
     data_type: 'string',
     sort_order: 0,
+    is_editable: true,
   },
 };
 


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

- Use the new type metadata description get and update APIs to allow users to view and add/edit descriptions for nested columns from the UI
- The column description APIs were changed on the frontend side only to take a column key instead of column name to be consistent with the type metadata APIs
- The logic to decide whether the badges column should be displayed was updated to check if any type metadata values have any badges as well instead of checking only the top level columns

### Tests

- Added tests for get/update type metadata description APIs
- Added tests for `ColumnDescEditableText` to test when it is used by a top level column or a nested column

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
