### PR TITLE
feat: Add clickable rows to table detail page and new expand/collapse arrow icons

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -614,14 +614,8 @@ exports[`eslint`] = {
       [168, 15, 20, "Script URL is a form of eval.", "3959800777"],
       [189, 16, 160, "A control must be associated with a text label.", "1834626670"]
     ],
-    "js/pages/TableDetailPage/RequestDescriptionText/index.spec.tsx:2570104867": [
-      [7, 7, 11, "\'globalState\' is defined but never used.", "1130616505"],
-      [14, 0, 50, "\`./constants\` import should occur before import of \`.\`", "1670547063"],
-      [45, 14, 5, "\'props\' is assigned a value but never used.", "187023499"]
-    ],
-    "js/pages/TableDetailPage/RequestDescriptionText/index.tsx:1276941631": [
-      [29, 4, 39, "Must use destructuring props assignment", "4072624518"],
-      [38, 13, 20, "Script URL is a form of eval.", "3373049033"]
+    "js/pages/TableDetailPage/RequestDescriptionText/index.tsx:1601553334": [
+      [39, 11, 20, "Script URL is a form of eval.", "3373049033"]
     ],
     "js/pages/TableDetailPage/RequestMetadataForm/index.spec.tsx:1512093594": [
       [17, 0, 338, "\`./constants\` import should occur before import of \`.\`", "263963311"],
@@ -652,7 +646,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:105919838": [
+    "js/pages/TableDetailPage/index.tsx:1880896433": [
       [161, 2, 20, "key should be placed after componentDidUpdate", "3916788587"],
       [208, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -209,6 +209,10 @@ $close-btn-size: 24px;
         margin-top: $aside-separation-space;
         position: relative;
       }
+
+      .editable-text {
+        font-size: 16px;
+      }
     }
 
     > .main-content-panel {

--- a/frontend/amundsen_application/static/js/components/SVGIcons/DownTriangleIcon.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/DownTriangleIcon.tsx
@@ -1,0 +1,32 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IconSizes } from 'interfaces';
+import { IconProps } from './types';
+import { DEFAULT_FILL_COLOR } from './constants';
+
+export const DownTriangleIcon: React.FC<IconProps> = ({
+  size = IconSizes.REGULAR,
+  fill = DEFAULT_FILL_COLOR,
+}: IconProps) => {
+  const id = `down_triangle_${uuidv4()}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      id={id}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.1783 19.569C11.3643 19.839 11.6723 20 12.0003 20C12.3283 20 12.6363 19.839 12.8223 19.569L21.8223 6.569C22.0343 6.263 22.0583 5.865 21.8853 5.536C21.7133 5.207 21.3723 5 21.0003 5H3.0003C2.6283 5 2.2873 5.207 2.1143 5.536C1.9413 5.865 1.9663 6.263 2.1783 6.569L11.1783 19.569Z"
+        fill={fill}
+      />
+    </svg>
+  );
+};

--- a/frontend/amundsen_application/static/js/components/SVGIcons/RightTriangleIcon.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/RightTriangleIcon.tsx
@@ -1,0 +1,32 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { IconSizes } from 'interfaces';
+import { IconProps } from './types';
+import { DEFAULT_FILL_COLOR } from './constants';
+
+export const RightTriangleIcon: React.FC<IconProps> = ({
+  size = IconSizes.REGULAR,
+  fill = DEFAULT_FILL_COLOR,
+}: IconProps) => {
+  const id = `right_triangle_${uuidv4()}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      id={id}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5.536 21.886C5.682 21.962 5.841 22 6 22C6.2 22 6.398 21.9401 6.569 21.8221L19.569 12.822C19.839 12.635 20 12.328 20 12C20 11.672 19.839 11.3651 19.569 11.1781L6.569 2.17805C6.264 1.96705 5.865 1.94205 5.536 2.11405C5.206 2.28705 5 2.62805 5 3.00005V21C5 21.372 5.206 21.713 5.536 21.886Z"
+        fill={fill}
+      />
+    </svg>
+  );
+};

--- a/frontend/amundsen_application/static/js/components/SVGIcons/index.tsx
+++ b/frontend/amundsen_application/static/js/components/SVGIcons/index.tsx
@@ -15,3 +15,5 @@ export * from './Chat';
 export * from './TableIcon';
 export * from './DoubleChevronUp';
 export * from './DoubleChevronDown';
+export * from './RightTriangleIcon';
+export * from './DownTriangleIcon';

--- a/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.spec.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { mocked } from 'ts-jest/utils';
 
-import { DoubleChevronDown, DoubleChevronUp } from 'components/SVGIcons';
+import { RightTriangleIcon, DownTriangleIcon } from 'components/SVGIcons';
 import TestDataBuilder from './testDataBuilder';
 import Table, { TableProps } from '.';
 
@@ -629,6 +629,74 @@ describe('Table', () => {
         });
       });
 
