### PR TITLE
feat: Adding expand all/collapse all functionality for nested columns

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -652,9 +652,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:953038643": [
-      [160, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
-      [206, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:105919838": [
+      [161, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
+      [208, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/js/components/SVGIcons/DoubleChevronDown.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/DoubleChevronDown.tsx
@@ -1,0 +1,36 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IconSizes } from 'interfaces';
+import { IconProps } from './types';
+import { DEFAULT_FILL_COLOR } from './constants';
+
+export const DoubleChevronDown: React.FC<IconProps> = ({
+  size = IconSizes.REGULAR,
+  fill = DEFAULT_FILL_COLOR,
+}: IconProps) => {
+  const id = `double_chevron_down_${uuidv4()}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      id={id}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 15.586L7.70697 11.293L6.29297 12.707L12 18.414L17.707 12.707L16.293 11.293L12 15.586Z"
+        fill={fill}
+      />
+      <path
+        d="M17.707 7.707L16.293 6.293L12 10.586L7.70697 6.293L6.29297 7.707L12 13.414L17.707 7.707Z"
+        fill={fill}
+      />
+    </svg>
+  );
+};

--- a/frontend/amundsen_application/static/js/components/SVGIcons/DoubleChevronUp.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/DoubleChevronUp.tsx
@@ -1,0 +1,36 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IconSizes } from 'interfaces';
+import { IconProps } from './types';
+import { DEFAULT_FILL_COLOR } from './constants';
+
+export const DoubleChevronUp: React.FC<IconProps> = ({
+  size = IconSizes.REGULAR,
+  fill = DEFAULT_FILL_COLOR,
+}: IconProps) => {
+  const id = `double_chevron_up_${uuidv4()}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      id={id}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6.29297 11.293L7.70697 12.707L12 8.414L16.293 12.707L17.707 11.293L12 5.586L6.29297 11.293Z"
+        fill={fill}
+      />
+      <path
+        d="M6.29297 16.293L7.70697 17.707L12 13.414L16.293 17.707L17.707 16.293L12 10.586L6.29297 16.293Z"
+        fill={fill}
+      />
+    </svg>
+  );
+};

--- a/frontend/amundsen_application/static/js/components/SVGIcons/index.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/index.tsx
@@ -13,3 +13,5 @@ export * from './InformationIcon';
 export * from './Binoculars';
 export * from './Chat';
 export * from './TableIcon';
+export * from './DoubleChevronUp';
+export * from './DoubleChevronDown';

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -17,6 +17,8 @@ const formatChildrenDataMock = jest.fn().mockImplementation((rowValue) => ({
   kind: rowValue.kind,
   children: rowValue.children,
 }));
+const hasRowsToExpandMock = jest.fn().mockReturnValue(true);
+const hasNoRowsToExpandMock = jest.fn().mockReturnValue(false);
 
 const setup = (propOverrides?: Partial<TableProps>) => {
   const { data, columns } = dataBuilder.build();
@@ -212,22 +214,52 @@ describe('Table', () => {
       describe('when the data has nested children', () => {
         const { columns, data } = dataBuilder.withCollapsedRow().build();
 
-        it('displays the expected specific type rows', () => {
-          const { wrapper } = setup({
-            data,
-            columns,
-            options: {
-              formatChildrenData: formatChildrenDataMock,
-              maxNumRows: 20,
-            },
+        describe('table body', () => {
+          it('renders expansion buttons for rows that are expandable', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+            });
+            const expected = data.filter((item) => item.isExpandable === true)
+              .length;
+            const actual = wrapper.find(
+              '.ams-table-body .ams-table-expanding-button'
+            ).length;
+
+            expect(actual).toEqual(expected);
           });
 
-          // The child rows include one array, one map, and one map within an array
-          // (multiplied by 2 for opener and closer)
-          const expected = 6;
-          const actual = wrapper.find('.is-specific-type-row').length;
+          describe('expanded row', () => {
+            it('renders hidden by default', () => {
+              const { wrapper } = setup({
+                data,
+                columns,
+              });
+              const expected = data.length;
+              const actual = wrapper.find('.ams-table-body .ams-table-row')
+                .length;
 
-          expect(actual).toEqual(expected);
+              expect(actual).toEqual(expected);
+            });
+          });
+
+          it('displays the expected specific type rows', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                formatChildrenData: formatChildrenDataMock,
+                maxNumRows: 20,
+              },
+            });
+
+            // The child rows include one array, one map, and one map within an array
+            // (multiplied by 2 for opener and closer)
+            const expected = 6;
+            const actual = wrapper.find('.is-specific-type-row').length;
+
+            expect(actual).toEqual(expected);
+          });
         });
       });
     });
