### PR TITLE
fix: Fixing column description markdown to handle more multiline cases

### DIFF
--- a/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
+++ b/frontend/amundsen_application/static/js/features/ColumnList/constants.ts
@@ -7,4 +7,5 @@ export const COLUMN_LINEAGE_UPSTREAM_TITLE = `Top ${COLUMN_LINEAGE_LIST_SIZE} Up
 export const COLUMN_LINEAGE_MORE_TEXT = 'See More';
 export const HAS_COLUMN_STATS_TEXT = 'Column stats available';
 export const DELAY_SHOW_POPOVER_MS = 500;
-export const BREAK_MARKDOWN_TYPE = 'break';
+export const BLOCKQUOTE_MARKDOWN_TYPE = 'blockquote';
+export const LIST_MARKDOWN_TYPE = 'list';

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -34,9 +34,10 @@ import { GraphIcon } from 'components/SVGIcons/GraphIcon';
 
 import ColumnType from './ColumnType';
 import {
-  BREAK_MARKDOWN_TYPE,
+  BLOCKQUOTE_MARKDOWN_TYPE,
   EMPTY_MESSAGE,
   HAS_COLUMN_STATS_TEXT,
+  LIST_MARKDOWN_TYPE,
 } from './constants';
 
 import './styles.scss';
@@ -265,7 +266,8 @@ const ColumnList: React.FC<ColumnListProps> = ({
               </div>
               <ReactMarkdown
                 className="column-desc"
-                disallowedTypes={[BREAK_MARKDOWN_TYPE]}
+                disallowedTypes={[BLOCKQUOTE_MARKDOWN_TYPE, LIST_MARKDOWN_TYPE]}
+                unwrapDisallowed
               >
                 {description}
               </ReactMarkdown>

--- a/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
+++ b/frontend/amundsen_application/static/js/features/ColumnList/styles.scss
@@ -7,6 +7,7 @@
 $description-max-width: 650px;
 $description-max-width-med: 450px;
 $description-max-width-small: 300px;
+$description-max-height: 18px;
 $nested-arrow-spacer: 24px;
 $nested-arrow-spacer-max: $nested-arrow-spacer * 4;
 $nested-column-row-color: $gray5;
@@ -80,21 +81,26 @@ $nested-column-row-color: $gray5;
     white-space: normal;
   }
 
-  .column-desc p {
-    @extend %text-body-w3;
+  .column-desc {
+    max-height: $description-max-height;
+    overflow-y: hidden;
 
-    margin: 0;
-    max-width: $description-max-width-small;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    p {
+      @extend %text-body-w3;
 
-    @media (min-width: $screen-md-max) {
-      max-width: $description-max-width-med;
-    }
+      margin: 0;
+      max-width: $description-max-width-small;
+      white-space: nowrap;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
 
-    @media (min-width: $screen-lg-max) {
-      max-width: $description-max-width;
+      @media (min-width: $screen-md-max) {
+        max-width: $description-max-width-med;
+      }
+
+      @media (min-width: $screen-lg-max) {
+        max-width: $description-max-width;
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Fixing the truncated column description shown in the table detail page to better handle various multiline options. This change limits the max height of the area to only show one line of text. This also does special handling for `blockquote` and `list` since the text for those would otherwise display a blank preview, since their first line is pushed down slightly.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
