### PR TITLE
feat and perf: Add support for Multiple Programmatic Descriptions and Table level Badges

### DIFF
--- a/databuilder/databuilder/models/table_metadata.py
+++ b/databuilder/databuilder/models/table_metadata.py
@@ -697,8 +697,8 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
             pd_node_key = self._get_table_description_key(pd_node)
             yield RDSTableProgrammaticDescription(
                 rk=pd_node_key,
-                description_source=pd_node.source, # TODO: error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "source"
-                description=pd_node.text, # TODO error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "text"
+                description_source=pd_node.source,
+                description=pd_node.text,
                 table_rk=self._get_table_key()
             )
 

--- a/databuilder/databuilder/models/table_metadata.py
+++ b/databuilder/databuilder/models/table_metadata.py
@@ -404,6 +404,13 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
         # self.programmatic_descriptions is a LIST of DescriptionMetadata
         for pd_node in self.programmatic_descriptions:
             # Therefore, `pd_node` is the "equivalent" of `self.description` from above
+            # TODO
+            """
+            Argument 1 to "_get_table_description_key" of "TableMetadata" has incompatible type
+            "Optional[DescriptionMetadata]"; expected "DescriptionMetadata"
+
+            error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "get_node"
+            """
             pd_node_key = self._get_table_description_key(pd_node)
             yield pd_node.get_node(pd_node_key)
 
@@ -526,10 +533,20 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
                                                 self._get_table_description_key(self.description))
 
         # for each programmatic description, create relations
+        # TODO
+        """
+        error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "get_relation"
+        """
         for pd_node in self.programmatic_descriptions:
             yield pd_node.get_relation(TableMetadata.TABLE_NODE_LABEL,
                                        self._get_table_key(),
                                        self._get_table_description_key(pd_node))
+            # TODO
+            """
+            Argument 1 to "_get_table_description_key" of "TableMetadata" has
+            incompatible type "Optional[DescriptionMetadata]";
+            expected "DescriptionMetadata"
+            """
 
         # relations for tags
         if self.tags:
@@ -672,11 +689,16 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
 
         # Multiple programmatic table descriptions
         for pd_node in self.programmatic_descriptions:
+            # TODO
+            """
+            error: Argument 1 to "_get_table_description_key" of "TableMetadata" has incompatible type
+            "Optional[DescriptionMetadata]"; expected "DescriptionMetadata"
+            """
             pd_node_key = self._get_table_description_key(pd_node)
             yield RDSTableProgrammaticDescription(
                 rk=pd_node_key,
-                description_source=pd_node.source,
-                description=pd_node.text,
+                description_source=pd_node.source, # TODO: error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "source"
+                description=pd_node.text, # TODO error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "text"
                 table_rk=self._get_table_key()
             )
 

--- a/databuilder/databuilder/models/table_metadata.py
+++ b/databuilder/databuilder/models/table_metadata.py
@@ -697,8 +697,8 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
             pd_node_key = self._get_table_description_key(pd_node)
             yield RDSTableProgrammaticDescription(
                 rk=pd_node_key,
-                description_source=pd_node.source,
-                description=pd_node.text,
+                description_source=pd_node.source, # TODO: error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "source"
+                description=pd_node.text, # TODO error: Item "None" of "Optional[DescriptionMetadata]" has no attribute "text"
                 table_rk=self._get_table_key()
             )
 

--- a/databuilder/example/scripts/sample_base_postgres_metadata_extractor.py
+++ b/databuilder/example/scripts/sample_base_postgres_metadata_extractor.py
@@ -1,6 +1,9 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+# A modified version of `base_postgres_metadata_extractor` as an example of new changes
+# The examples provided are for illustrative purposes only and will differ from the actual use case
+
 import abc
 import logging
 from collections import namedtuple