+      describe('when onRowClick is passed', () => {
+        const {
+          columns,
+          data,
+        } = new TestDataBuilder().withFourColumns().build();
+
+        describe('when clicking on row', () => {
+          it('calls the onRowClick handler', () => {
+            const onRowClickSpy = jest.fn();
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                onRowClick: onRowClickSpy,
+              },
+            });
+            const expected = 1;
+
+            wrapper.find('.ams-table-row').at(0).simulate('click');
+
+            const actual = onRowClickSpy.mock.calls.length;
+
+            expect(actual).toEqual(expected);
+          });
+
+          it('calls the onRowClick handler with the row values and the index', () => {
+            const onRowClickSpy = jest.fn();
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                onRowClick: onRowClickSpy,
+              },
+            });
+            const expected = [
+              data[0],
+              'database://cluster.schema/table/rowName',
+            ];
+
+            wrapper.find('.ams-table-row').at(0).simulate('click');
+
+            const [actual] = onRowClickSpy.mock.calls;
+            expect(actual).toEqual(expected);
+          });
+        });
+
+        describe('when clicking on multiple rows', () => {
+          it('calls the onRowClick handler several times', () => {
+            const onRowClickSpy = jest.fn();
+            const { wrapper } = setup({
+              data,
+              columns,
+              options: {
+                onRowClick: onRowClickSpy,
+              },
+            });
+            const expected = 2;
+
+            wrapper.find('.ams-table-row').at(0).simulate('click');
+            wrapper.find('.ams-table-row').at(1).simulate('click');
+
+            const actual = onRowClickSpy.mock.calls.length;
+
+            expect(actual).toEqual(expected);
+          });
+        });
+      });
+
       describe('when emptyMessage is passed', () => {
         const { columns, data } = dataBuilder.withEmptyData().build();
         const TEST_EMPTY_MESSAGE = 'Test Empty Message';
@@ -830,7 +898,7 @@ describe('Table', () => {
               .find(
                 '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
               )
-              .find(DoubleChevronUp).length;
+              .find(DownTriangleIcon).length;
 
             expect(actual).toEqual(expected);
           });
@@ -852,7 +920,7 @@ describe('Table', () => {
               .find(
                 '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
               )
-              .find(DoubleChevronUp).length;
+              .find(DownTriangleIcon).length;
 
             expect(actual).toEqual(expected);
           });
@@ -874,7 +942,7 @@ describe('Table', () => {
               .find(
                 '.ams-table-header .ams-table-heading-cell .ams-table-expanding-button'
               )
-              .find(DoubleChevronDown).length;
+              .find(RightTriangleIcon).length;
 
             expect(actual).toEqual(expected);
           });

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -17,7 +17,7 @@ $table-header-background-color: $gray5;
 $row-bottom-border-color: $gray10;
 $nested-column-row-color: $gray5;
 $nested-column-bottom-border-color: $gray15;
-$selected-row-color: $gray15;
+$selected-row-color: $indigo10;
 
 .ams-table {
   width: 100%;
@@ -86,6 +86,19 @@ $selected-row-color: $gray15;
   &.has-child-expanded {
     border-bottom: 0;
   }
+
+  &.is-interactive-row {
+    position: relative;
+    cursor: pointer;
+
+    &:hover {
+      box-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.12), 0 2px 3px 0 rgba(0, 0, 0, 0.16);
+      z-index: 1;
+    }
+    &:active {
+      background-color: $selected-row-color;
+    }
+  }
 }
 
 .ams-table-expanded-row {
@@ -134,19 +147,16 @@ $selected-row-color: $gray15;
 
 .ams-table-expanding-button {
   border: 0;
-  padding: 0;
-  background-color: white;
+  padding: $spacer-1;
+  line-height: normal;
+  background-color: transparent;
 
   svg {
     vertical-align: bottom;
   }
 
-  &.is-nested-column-row {
-    background-color: $nested-column-row-color;
-  }
-
-  &.is-selected-row {
-    background-color: $selected-row-color;
+  &.is-expand-collapse-all {
+    padding: 0;
   }
 
   &:hover svg use {

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -6,6 +6,7 @@ import { shallow } from 'enzyme';
 import { getColumnLink } from 'utils/navigationUtils';
 import ExpandableUniqueValues from 'features/ExpandableUniqueValues';
 import BadgeList from 'features/BadgeList';
+import RequestDescriptionText from 'pages/TableDetailPage/RequestDescriptionText';
 import ColumnDescEditableText from '../ColumnDescEditableText';
 import ColumnStats from '../ColumnStats';
 import ColumnLineage from '../ColumnLineage';
@@ -70,9 +71,11 @@ jest.mock('utils/stats', () => ({
   getUniqueValues: () => mockStats,
 }));
 let mockLineageEnabled = true;
+let mockNotificationsEnabled = false;
 jest.mock('config/config-utils', () => ({
   isColumnListLineageEnabled: () => mockLineageEnabled,
   getMaxLength: jest.fn(),
+  notificationsEnabled: () => mockNotificationsEnabled,
 }));
 
 describe('ColumnDetailsPanel', () => {
@@ -184,6 +187,30 @@ describe('ColumnDetailsPanel', () => {
 
         const actual = wrapper.find(ColumnDescEditableText).length;
         const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when notifications are not enabled', () => {
+      it('should not render the request description text', () => {
+        mockNotificationsEnabled = false;
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(RequestDescriptionText).length;
+        const expected = 0;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when notifications are enabled', () => {
+      it('should render the request description text', () => {
+        mockNotificationsEnabled = true;
+        const { wrapper } = setup();
+
+        const actual = wrapper.find(RequestDescriptionText).length;
+        const expected = 1;
 
         expect(actual).toEqual(expected);
       });

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.tsx
@@ -9,9 +9,15 @@ import ColumnLineage from 'features/ColumnList/ColumnLineage';
 import ColumnStats from 'features/ColumnList/ColumnStats';
 import ExpandableUniqueValues from 'features/ExpandableUniqueValues';
 import { FormattedDataType } from 'interfaces/ColumnList';
-import { getMaxLength, isColumnListLineageEnabled } from 'config/config-utils';
+import RequestDescriptionText from 'pages/TableDetailPage/RequestDescriptionText';
+import {
+  getMaxLength,
+  isColumnListLineageEnabled,
+  notificationsEnabled,
+} from 'config/config-utils';
 import { buildTableKey, getColumnLink } from 'utils/navigationUtils';
 import { filterOutUniqueValues, getUniqueValues } from 'utils/stats';
+import { RequestMetadataType } from 'interfaces/Notifications';
 import {
   COPY_COL_LINK_LABEL,
   COPY_COL_NAME_LABEL,
@@ -33,6 +39,12 @@ const shouldRenderDescription = (columnDetails: FormattedDataType) => {
     return false;
   }
   return true;
+};
+
+const getColumnNamePath = (key, tableParams) => {
+  const tableKey = buildTableKey(tableParams);
+  const columnNamePath = key.replace(tableKey + '/', '');
+  return columnNamePath;
 };
 
 const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
@@ -60,13 +72,13 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
   };
 
   const handleCopyNameClick = () => {
-    navigator.clipboard.writeText(name);
+    navigator.clipboard.writeText(getColumnNamePath(key, tableParams));
   };
 
   const handleCopyLinkClick = () => {
-    const tableKey = buildTableKey(tableParams);
-    const columnNamePath = key.replace(tableKey + '/', '');
-    navigator.clipboard.writeText(getColumnLink(tableParams, columnNamePath));
+    navigator.clipboard.writeText(
+      getColumnLink(tableParams, getColumnNamePath(key, tableParams))
+    );
   };
 
   return (
@@ -118,6 +130,14 @@ const ColumnDetailsPanel: React.FC<ColumnDetailsPanelProps> = ({
             maxLength={getMaxLength('columnDescLength')}
             value={content.description}
           />
+          <span>
+            {notificationsEnabled() && (
+              <RequestDescriptionText
+                requestMetadataType={RequestMetadataType.COLUMN_DESCRIPTION}
+                columnName={getColumnNamePath(key, tableParams)}
+              />
+            )}
+          </span>
         </EditableSection>
       )}
       {normalStats && normalStats.length > 0 && (

--- a/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
@@ -1,5 +1,3 @@
-export const MORE_BUTTON_TEXT = 'More options';
-export const REQUEST_DESCRIPTION_TEXT = 'Request Column Description';
 export const EMPTY_MESSAGE = 'There are no available columns for this table';
 export const EDITABLE_SECTION_TITLE = 'Description';
 export const COLUMN_STATS_TITLE = 'Column Statistics';
@@ -7,6 +5,5 @@ export const COLUMN_LINEAGE_LIST_SIZE = 5;
 export const COLUMN_LINEAGE_DOWNSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} Downstream Columns`;
 export const COLUMN_LINEAGE_UPSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} Upstream Columns`;
 export const COLUMN_LINEAGE_MORE_TEXT = 'See More';
-export const COPY_COLUMN_LINK_TEXT = 'Copy Column Link';
 export const HAS_COLUMN_STATS_TEXT = 'Column stats available';
 export const DELAY_SHOW_POPOVER_MS = 500;

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -20,10 +20,6 @@ import ColumnList, { ColumnListProps } from '.';
 
 jest.mock('config/config-utils');
 
-const mockedNotificationsEnabled = mocked(
-  ConfigUtils.notificationsEnabled,
-  true
-);
 const mockedGetTableSortCriterias = mocked(
   ConfigUtils.getTableSortCriterias,
   true
@@ -80,7 +76,6 @@ describe('ColumnList', () => {
       direction: SortDirection.descending,
     },
   });
-  mockedNotificationsEnabled.mockReturnValue(true);
 
   describe('render', () => {
     it('renders without issues', () => {
@@ -134,14 +129,6 @@ describe('ColumnList', () => {
         const { wrapper } = setup({ columns, hideSomeColumnMetadata: true });
         const expected = 0;
         const actual = wrapper.find('.table-detail-table .usage-value').length;
-
-        expect(actual).toEqual(expected);
-      });
-
-      it('should render the actions column', () => {
-        const { wrapper } = setup({ columns });
-        const expected = columns.length;
-        const actual = wrapper.find('.table-detail-table .actions').length;
 
         expect(actual).toEqual(expected);
       });
@@ -327,19 +314,6 @@ describe('ColumnList', () => {
 
           expect(actual).toEqual(expected);
         });
-      });
-    });
-
-    describe('when notifications are not enabled', () => {
-      const { columns } = dataBuilder.build();
-
-      it('should not render the actions column', () => {
-        mockedNotificationsEnabled.mockReturnValue(false);
-        const { wrapper } = setup({ columns });
-        const expected = 0;
-        const actual = wrapper.find('.table-detail-table .actions').length;
-
-        expect(actual).toEqual(expected);
       });
     });
 

--- a/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
@@ -24,46 +24,6 @@ $nested-column-row-color: $gray5;
 .table-detail-table {
   margin-bottom: 0;
 
-  .ams-table-body .actions .column-dropdown {
-    &.open {
-      background-color: $body-bg-tertiary;
-
-      .icon {
-        background-color: $icon-bg-dark;
-      }
-    }
-
-    .dropdown-toggle {
-      border: none;
-      border-radius: 4px;
-      height: 32px;
-      padding: 4px;
-      width: 32px;
-
-      &.is-nested-column-row {
-        background-color: $nested-column-row-color;
-      }
-
-      .icon {
-        background-color: $icon-bg;
-        height: 22px;
-        margin: 0;
-        -webkit-mask-size: 22px;
-        mask-size: 22px;
-        width: 22px;
-      }
-
-      &:hover,
-      &:focus {
-        background-color: $body-bg-secondary;
-
-        .icon {
-          background-color: $icon-bg-dark;
-        }
-      }
-    }
-  }
-
   .nesting-arrow-spacer {
     height: $nested-arrow-spacer;
     width: $nested-arrow-spacer-max;

--- a/frontend/amundsen_application/static/js/interfaces/ColumnList.ts
+++ b/frontend/amundsen_application/static/js/interfaces/ColumnList.ts
@@ -22,17 +22,12 @@ type DatatypeType = {
   type: string;
 };
 
-type ActionType = {
-  isActionEnabled: boolean;
-};
-
 export type FormattedDataType = {
   content: ContentType;
   type: DatatypeType;
   usage: number | null;
   stats: TableColumnStats[] | null;
   children: TableColumn[] | TypeMetadata[];
-  action: ActionType;
   editText: string | null;
   editUrl: string | null;
   index: number;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/RequestDescriptionText/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/RequestDescriptionText/index.spec.tsx
@@ -5,22 +5,22 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import globalState from 'fixtures/globalState';
 import { RequestMetadataType } from 'interfaces';
+import { REQUEST_DESCRIPTION } from './constants';
 import {
   RequestDescriptionText,
   mapDispatchToProps,
   RequestDescriptionTextProps,
 } from '.';
-import { REQUEST_DESCRIPTION } from './constants';
 
 describe('RequestDescriptionText', () => {
   const setup = (propOverrides?: Partial<RequestDescriptionTextProps>) => {
     const props: RequestDescriptionTextProps = {
+      requestMetadataType: RequestMetadataType.TABLE_DESCRIPTION,
       openRequestDescriptionDialog: jest.fn(),
       ...propOverrides,
     };
-    const wrapper = shallow<RequestDescriptionText>(
+    const wrapper = shallow<typeof RequestDescriptionText>(
       // eslint-disable-next-line react/jsx-props-no-spreading
       <RequestDescriptionText {...props} />
     );
@@ -28,23 +28,40 @@ describe('RequestDescriptionText', () => {
   };
 
   describe('openRequest', () => {
-    it('calls openRequestDescriptionDialog', () => {
+    it('calls openRequestDescriptionDialog for a table', () => {
       const { props, wrapper } = setup();
       const openRequestDescriptionDialogSpy = jest.spyOn(
         props,
         'openRequestDescriptionDialog'
       );
-      wrapper.instance().openRequest();
+      wrapper.find('.request-description').simulate('click');
       expect(openRequestDescriptionDialogSpy).toHaveBeenCalledWith(
-        RequestMetadataType.TABLE_DESCRIPTION
+        RequestMetadataType.TABLE_DESCRIPTION,
+        undefined
+      );
+    });
+
+    it('calls openRequestDescriptionDialog for a column', () => {
+      const columnName = 'column';
+      const { props, wrapper } = setup({
+        requestMetadataType: RequestMetadataType.COLUMN_DESCRIPTION,
+        columnName,
+      });
+      const openRequestDescriptionDialogSpy = jest.spyOn(
+        props,
+        'openRequestDescriptionDialog'
+      );
+      wrapper.find('.request-description').simulate('click');
+      expect(openRequestDescriptionDialogSpy).toHaveBeenCalledWith(
+        RequestMetadataType.COLUMN_DESCRIPTION,
+        columnName
       );
     });
   });
 
   describe('render', () => {
     it('renders Request Description button with correct text', () => {
-      const { props, wrapper } = setup();
-      wrapper.instance().render();
+      const { wrapper } = setup();
       expect(wrapper.find('.request-description').text()).toEqual(
         REQUEST_DESCRIPTION
       );

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/RequestDescriptionText/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/RequestDescriptionText/index.tsx
@@ -10,40 +10,40 @@ import { bindActionCreators } from 'redux';
 import { RequestMetadataType } from 'interfaces';
 import { REQUEST_DESCRIPTION } from './constants';
 
+export interface RequestDescriptionTextOwnProps {
+  requestMetadataType: RequestMetadataType;
+  columnName?: string;
+}
+
 export interface DispatchFromProps {
   openRequestDescriptionDialog: (
-    requestMetadataType: RequestMetadataType
+    requestMetadataType: RequestMetadataType,
+    columnName?: string
   ) => OpenRequestAction;
 }
 
-export type RequestDescriptionTextProps = DispatchFromProps;
+export type RequestDescriptionTextProps = RequestDescriptionTextOwnProps &
+  DispatchFromProps;
 
-interface RequestDescriptionTextState {}
-
-export class RequestDescriptionText extends React.Component<
-  RequestDescriptionTextProps,
-  RequestDescriptionTextState
-> {
-  public static defaultProps: Partial<RequestDescriptionTextProps> = {};
-
-  openRequest = () => {
-    this.props.openRequestDescriptionDialog(
-      RequestMetadataType.TABLE_DESCRIPTION
-    );
+export const RequestDescriptionText: React.FC<RequestDescriptionTextProps> = ({
+  requestMetadataType,
+  columnName,
+  openRequestDescriptionDialog,
+}) => {
+  const openRequest = () => {
+    openRequestDescriptionDialog(requestMetadataType, columnName);
   };
 
-  render() {
-    return (
-      <a
-        className="request-description body-link"
-        href="JavaScript:void(0)"
-        onClick={this.openRequest}
-      >
-        {REQUEST_DESCRIPTION}
-      </a>
-    );
-  }
-}
+  return (
+    <a
+      className="request-description body-link"
+      href="JavaScript:void(0)"
+      onClick={openRequest}
+    >
+      {REQUEST_DESCRIPTION}
+    </a>
+  );
+};
 
 export const mapDispatchToProps = (dispatch: any) =>
   bindActionCreators({ openRequestDescriptionDialog }, dispatch);

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -353,7 +353,6 @@ export class TableDetail extends React.Component<
       isLoadingDashboards,
       numRelatedDashboards,
       tableData,
-      openRequestDescriptionDialog,
       tableLineage,
     } = this.props;
     const {
@@ -375,7 +374,6 @@ export class TableDetail extends React.Component<
     tabInfo.push({
       content: (
         <ColumnList
-          openRequestDescriptionDialog={openRequestDescriptionDialog}
           columns={tableData.columns}
           database={tableData.database}
           tableParams={tableParams}
@@ -641,7 +639,13 @@ export class TableDetail extends React.Component<
                   editable={data.is_editable}
                 />
                 <span>
-                  {notificationsEnabled() && <RequestDescriptionText />}
+                  {notificationsEnabled() && (
+                    <RequestDescriptionText
+                      requestMetadataType={
+                        RequestMetadataType.TABLE_DESCRIPTION
+                      }
+                    />
+                  )}
                 </span>
               </EditableSection>
               {issueTrackingEnabled() && (


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

- Added clickable rows to Table Detail Page to allow users to expand the right side panel by clicking on the row instead of only the column name, and included a hover box shadow that matches the same effect used on the dashboard page
- The active row that has been clicked is now indigo rather than dark gray to differentiate more from nested column rows
- Use new tree structure arrow icons that point right when a row is collapsed and down when a row is expanded
- Added the `Request Description` link to the right side panel and removed the action column from the main table since it was now redundant
- Fixed the `Copy column name` button in the right side panel to copy the whole column name path rather than only the name itself to be more useful

Rows all expanded:
![Screen Shot 2022-06-10 at 10 52 44 AM](https://user-images.githubusercontent.com/6732445/173144945-a504d873-0a3e-420e-87c5-91569ec92058.png)

Rows collapsed:
![Screen Shot 2022-06-10 at 10 54 57 AM](https://user-images.githubusercontent.com/6732445/173144984-c5c4b3a5-935f-4bab-b09e-ef945ed91d18.png)

### Tests

- Added tests for clickable rows in the table component
- Added tests for the `Request Description` link in the side panel
- Removed tests around the action buttons column since that no longer exists
- Changed the `RequestDescriptionText` component to accept props, so updated the tests to reflect that

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
