### PR TITLE
feat: added ngram subfield with no stemming on ES mappings

### DIFF
--- a/databuilder/databuilder/task/search/document_mappings.py
+++ b/databuilder/databuilder/task/search/document_mappings.py
@@ -77,6 +77,7 @@ class Subfield:
                          analyzer=Analyzer.general_analyzer,
                          term_vector=POSITIONS_OFFSETS)
 
+    @staticmethod
     def get_ngram_subfield(field_name: str,
                            multi: bool = False,
                            min_shingle_size: int = 2,

--- a/databuilder/databuilder/task/search/document_mappings.py
+++ b/databuilder/databuilder/task/search/document_mappings.py
@@ -87,7 +87,7 @@ class Subfield:
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-shingle-tokenfilter.html
         shingle_filter = token_filter(f"shingle_filter_{field_name}",
                                       type="shingle",
-                                      output_unigrams=False,
+                                      output_unigrams=True,
                                       min_shingle_size=min_shingle_size,
                                       max_shingle_size=max_shingle_size,
                                       token_separator=token_separator)

--- a/databuilder/databuilder/task/search/document_mappings.py
+++ b/databuilder/databuilder/task/search/document_mappings.py
@@ -136,7 +136,7 @@ class Table(SearchableResource):
                     term_vector=POSITIONS_OFFSETS)
     cluster = Text(required=True,
                    fields={
-                      "keyword": Subfield.keyword
+                       "keyword": Subfield.keyword
                    },
                    analyzer=Analyzer.general_analyzer,
                    term_vector=POSITIONS_OFFSETS)

--- a/databuilder/databuilder/task/search/document_mappings.py
+++ b/databuilder/databuilder/task/search/document_mappings.py
@@ -169,8 +169,7 @@ class Table(SearchableResource):
                        "ngram": Subfield.get_ngram_subfield(
                            field_name="table_columns",
                            multi=True,
-                           token_separator="_"
-                        )
+                           token_separator="_")
                    },
                    term_vector=POSITIONS_OFFSETS,
                    analyzer=Analyzer.stemming_analyzer)

--- a/databuilder/databuilder/task/search/search_metadata_to_elasticsearch_task.py
+++ b/databuilder/databuilder/task/search/search_metadata_to_elasticsearch_task.py
@@ -154,7 +154,7 @@ class SearchMetadatatoElasticasearchTask(Task):
             index = Index(name=self.elasticsearch_new_index, using=self.elasticsearch_client)
             index.document(self.document_mapping)
 
-            # allow for longer ngram difference
+            # allow for longer ngram length
             index.settings(max_shingle_diff=10)
 
             index.create()

--- a/databuilder/databuilder/task/search/search_metadata_to_elasticsearch_task.py
+++ b/databuilder/databuilder/task/search/search_metadata_to_elasticsearch_task.py
@@ -153,6 +153,10 @@ class SearchMetadatatoElasticasearchTask(Task):
             LOGGER.info(f"Creating ES index {self.elasticsearch_new_index}")
             index = Index(name=self.elasticsearch_new_index, using=self.elasticsearch_client)
             index.document(self.document_mapping)
+
+            # allow for longer ngram difference
+            index.settings(max_shingle_diff=10)
+
             index.create()
 
             # publish search metadata to ES

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.8.0'
+__version__ = '6.9.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.9.0'
+__version__ = '6.10.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
Added mapping subfields that contain the tokenized text with no stemming so we can prioritize exact text matches over stemmed ones when possible, using ngram to allow combinations of words too.