### PR TITLE
feat: added addition fields config to publisher

### DIFF
--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -150,12 +150,8 @@ class Neo4jCsvPublisher(Publisher):
             else neo4j.TRUST_ALL_CERTIFICATES
         self._driver = \
             GraphDatabase.driver(conf.get_string(NEO4J_END_POINT_KEY),
-                                 max_connection_life_time=conf.get_int(
-                                     NEO4J_MAX_CONN_LIFE_TIME_SEC
-                                 ),
-                                 auth=(
-                                     conf.get_string(NEO4J_USER), conf.get_string(NEO4J_PASSWORD)
-                                 ),
+                                 max_connection_life_time=conf.get_int(NEO4J_MAX_CONN_LIFE_TIME_SEC),
+                                 auth=(conf.get_string(NEO4J_USER), conf.get_string(NEO4J_PASSWORD)),
                                  encrypted=conf.get_bool(NEO4J_ENCRYPTED),
                                  trust=trust)
         self._transaction_size = conf.get_int(NEO4J_TRANSACTION_SIZE)

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -421,7 +421,7 @@ class Neo4jCsvPublisher(Publisher):
 
         # add additional metatada fields from config
         for k, v in self.additional_fields.items():
-            val = v if type(v) == int or type(v) == float else f"'{v}'"
+            val = v if isinstance(v, int) or isinstance(v, float) else f"'{v}'"
             props.append(f"{identifier}.{k}= {val}")
 
         return ', '.join(props)

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -8,7 +8,9 @@ import time
 from io import open
 from os import listdir
 from os.path import isfile, join
-from typing import Dict, List, Set
+from typing import (
+    Dict, List, Set,
+)
 
 import neo4j
 import pandas

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -107,6 +107,7 @@ DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_TRANSACTION_SIZE: 500,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50,
                                           NEO4J_ENCRYPTED: True,
                                           NEO4J_VALIDATE_SSL: False,
+                                          JOB_PUBLISHED_BY: None,
                                           ADD_PUBLISHER_METADATA: True,
                                           RELATION_PREPROCESSOR: NoopRelationPreprocessor()})
 

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -56,9 +56,13 @@ NEO4J_VALIDATE_SSL = 'neo4j_validate_ssl'
 
 # This will be used to provide unique tag to the node and relationship
 JOB_PUBLISH_TAG = 'job_publish_tag'
+JOB_PUBLISHED_BY = 'job_published_by'
 
 # Neo4j property name for published tag
 PUBLISHED_TAG_PROPERTY_NAME = 'published_tag'
+
+# Neo4j property name for publishing job id or name
+PUBLISHED_BY_PROPERTY_NAME = 'published_by'
 
 # Neo4j property name for last updated timestamp
 LAST_UPDATED_EPOCH_MS = 'publisher_last_updated_epoch_ms'
@@ -156,6 +160,7 @@ class Neo4jCsvPublisher(Publisher):
         self.deadlock_node_labels = set(conf.get_list(NEO4J_DEADLOCK_NODE_LABELS, default=[]))
         self.labels: Set[str] = set()
         self.publish_tag: str = conf.get_string(JOB_PUBLISH_TAG)
+        self.published_by: str = conf.get_string(JOB_PUBLISHED_BY)
         self.add_publisher_metadata: bool = conf.get_bool(ADD_PUBLISHER_METADATA)
         if self.add_publisher_metadata and not self.publish_tag:
             raise Exception(f'{JOB_PUBLISH_TAG} should not be empty')
@@ -413,6 +418,9 @@ class Neo4jCsvPublisher(Publisher):
         if self.add_publisher_metadata:
             props.append(f"{identifier}.{PUBLISHED_TAG_PROPERTY_NAME} = '{self.publish_tag}'")
             props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
+            if self.published_by:
+                # add optional metadata with information about the job publishing this node/relationship
+                props.append(f"{identifier}.{PUBLISHED_BY_PROPERTY_NAME} = {self.published_by}")
 
         return ', '.join(props)
 

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -421,7 +421,7 @@ class Neo4jCsvPublisher(Publisher):
             props.append(f"{identifier}.{LAST_UPDATED_EPOCH_MS} = timestamp()")
             if self.published_by:
                 # add optional metadata with information about the job publishing this node/relationship
-                props.append(f"{identifier}.{PUBLISHED_BY_PROPERTY_NAME} = {self.published_by}")
+                props.append(f"{identifier}.{PUBLISHED_BY_PROPERTY_NAME} = '{self.published_by}'")
 
         return ', '.join(props)
 

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '6.8.0'
+__version__ = '6.9.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -8,15 +8,13 @@ from setuptools import find_packages, setup
 __version__ = '6.9.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                 'r',
                                  'requirements.txt')
-with open(requirements_path) as requirements_file:
+with open(requirements_path, 'r') as requirements_file:
     requirements = requirements_file.readlines()
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                 'r',
                                  'requirements-dev.txt')
-with open(requirements_path) as requirements_file:
+with open(requirements_path, 'r') as requirements_file:
     requirements_dev = requirements_file.readlines()
 
 kafka = ['confluent-kafka==1.0.0']

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -1,16 +1,21 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
+
 import os
 
 from setuptools import find_packages, setup
 
 __version__ = '6.9.0'
 
-requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
+requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                 'r',
+                                 'requirements.txt')
 with open(requirements_path) as requirements_file:
     requirements = requirements_file.readlines()
 
-requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')
+requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                 'r',
+                                 'requirements-dev.txt')
 with open(requirements_path) as requirements_file:
     requirements_dev = requirements_file.readlines()
 
@@ -93,7 +98,8 @@ teradata = [
 ]
 
 all_deps = requirements + requirements_dev + kafka + cassandra + glue + snowflake + athena + \
-    bigquery + jsonpath + db2 + dremio + druid + spark + feast + neptune + rds + atlas + salesforce + oracle + teradata
+    bigquery + jsonpath + db2 + dremio + druid + spark + feast + neptune + rds \
+    + atlas + salesforce + oracle + teradata
 
 setup(
     name='amundsen-databuilder',


### PR DESCRIPTION
Added optional `additional_fields` property to publisher so we can add additional metadata about the publishing job to a node, like an airflow execution ID or name.