### PR TITLE
fix: Updating tour feature to store wildcard path instead of the url path

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -643,7 +643,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:214507318": [
+    "js/pages/TableDetailPage/index.tsx:3141476111": [
       [161, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
       [209, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -498,11 +498,15 @@ export function getMaxNestedColumns() {
 /**
  * Returns the configuration for the Product Tour
  */
-export function getProductToursFor(path: string): TourConfig[] | null {
+export function getProductToursFor(
+  path: string
+): { result: TourConfig[] | null; tourPath: string } {
   let result: TourConfig[] | null = null;
+  let tourPath: string = '';
 
   if (AppConfig.productTour[path] && AppConfig.productTour[path].length) {
     result = AppConfig.productTour[path];
+    tourPath = path;
   }
 
   const wildcardPathKeys = Object.keys(AppConfig.productTour).filter(
@@ -514,11 +518,12 @@ export function getProductToursFor(path: string): TourConfig[] | null {
 
       if (path.startsWith(decomposedKey)) {
         result = AppConfig.productTour[key];
+        tourPath = key;
       }
     });
   }
 
-  return result;
+  return { result, tourPath };
 }
 
 export function searchHighlightingEnabled(resource: ResourceType): boolean {

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -853,7 +853,7 @@ describe('getProductToursFor', () => {
           },
         ],
       };
-      const actual = ConfigUtils.getProductToursFor('/');
+      const { result: actual } = ConfigUtils.getProductToursFor('/');
       const expected = AppConfig.productTour['/'];
 
       expect(actual).toBe(expected);
@@ -879,7 +879,7 @@ describe('getProductToursFor', () => {
           },
         ],
       };
-      const actual = ConfigUtils.getProductToursFor(
+      const { result: actual } = ConfigUtils.getProductToursFor(
         '/table_detail/gold/hive/core/test_table'
       );
       const expected = AppConfig.productTour['/table_detail/*'];

--- a/frontend/amundsen_application/static/js/features/NavBar/index.tsx
+++ b/frontend/amundsen_application/static/js/features/NavBar/index.tsx
@@ -127,26 +127,30 @@ const generateKeyFromSteps = (tourSteps: TourConfig[], pathname: string) =>
     : false;
 
 const getPageTourInfo = (pathname) => {
-  const productToursForThisPage = getProductToursFor(pathname);
+  const { result: productToursForThisPage, tourPath } = getProductToursFor(
+    pathname
+  );
   const pageTours = productToursForThisPage
     ? productToursForThisPage.reduce(reduceToPageTours, [])
     : [];
   const pageTourSteps = pageTours.length ? pageTours[0].steps : [];
   const pageTourKey =
-    generateKeyFromSteps(pageTours, pathname) || DEFAULT_PAGE_TOUR_KEY;
+    generateKeyFromSteps(pageTours, tourPath) || DEFAULT_PAGE_TOUR_KEY;
   const hasPageTour = productToursForThisPage ? !!pageTours.length : false;
 
   return { hasPageTour, pageTourKey, pageTourSteps };
 };
 
 const getFeatureTourInfo = (pathname) => {
-  const productToursForThisPage = getProductToursFor(pathname);
+  const { result: productToursForThisPage, tourPath } = getProductToursFor(
+    pathname
+  );
   const featureTours = productToursForThisPage
     ? productToursForThisPage.reduce(reduceToFeatureTours, [])
     : [];
   const featureTourSteps = featureTours.length ? featureTours[0].steps : [];
   const featureTourKey =
-    generateKeyFromSteps(featureTours, pathname) || DEFAULT_FEATURE_TOUR_KEY;
+    generateKeyFromSteps(featureTours, tourPath) || DEFAULT_FEATURE_TOUR_KEY;
   const hasFeatureTour = productToursForThisPage
     ? !!featureTourSteps.length
     : false;


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Previously, if you configured a product/feature tour by using a wildcard path, the actual path of the page you visited would be stored rather than with the wildcard. This resulted in the tour showing up for every new page you visited under the wildcard. This change stores the actual configured path so that if wildcards are used, it will only show the tour on the first page you visit.

### Tests

Updated tests to handle the change to the return value of `getProductToursFor`

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
