### PR TITLE
feat: add get_lineage support for neptune backend

### DIFF
--- a/metadata/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata/metadata_service/proxy/gremlin_proxy.py
@@ -46,12 +46,12 @@ from gremlin_python.process.graph_traversal import (GraphTraversal,
                                                     constant, has, inE, inV,
                                                     outE, outV, select, unfold,
                                                     valueMap, values)
-from gremlin_python.structure.graph import Path
 from gremlin_python.process.traversal import Cardinality
 from gremlin_python.process.traversal import Column as MapColumn
 from gremlin_python.process.traversal import (Direction, Order, P, T, TextP,
                                               Traversal, gte, not_, within,
                                               without)
+from gremlin_python.structure.graph import Path
 from neptune_python_utils.gremlin_utils import ExtendedGraphSONSerializersV3d0
 from overrides import overrides
 from tornado import httpclient
@@ -1813,8 +1813,8 @@ class AbstractGremlinProxy(BaseProxy):
             paths.append(('upstream', self.query_executor()(query=upstream_query, get=FromResultSet.toList)))
             paths.append(('downstream', self.query_executor()(query=downstream_query, get=FromResultSet.toList)))
 
-        downstream_tables = []
-        upstream_tables = []
+        downstream_tables: List[LineageItem] = []
+        upstream_tables: List[LineageItem] = []
         for type_, path_list in paths:
             if path_list == []:
                 continue


### PR DESCRIPTION
### Summary of Changes

Currently, using AWS Neptune as the backend, the get_lienage function is not implemented at the `NeptuneGremlinProxy`,  `AbstractGremlinProxy` and `BaseProxy`, which means that the lineage graph & the frontend tab displaying lineage does not work properly due to the missing implementation. For details, you can refer to this chat : 

https://amundsenworkspace.slack.com/archives/C01A87A5EUU/p1653483057967299?thread_ts=1653374819.089879&cid=C01A87A5EUU

Hence, this PR attempts to create such functionality so that lineage works fine using Neptune as backend.

### Tests

I tested the code using my company's aws environment (which uses AWS neptune & opensearch as the backend) and it worked fine.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