@@ -82,26 +85,67 @@ class BasePostgresMetadataExtractor(Extractor):
         :return:
         """
         for _, group in groupby(self._get_raw_extract_iter(), self._get_table_key):
+            # columns is a list of ColumnMetadata values
             columns = []
 
+            # each row in group represents a row in the returned SQL query.
+            # you can adjust the query to bring in more information and access it
+            # as a dictionary i.e row['some_new_column']
             for row in group:
                 last_row = row
+
+                column_badges = []
+                # Example 1: Partition Column i.e par_region
+                if 'par_' in row['col_name']:
+                    column_badges.append('Partition Column')
+
+                # Example 2: Let's say column description contains the sensitivity or PII information
+                if 'sensitivitiy' in row['col_description'].casefold():
+                    column_badges.append("Contains PII")
+
+                # Example 3: Let's say this column is a business date key or equivalent
+                if '_date' in row['col_name'] or '_time' in row['col_name']:
+                    column_badges.append("Business Date Key")
+
                 columns.append(
                     ColumnMetadata(
                         name=row['col_name'],
                         description=row['col_description'],
                         col_type=row['col_type'],
-                        sort_order=row['col_sort_order']
+                        sort_order=row['col_sort_order'],
+                        badges=column_badges
                     )
                 )
 
+            # set up table tags and badges
+            table_badges = []  # will be title-cased in the front end
+            table_tags = []  # must be _ seperated
+            # Example 1: Grab the table type i.e EXTERNAL, PHYSICAL, or VIEW assuming you bring this info in
+            if last_row['table_type']:
+                table_badges.append(last_row['table_type'])
+                # i.e "PHYSICAL TABLE" -> "physical_table" for the tag
+                table_tags.append(last_row['table_type'].replace(" ", "_"))
+
+            # new feature: set up programmatic descriptions to appear
+            programmatic_descs = {
+                "Table Information": "Insert some description here that can be derived from a column",
+                "Example Desc": f"This object is a {last_row['table_type']}.",  # i.e "this object is a view"
+                "Example Desc 2": "To ask questions about this table, please reach out to "
+                                  "[some_support_url](insert_some_url_here)"
+            }
+
             yield TableMetadata(
-                database=self._database,
-                cluster=last_row['cluster'],
+                database=self._database,  # the database that the metadata comes from -> postgres
+                cluster=last_row['cluster'],  # the database that the data comes from
                 schema=last_row['schema'],
                 name=last_row['name'],
+                columns=columns,
+                # The default `description_source` is "description" which is the Amundsen UI description field.
+                # The programmatic ones added as non-editable heading/texts in the UI.
                 description=last_row['description'],
-                columns=columns
+                tags=table_tags,
+                badges=table_badges,
+                programmatic_descriptions=programmatic_descs
             )
 
     def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:


### PR DESCRIPTION
### Summary of Changes

Hey team, thanks for reviewing this PR! This is a newer PR with the correct sign-off.

The motivation originates from https://github.com/amundsen-io/amundsen/discussions/1828 which makes the original code quite convoluted and creates duplicated nodes/records. However, with https://github.com/amundsen-io/amundsen/pull/1877 being an epic speed-up to the original `Neo4JCSV` process (hopefully the PR is merged soon), the original naive method of duplicating `TableMetadata` for multiple programmatic descriptions **does not work**.

The changes here aim to mitigate this issue and allow multiple programmatic descriptions to be added **and** also benefit from the significantly reduced runtime using `APOC`.

Change Log:
- Added support Table level Badges
- Added support for multiple programmatic descriptions to reduce duplicate calls to `TableMetadata`
- Added a sample script under `example/scripts/sample_base_postgres_metadata_extractor` for examples
- Added some extra comments that I felt were useful when reading through the code (they were quite sparse)
- In future, it may be worth deprecating the `is_view` flag and use the new `badges` argument instead (as its generalised). We've removed the flag from our prod instance without issues.

Example Changes:
(all sensitive info has been removed)
- Table Badges
<img width="839" alt="image" src="https://user-images.githubusercontent.com/30443254/173512465-f0023359-c241-4a5c-b0cb-10891c6b7f27.png">

- Programmatic Descriptions
<img width="390" alt="image" src="https://user-images.githubusercontent.com/30443254/173513763-2826e326-3e7c-43a6-a662-0a48628e44fc.png">


### Tests
The code has been tested and deployed in our prod environment and I am more than happy to have a quick knowledge share on my changes / tests. This consists of over 40 thousand tables and 500,000 thousand columns.

However testing from the core repo side **would be appreciated** as our Amundsen is **greatly modified** and as such, our environment will not capture all test cases.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
