### PR TITLE
fix: Add postgres compatibility in HiveTableLastUpdatedExtractor

### DIFF
--- a/databuilder/databuilder/extractor/hive_table_last_updated_extractor.py
+++ b/databuilder/databuilder/extractor/hive_table_last_updated_extractor.py
@@ -12,7 +12,6 @@ from typing import (
 
 from pyhocon import ConfigFactory, ConfigTree
 from pytz import UTC
-from sqlalchemy.engine.url import make_url
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -175,8 +174,8 @@ class HiveTableLastUpdatedExtractor(Extractor):
         return sql_alchemy_extractor
 
     def _choose_default_partitioned_sql_stm(self) -> str:
-        url = make_url(self._conf.get_string("extractor.sqlalchemy.conn_string"))
-        if url.drivername.lower() in ['postgresql', 'postgres']:
+        conn_string = self._conf.get_string("extractor.sqlalchemy.conn_string")
+        if conn_string.startswith('postgres') or conn_string.startswith('postgresql'):
             return self.DEFAULT_POSTGRES_PARTITION_TABLE_SQL_STATEMENT
         else:
             return self.DEFAULT_PARTITION_TABLE_SQL_STATEMENT
@@ -213,9 +212,10 @@ class HiveTableLastUpdatedExtractor(Extractor):
         return sql_alchemy_extractor
 
     def _choose_default_non_partitioned_sql_stm(self) -> List[str]:
-        url = make_url(self._conf.get_string("extractor.sqlalchemy.conn_string"))
-        if url.drivername.lower() in ['postgresql', 'postgres']:
-            return [self.DEFAULT_POSTGRES_NON_PARTITIONED_TABLE_SQL_STATEMENT, self.DEFAULT_POSTGRES_ADDTIONAL_WHERE_CLAUSE]
+        conn_string = self._conf.get_string("extractor.sqlalchemy.conn_string")
+        if conn_string.startswith('postgres') or conn_string.startswith('postgresql'):
+            return [self.DEFAULT_POSTGRES_NON_PARTITIONED_TABLE_SQL_STATEMENT,
+                    self.DEFAULT_POSTGRES_ADDTIONAL_WHERE_CLAUSE]
         else:
             return [self.DEFAULT_NON_PARTITIONED_TABLE_SQL_STATEMENT, self.DEFAULT_ADDTIONAL_WHERE_CLAUSE]
 


### PR DESCRIPTION
### Summary of Changes

- Related issue: https://github.com/amundsen-io/amundsen/issues/1608
- Similar PR: https://github.com/amundsen-io/amundsen/pull/1878
- Currently, HiveTableLastUpdatedExtractor is only workable with MySQL connection string. The syntax of the SQL statement is not compatible with Postgres
- Followed the [method](https://github.com/amundsen-io/amundsen/blob/30cf377ef9d4516cc36f4c7cf08fc5abc4d77461/databuilder/databuilder/extractor/hive_table_metadata_extractor.py#L115) in HiveTableMetadataExtractor
  - Added SQL statement for Postgres
  - Added a helper function to choose the SQL statement based on the connection string

### Tests

This change has been running in our production environment for a couple of months. I believe no additional unit test is needed since it's simply fixing an unexpected behavior.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
