### PR TITLE
docs: Improves the frontend documentation on announcements 

### DIFF
--- a/frontend/amundsen_application/static/js/config/config-custom.ts
+++ b/frontend/amundsen_application/static/js/config/config-custom.ts
@@ -34,6 +34,9 @@ const configCustom: AppConfigCustom = {
       inputHint: '',
     },
   },
+  announcements: {
+    enabled: false,
+  },
   productTour: {},
 };
 

--- a/frontend/docs/application_config.md
+++ b/frontend/docs/application_config.md
@@ -1,6 +1,6 @@
 # Application configuration
 
-This document describes how to leverage the frontend service's application configuration to configure particular features. After modifying the `AppConfigCustom` object in [config-custom.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-custom.ts) in the ways described in this document, be sure to rebuild your application with these changes.
+This document describes how to leverage the frontend service's application configuration to configure particular features. After modifying the `AppConfigCustom` object in [config-custom.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-custom.ts) in the ways described in this document, be sure to rebuild your application with these changes. All default config values are set in [config-default.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-default.ts) file.
 
 **NOTE: This document is a work in progress and does not include 100% of features. We welcome PRs to complete this document**
 
@@ -14,6 +14,8 @@ Annoncements is a feature that allows to disclose new features, changes or any o
 </figure>
 
 To enable this feature, change the `announcements.enabled` boolean value by overriding it on [config-custom.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-custom.ts). Once activated, an "Announcements" link will be available in the global navigation, and a new list of announcements will show up on the right sidebar on the Homepage.
+
+Refer to [announcement_client.md](https://github.com/amundsen-io/amundsenfrontendlibrary/blob/master/docs/examples/announcement_client.md) for information about fetching announcements.
 
 ## Badge Config
 

--- a/frontend/docs/application_config.md
+++ b/frontend/docs/application_config.md
@@ -13,7 +13,7 @@ Annoncements is a feature that allows to disclose new features, changes or any o
   <figcaption>Announcements in the homepage</figcaption>
 </figure>
 
-To enable this feature, change the `announcements.enable` boolean value by overriding it on [config-custom.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-custom.ts). Once activated, an "Announcements" link will be available in the global navigation, and a new list of announcements will show up on the right sidebar on the Homepage.
+To enable this feature, change the `announcements.enabled` boolean value by overriding it on [config-custom.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-custom.ts). Once activated, an "Announcements" link will be available in the global navigation, and a new list of announcements will show up on the right sidebar on the Homepage.
 
 ## Badge Config
 


### PR DESCRIPTION
### Summary of Changes
- Added default value for `announcements.enabled` to custom config to increase verbosity
- Fixed wrong object name (typo) in the documentation
- Added information about `config-default.ts` file to docs
- Added information about `announcement_client.md` README

### Tests
I've checked that announcements are disabled when the variable added to `custom-config.ts` is set to false and that setting it to true enables the feature. No new automated tests are needed IMO.

### Documentation

Described above

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
