### PR TITLE
test: Fix databuilder PR unit test import error

### DIFF
--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -66,7 +66,8 @@ neptune = [
 ]
 
 feast = [
-    'feast==0.17.0'
+    'feast==0.17.0',
+    'fastapi!=0.76.*'
 ]
 
 atlas = [


### PR DESCRIPTION
### Summary of Changes

Originally, the databuilder unit test will fail because of the fastAPI version problem. This blocked all the databuilder related PRs. Fast API is required by Feast.
An example of the failing workflow: https://github.com/amundsen-io/amundsen/runs/6646082819
The log looks like

```
tests/unit/extractor/test_feast_extractor.py:13: in <module>
    from databuilder.extractor.feast_extractor import FeastExtractor
databuilder/extractor/feast_extractor.py:7: in <module>
    from feast import FeatureStore, FeatureView
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/feast/__init__.py:13: in <module>
    from .feature_store import FeatureStore
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/feast/feature_store.py:[38](https://github.com/amundsen-io/amundsen/runs/6646082819?check_suite_focus=true#step:5:39): in <module>
    from feast import feature_server, flags, flags_helper, utils
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/feast/feature_server.py:3: in <module>
    from fastapi import FastAPI, HTTPException, Request
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/fastapi/__init__.py:7: in <module>
    from .applications import FastAPI as FastAPI
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/fastapi/applications.py:4: in <module>
    from fastapi import routing
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/fastapi/routing.py:22: in <module>
    from fastapi.datastructures import Default, DefaultPlaceholder
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/fastapi/datastructures.py:3: in <module>
    from starlette.datastructures import URL as URL  # noqa: F[40](https://github.com/amundsen-io/amundsen/runs/6646082819?check_suite_focus=true#step:5:41)1
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/starlette/datastructures.py:8: in <module>
    from starlette.concurrency import run_in_threadpool
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/starlette/concurrency.py:10: in <module>
    from typing_extensions import ParamSpec
E   ImportError: cannot import name 'ParamSpec' from 'typing_extensions' (/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/typing_extensions.py)
```

According to https://github.com/tiangolo/fastapi/issues/4877 and https://github.com/tiangolo/fastapi/issues/4868#issuecomment-1119678681 , the problem is fixed in `fastapi==0.77.0`. However, doing `fastapi>=0.77.0` seems to be incompatible with other packages, this is a [test run](https://github.com/chonyy/amundsen/runs/6780283036?check_suite_focus=true) of it. That's why I decided to just skip the troublesome versions. 

### Tests

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