@@ -596,66 +628,6 @@ describe('Table', () => {
         });
       });
 
-      describe('when a row is expandable', () => {
-        const { columns, data } = dataBuilder.withCollapsedRow().build();
-
-        describe('table header', () => {
-          it('renders a table header', () => {
-            const { wrapper } = setup({
-              data,
-              columns,
-            });
-            const expected = 1;
-            const actual = wrapper.find('.ams-table-header').length;
-
-            expect(actual).toEqual(expected);
-          });
-
-          it('renders the same amount of cells equal to columns length inside the header', () => {
-            const { wrapper } = setup({
-              data,
-              columns,
-            });
-            const expected = columns.length;
-            const actual = wrapper.find(
-              '.ams-table-header .ams-table-heading-cell'
-            ).length;
-
-            expect(actual).toEqual(expected);
-          });
-        });
-
-        describe('table body', () => {
-          it('renders expansion buttons for rows that are expandable', () => {
-            const { wrapper } = setup({
-              data,
-              columns,
-            });
-            const expected = data.filter((item) => item.isExpandable === true)
-              .length;
-            const actual = wrapper.find(
-              '.ams-table-body .ams-table-expanding-button'
-            ).length;
-
-            expect(actual).toEqual(expected);
-          });
-
-          describe('expanded row', () => {
-            it('renders hidden by default', () => {
-              const { wrapper } = setup({
-                data,
-                columns,
-              });
-              const expected = data.length;
-              const actual = wrapper.find('.ams-table-body .ams-table-row')
-                .length;
-
-              expect(actual).toEqual(expected);
-            });
-          });
-        });
-      });
-
       describe('when emptyMessage is passed', () => {
         const { columns, data } = dataBuilder.withEmptyData().build();
         const TEST_EMPTY_MESSAGE = 'Test Empty Message';
@@ -837,15 +809,233 @@ describe('Table', () => {
           });
         });
       });
