### PR TITLE
fix: Add postgres compatibility in PrestoViewMetadataExtractor

### DIFF
--- a/databuilder/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/presto_view_metadata_extractor.py
@@ -9,7 +9,6 @@ from typing import (
 )
 
 from pyhocon import ConfigFactory, ConfigTree
-from sqlalchemy.engine.url import make_url
 
 from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
@@ -72,8 +71,8 @@ class PrestoViewMetadataExtractor(Extractor):
         self._extract_iter: Union[None, Iterator] = None
 
     def _choose_default_sql_stm(self, conf: ConfigTree) -> str:
-        url = make_url(conf.get_string("extractor.sqlalchemy.conn_string"))
-        if url.drivername.lower() in ['postgresql', 'postgres']:
+        conn_string = conf.get_string("extractor.sqlalchemy.conn_string")
+        if conn_string.startswith('postgres') or conn_string.startswith('postgresql'):
             return self.DEFAULT_POSTGRES_SQL_STATEMENT
         else:
             return self.DEFAULT_SQL_STATEMENT

--- a/databuilder/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/presto_view_metadata_extractor.py
@@ -9,6 +9,7 @@ from typing import (
 )
 
 from pyhocon import ConfigFactory, ConfigTree
+from sqlalchemy.engine.url import make_url
 
 from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor
@@ -24,13 +25,26 @@ class PrestoViewMetadataExtractor(Extractor):
     """
     # SQL statement to extract View metadata
     # {where_clause_suffix} could be used to filter schemas
-    SQL_STATEMENT = """
+    DEFAULT_SQL_STATEMENT = """
     SELECT t.TBL_ID, d.NAME as `schema`, t.TBL_NAME name, t.TBL_TYPE, t.VIEW_ORIGINAL_TEXT as view_original_text
     FROM TBLS t
     JOIN DBS d ON t.DB_ID = d.DB_ID
     WHERE t.VIEW_EXPANDED_TEXT = '/* Presto View */'
     {where_clause_suffix}
     ORDER BY t.TBL_ID desc;
+    """
+
+    DEFAULT_POSTGRES_SQL_STATEMENT = """
+    SELECT t."TBL_ID",
+    d."NAME" as "schema",
+    t."TBL_NAME" as name,
+    t."TBL_TYPE",
+    t."VIEW_ORIGINAL_TEXT" as view_original_text
+    FROM "TBLS" t
+    JOIN "DBS" d ON t."DB_ID" = d."DB_ID"
+    WHERE t."VIEW_EXPANDED_TEXT" = '/* Presto View */'
+    {where_clause_suffix}
+    ORDER BY t."TBL_ID" desc;
     """
 
     # Presto View data prefix and suffix definition:
@@ -49,13 +63,20 @@ class PrestoViewMetadataExtractor(Extractor):
         conf = conf.with_fallback(PrestoViewMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = conf.get_string(PrestoViewMetadataExtractor.CLUSTER_KEY)
 
-        self.sql_stmt = PrestoViewMetadataExtractor.SQL_STATEMENT.format(
+        self.sql_stmt = self._choose_default_sql_stm(conf).format(
             where_clause_suffix=conf.get_string(PrestoViewMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY))
 
         LOGGER.info('SQL for hive metastore: %s', self.sql_stmt)
 
         self._alchemy_extractor = sql_alchemy_extractor.from_surrounding_config(conf, self.sql_stmt)
         self._extract_iter: Union[None, Iterator] = None
+
+    def _choose_default_sql_stm(self, conf: ConfigTree) -> str:
+        url = make_url(conf.get_string("extractor.sqlalchemy.conn_string"))
+        if url.drivername.lower() in ['postgresql', 'postgres']:
+            return self.DEFAULT_POSTGRES_SQL_STATEMENT
+        else:
+            return self.DEFAULT_SQL_STATEMENT
 
     def close(self) -> None:
         if getattr(self, '_alchemy_extractor', None) is not None:


### PR DESCRIPTION
### Summary of Changes

- Related issue: https://github.com/amundsen-io/amundsen/issues/1608
- Currently, PrestoViewMetadataExtractor is only workable with MySQL connection string. The syntax of the SQL statement is not compatible with Postgres
- Followed the [method](https://github.com/amundsen-io/amundsen/blob/30cf377ef9d4516cc36f4c7cf08fc5abc4d77461/databuilder/databuilder/extractor/hive_table_metadata_extractor.py#L115) in HiveTableMetadataExtractor
  - Added SQL statement for Postgres
  - Added a helper function to choose the SQL statement based on the connection string

### Tests

This change has been running in our production environment for a couple of months. I believe no additional unit test is needed since it's simply fixing an unexpected behavior.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