+
+      describe('when shouldExpandAllRows is passed', () => {
+        const { columns, data } = dataBuilder.withCollapsedRow().build();
+
+        describe('when shouldExpandAllRows is true', () => {
+          it('displays the up icon in the header to collapse all rows', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                shouldExpandAllRows: true,
+                hasRowsToExpand: hasRowsToExpandMock,
+              },
+            });
+
+            const expected = 1;
+            const actual = wrapper
+              .find(
+                '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+              )
+              .findWhere((node) => node.key() === 'collapseAllIcon').length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+
+        describe('when shouldExpandAllRows is undefined', () => {
+          it('displays the up icon in the header to collapse all rows', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                shouldExpandAllRows: undefined,
+                hasRowsToExpand: hasRowsToExpandMock,
+              },
+            });
+
+            const expected = 1;
+            const actual = wrapper
+              .find(
+                '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+              )
+              .findWhere((node) => node.key() === 'collapseAllIcon').length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+
+        describe('when shouldExpandAllRows is false', () => {
+          it('displays the down icon in the header to expand all rows', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                shouldExpandAllRows: false,
+                hasRowsToExpand: hasRowsToExpandMock,
+              },
+            });
+
+            const expected = 1;
+            const actual = wrapper
+              .find(
+                '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+              )
+              .findWhere((node) => node.key() === 'expandAllIcon').length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+      });
+
+      describe('when hasRowsToExpand is passed', () => {
+        const { columns, data } = dataBuilder.withCollapsedRow().build();
+
+        describe('when there are no expandable rows', () => {
+          it('does not render an expand/collapse all button in the first header cell', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                hasRowsToExpand: hasNoRowsToExpandMock,
+              },
+            });
+
+            const expected = 0;
+            const actual = wrapper.find(
+              '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+            ).length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+
+        describe('when there are expandable rows', () => {
+          it('renders an expand/collapse all button in the first header cell', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                hasRowsToExpand: hasRowsToExpandMock,
+              },
+            });
+
+            const expected = 1;
+            const actual = wrapper.find(
+              '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+            ).length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+      });
     });
   });
 
   describe('lifetime', () => {
-    describe('when collapsing and expanding rows', () => {
+    describe('when collapsing and expanding all rows', () => {
+      const { columns, data } = dataBuilder.withCollapsedRow().build();
+
+      describe('when clicking on button to collapse all', () => {
+        it('hides all child rows', () => {
+          const { wrapper } = setup({
+            data,
+            columns,
+            options: {
+              hasRowsToExpand: hasRowsToExpandMock,
+              formatChildrenData: formatChildrenDataMock,
+              maxNumRows: 20,
+            },
+          });
+
+          const mockToggleExpandingRows = jest.fn().mockImplementation(() => {
+            const currentShouldExpandAllRows = wrapper.props().options
+              ?.shouldExpandAllRows;
+
+            wrapper.setProps({
+              options: {
+                ...wrapper.props().options,
+                shouldExpandAllRows: !(
+                  currentShouldExpandAllRows ||
+                  currentShouldExpandAllRows === undefined
+                ),
+              },
+            });
+          });
+          wrapper.setProps({
+            options: {
+              ...wrapper.props().options,
+              toggleExpandingRows: mockToggleExpandingRows,
+            },
+          });
+
+          const expected = data.length;
+
+          wrapper
+            .find(
+              '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+            )
+            .at(0)
+            .simulate('click');
+
+          const actual = wrapper
+            .find('.ams-table-body .ams-table-row')
+            .not('.is-specific-type-row').length;
+
+          expect(actual).toEqual(expected);
+        });
+
+        describe('when clicking again to expand all', () => {
+          it('shows all child rows', () => {
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                hasRowsToExpand: hasRowsToExpandMock,
+                formatChildrenData: formatChildrenDataMock,
+                maxNumRows: 20,
+              },
+            });
+
+            const mockToggleExpandingRows = jest.fn().mockImplementation(() => {
+              const currentShouldExpandAllRows = wrapper.props().options
+                ?.shouldExpandAllRows;
+
+              wrapper.setProps({
+                options: {
+                  ...wrapper.props().options,
+                  shouldExpandAllRows: !(
+                    currentShouldExpandAllRows ||
+                    currentShouldExpandAllRows === undefined
+                  ),
+                },
+              });
+            });
+            wrapper.setProps({
+              options: {
+                ...wrapper.props().options,
+                toggleExpandingRows: mockToggleExpandingRows,
+              },
+            });
+
+            // 8 total child rows
+            const expected = data.length + 8;
+
+            wrapper
+              .find(
+                '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
+              )
+              .at(0)
+              .simulate('click')
+              .simulate('click');
+
+            const actual = wrapper
+              .find('.ams-table-body .ams-table-row')
+              .not('.is-specific-type-row').length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+      });
+    });
+
+    describe('when collapsing and expanding individual rows', () => {
       const { columns, data } = dataBuilder.withCollapsedRow().build();
 
       describe('when clicking on collapse button', () => {
-        it('hide the expanded rows', () => {
+        it('hides the expanded rows', () => {
           const { wrapper } = setup({
             data,
             columns,

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { mocked } from 'ts-jest/utils';
 
+import { DoubleChevronDown, DoubleChevronUp } from 'components/SVGIcons';
 import TestDataBuilder from './testDataBuilder';
 import Table, { TableProps } from '.';
 
@@ -829,7 +830,7 @@ describe('Table', () => {
               .find(
                 '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
               )
-              .findWhere((node) => node.key() === 'collapseAllIcon').length;
+              .find(DoubleChevronUp).length;
 
             expect(actual).toEqual(expected);
           });
@@ -851,7 +852,7 @@ describe('Table', () => {
               .find(
                 '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
               )
-              .findWhere((node) => node.key() === 'collapseAllIcon').length;
+              .find(DoubleChevronUp).length;
 
             expect(actual).toEqual(expected);
           });
@@ -873,7 +874,7 @@ describe('Table', () => {
               .find(
                 '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
               )
-              .findWhere((node) => node.key() === 'expandAllIcon').length;
+              .find(DoubleChevronDown).length;
 
             expect(actual).toEqual(expected);
           });

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -58,7 +58,7 @@ $selected-row-color: $gray15;
   }
 
   &:first-child {
-    padding-left: $spacer-3;
+    padding-left: 0;
   }
 
   &:last-child {

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -49,6 +49,9 @@ const setup = (propOverrides?: Partial<ColumnListProps>) => {
     preExpandRightPanel: jest.fn(),
     hideSomeColumnMetadata: false,
     currentSelectedKey: '',
+    areNestedColumnsExpanded: true,
+    toggleExpandingColumns: jest.fn(),
+    hasColumnsToExpand: jest.fn(),
     ...propOverrides,
   };
   // Update state

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -65,6 +65,9 @@ export interface ComponentProps {
   toggleRightPanel: (newColumnDetails: FormattedDataType | undefined) => void;
   hideSomeColumnMetadata: boolean;
   currentSelectedKey: string;
+  areNestedColumnsExpanded: boolean | undefined;
+  toggleExpandingColumns: () => void;
+  hasColumnsToExpand: () => boolean;
 }
 
 export type ColumnListProps = ComponentProps;
@@ -155,6 +158,9 @@ const ColumnList: React.FC<ColumnListProps> = ({
   toggleRightPanel,
   hideSomeColumnMetadata,
   currentSelectedKey,
+  areNestedColumnsExpanded,
+  toggleExpandingColumns,
+  hasColumnsToExpand,
 }: ColumnListProps) => {
   const hasColumnBadges = hasColumnWithBadge(columns);
   const formatColumnData = (item, index) => {
@@ -447,6 +453,9 @@ const ColumnList: React.FC<ColumnListProps> = ({
         currentSelectedKey,
         tableKey,
         maxNumRows: getMaxNestedColumns(),
+        shouldExpandAllRows: areNestedColumnsExpanded,
+        toggleExpandingRows: toggleExpandingColumns,
+        hasRowsToExpand: hasColumnsToExpand,
       }}
     />
   );

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
@@ -14,6 +14,8 @@ export const OWNERS_TITLE = 'Owners';
 export const TAG_TITLE = 'Tags';
 export const SORT_BY_DROPDOWN_TITLE = 'Sort by';
 export const SORT_BY_MENU_TITLE_TEXT = 'Sort by';
+export const COLLAPSE_ALL_NESTED_LABEL = 'Collapse all nested';
+export const EXPAND_ALL_NESTED_LABEL = 'Expand all nested';
 
 export enum TABLE_TAB {
   COLUMN = 'columns',

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -226,5 +226,30 @@ describe('TableDetail', () => {
         });
       });
     });
+
+    describe('when toggleExpandingColumns is called while the columns are expanded', () => {
+      it('toggles the areNestedColumnsExpanded state to false', () => {
+        setStateSpy.mockClear();
+        const { wrapper } = setup();
+        wrapper.instance().toggleExpandingColumns();
+
+        expect(setStateSpy).toHaveBeenCalledWith({
+          areNestedColumnsExpanded: false,
+        });
+      });
+
+      describe('when toggleExpandingColumns is called again after collapsing the columns', () => {
+        it('toggles the areNestedColumnsExpanded state to true', () => {
+          setStateSpy.mockClear();
+          const { wrapper } = setup();
+          wrapper.instance().toggleExpandingColumns();
+          wrapper.instance().toggleExpandingColumns();
+
+          expect(setStateSpy).toHaveBeenCalledWith({
+            areNestedColumnsExpanded: true,
+          });
+        });
+      });
+    });
   });
 });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/styles.scss
@@ -4,6 +4,8 @@
 @import 'variables';
 @import 'typography';
 
+$expand-collapse-all-button-height: 32px;
+
 .table-detail {
   .single-column-layout .left-panel {
     .alert {
@@ -67,9 +69,25 @@
     position: relative;
   }
 
-  .list-sorting-dropdown {
+  .column-tab-action-buttons {
+    display: flex;
+    align-items: center;
+    gap: $spacer-2;
     right: $spacer-3;
     top: $spacer-2;
     position: absolute;
+  }
+
+  .expand-collapse-all-button {
+    padding: 0;
+    border: none;
+    background: none;
+    height: $expand-collapse-all-button-height;
+  }
+
+  .expand-collapse-all-text {
+    @extend %text-title-w3;
+
+    color: $link-color;
   }
 }


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Added a button that displays `Expand all nested` or `Collapse all nested` to allow users to expand/collapse all nested columns with one click. This will default to show as `Collapse all nested` for most cases, but if the amount of columns exceeds the configured threshold then it will default to have all the rows collapsed and display `Expand all nested` on the button. In addition, a small caret button was added to the table header in vertical alignment with the other expand/collapse buttons per row that allows users to expand all/collapse all from there as well.

![Screen Shot 2022-06-07 at 2 14 51 PM](https://user-images.githubusercontent.com/6732445/172486416-7fd140e0-c36d-43e4-a57c-47dc4fb11351.png)

![Screen Shot 2022-06-07 at 2 17 25 PM](https://user-images.githubusercontent.com/6732445/172486443-07f601e4-6f5f-4fa7-ac19-426b7c3836bd.png)

### Tests

In the `Table` component, added tests for the rendering of the expand/collapse all button that appears in the table header, along with lifecycle tests for when the button is clicked. The `TableDetailPage` tests the usage of the `toggleExpandingColumns` function which sets the state to determine whether all the columns should be expanded or collapsed.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
