### PR TITLE
feat: Sticky TabsComponent and Table headers

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -643,9 +643,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:3141476111": [
-      [161, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
-      [209, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:3807553113": [
+      [162, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
+      [215, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -10,7 +10,6 @@ $screen-lg-container: 1440px;
 $header-link-height: 32px;
 $icon-header-size: 32px;
 $inner-column-size: 175px;
-$side-panel-size: 425px;
 $close-btn-size: 24px;
 
 .resource-detail-layout {
@@ -109,7 +108,7 @@ $close-btn-size: 24px;
 
     > .left-panel {
       border-right: $spacer-half solid $divider;
-      flex-basis: $side-panel-size;
+      flex-basis: $left-panel-width;
       flex-shrink: 0;
       min-height: min-content;
       overflow-y: auto;
@@ -161,7 +160,7 @@ $close-btn-size: 24px;
 
     > .right-panel {
       border-left: $spacer-half solid $divider;
-      flex-basis: $side-panel-size;
+      flex-basis: $right-panel-width;
       flex-shrink: 0;
       min-height: min-content;
       overflow-y: auto;
@@ -216,22 +215,20 @@ $close-btn-size: 24px;
     }
 
     > .main-content-panel {
-      flex-basis: 500px;
+      flex-basis: $main-content-panel;
       flex-grow: 1;
       flex-shrink: 0;
       overflow-y: scroll;
       width: 0; // Required for text truncation
     }
 
-    @media (max-width: 1440px) {
-      > .left-panel {
-        flex-basis: 500px;
-      }
-    }
-
     @media (max-width: 1200px) {
       > .left-panel {
-        flex-basis: 415px;
+        flex-basis: $left-panel-smaller-width;
+      }
+
+      > .right-panel {
+        flex-basis: $right-panel-smaller-width;
       }
     }
   }

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -215,7 +215,7 @@ $close-btn-size: 24px;
     }
 
     > .main-content-panel {
-      flex-basis: $main-content-panel;
+      flex-basis: $main-content-panel-width;
       flex-grow: 1;
       flex-shrink: 0;
       overflow-y: scroll;

--- a/frontend/amundsen_application/static/css/_variables-default.scss
+++ b/frontend/amundsen_application/static/css/_variables-default.scss
@@ -107,6 +107,13 @@ $screen-lg-max: 1490px;
 $search-panel-width: 270px;
 $search-panel-border-width: 4px;
 
+// Layout Panels
+$main-content-panel: 500px;
+$left-panel-width: 425px;
+$right-panel-width: 425px;
+$left-panel-smaller-width: 415px;
+$right-panel-smaller-width: 415px;
+
 // List Group
 $list-group-border: $stroke !default;
 $list-group-border-radius: 0 !default;
@@ -117,6 +124,9 @@ $label-primary-bg: $brand-color-3 !default;
 //Priority
 $priority-text-blocker: $white;
 $priority-bg-color: $rose80;
+
+// Tabs
+$tab-content-margin-top: 56px;
 
 // Tags
 $tag-bg: $gray5;

--- a/frontend/amundsen_application/static/css/_variables-default.scss
+++ b/frontend/amundsen_application/static/css/_variables-default.scss
@@ -108,7 +108,7 @@ $search-panel-width: 270px;
 $search-panel-border-width: 4px;
 
 // Layout Panels
-$main-content-panel: 500px;
+$main-content-panel-width: 500px;
 $left-panel-width: 425px;
 $right-panel-width: 425px;
 $left-panel-smaller-width: 415px;

--- a/frontend/amundsen_application/static/js/components/Table/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Table/styles.scss
@@ -31,8 +31,10 @@ $selected-row-color: $indigo10;
 
   background-color: $table-header-background-color;
   color: $text-secondary;
-  border-bottom: $table-header-border-width solid
-    $table-header-bottom-border-color;
+  box-shadow: $hover-box-shadow;
+  position: sticky;
+  top: $tab-content-margin-top;
+  z-index: 5;
 }
 
 .ams-table-heading-cell {

--- a/frontend/amundsen_application/static/js/components/TabsComponent/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/TabsComponent/index.spec.tsx
@@ -39,7 +39,7 @@ describe('Tabs', () => {
     it('renders Tabs with correct props', () => {
       expect(subject.find(Tabs).props()).toMatchObject({
         id: 'tab',
-        className: 'tabs-component',
+        className: 'tabs-component ',
         defaultActiveKey: props.defaultTab,
         activeKey: props.activeKey,
         onSelect: props.onSelect,

--- a/frontend/amundsen_application/static/js/components/TabsComponent/index.tsx
+++ b/frontend/amundsen_application/static/js/components/TabsComponent/index.tsx
@@ -11,6 +11,7 @@ export interface TabsProps {
   activeKey?: string;
   defaultTab?: string;
   onSelect?: (key: string) => void;
+  isRightPanelOpen?: boolean;
 }
 
 export interface TabInfo {
@@ -24,10 +25,13 @@ const TabsComponent: React.FC<TabsProps> = ({
   activeKey,
   defaultTab,
   onSelect,
+  isRightPanelOpen,
 }: TabsProps) => (
   <Tabs
     id="tab"
-    className="tabs-component"
+    className={`tabs-component ${
+      isRightPanelOpen ? 'has-open-right-panel' : ''
+    }`}
     defaultActiveKey={defaultTab}
     activeKey={activeKey}
     onSelect={onSelect}

--- a/frontend/amundsen_application/static/js/components/TabsComponent/styles.scss
+++ b/frontend/amundsen_application/static/js/components/TabsComponent/styles.scss
@@ -6,8 +6,12 @@
 .tabs-component {
   .nav.nav-tabs {
     border-bottom: 1px solid $stroke;
-    margin-top: $spacer-2;
-    padding: 0 12px;
+    background-color: $white;
+    margin-top: 0;
+    padding: $spacer-2 $spacer-2 0 $spacer-2;
+    position: fixed;
+    width: 100%;
+    z-index: 5;
 
     > li {
       margin: 0 12px;
@@ -51,6 +55,8 @@
   }
 
   .tab-content {
+    margin-top: $tab-content-margin-top;
+
     .tab-pane {
       .list-group {
         margin-top: 0;
@@ -59,8 +65,14 @@
   }
 
   .main-content-panel & {
-    .tab-content .list-group-item:first-child {
-      border-top: none;
+    .tab-content .list-group-item {
+      &:hover {
+        z-index: 1;
+      }
+
+      &:first-child {
+        border-top: none;
+      }
     }
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
@@ -17,6 +17,8 @@ export const SORT_BY_MENU_TITLE_TEXT = 'Sort by';
 export const COLLAPSE_ALL_NESTED_LABEL = 'Collapse all nested';
 export const EXPAND_ALL_NESTED_LABEL = 'Expand all nested';
 export const ESC_BUTTON_KEY = 'Escape';
+export const MIN_WIDTH_DISPLAY_BTN = 1100;
+export const MIN_WIDTH_DISPLAY_BTN_WITH_OPEN_PANEL = 1350;
 
 export enum TABLE_TAB {
   COLUMN = 'columns',

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -238,12 +238,12 @@ export class TableDetail extends React.Component<
     const minWidth = isRightPanelOpen
       ? Constants.MIN_WIDTH_DISPLAY_BTN_WITH_OPEN_PANEL
       : Constants.MIN_WIDTH_DISPLAY_BTN;
+    let newState = { isExpandCollapseAllBtnVisible: false };
 
     if (window.matchMedia(`(min-width: ${minWidth}px)`).matches) {
-      this.setState({ isExpandCollapseAllBtnVisible: true });
-    } else {
-      this.setState({ isExpandCollapseAllBtnVisible: false });
+      newState = { isExpandCollapseAllBtnVisible: true };
     }
+    this.setState(newState);
   };
 
   getDefaultTab() {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/styles.scss
@@ -5,6 +5,15 @@
 @import 'typography';
 
 $expand-collapse-all-button-height: 32px;
+$total-panel-width: $left-panel-width + $right-panel-width;
+$base-max-width: 1350px;
+
+$width-increment: 75px;
+$width-increment-1: $width-increment;
+$width-increment-2: $width-increment * 2;
+$width-increment-3: $width-increment * 3;
+$width-increment-4: $width-increment * 4;
+$width-increment-5: $width-increment * 5;
 
 .table-detail {
   .single-column-layout .left-panel {
@@ -56,9 +65,44 @@ $expand-collapse-all-button-height: 32px;
     }
   }
 
-  .nav.nav-tabs {
-    margin-top: $spacer-2;
-    padding: 0 $spacer-2;
+  .has-open-right-panel .nav.nav-tabs {
+    width: calc(100% - #{$total-panel-width});
+  }
+
+  @media (max-width: $base-max-width) {
+    .has-open-right-panel .nav.nav-tabs {
+      width: calc(100% - #{$total-panel-width - $width-increment-1});
+    }
+  }
+
+  @media (max-width: calc(#{$base-max-width - $width-increment-1})) {
+    .has-open-right-panel .nav.nav-tabs {
+      width: calc(100% - #{$total-panel-width - $width-increment-2});
+    }
+  }
+
+  @media (max-width: calc(#{$base-max-width - $width-increment-2})) {
+    .has-open-right-panel .nav.nav-tabs {
+      width: calc(100% - #{$total-panel-width - $width-increment-3});
+    }
+  }
+
+  @media (max-width: calc(#{$base-max-width - $width-increment-3})) {
+    .has-open-right-panel .nav.nav-tabs {
+      width: calc(100% - #{$total-panel-width - $width-increment-4});
+    }
+  }
+
+  @media (max-width: calc(#{$base-max-width - $width-increment-4})) {
+    .has-open-right-panel .nav.nav-tabs {
+      width: calc(100% - #{$total-panel-width - $width-increment-5});
+    }
+  }
+
+  @media (max-width: calc(#{$base-max-width - $width-increment-5})) {
+    .has-open-right-panel .nav.nav-tabs {
+      width: 100%;
+    }
   }
 
   .tabs-component .nav.nav-tabs > li {
@@ -69,13 +113,25 @@ $expand-collapse-all-button-height: 32px;
     position: relative;
   }
 
+  .right-panel {
+    z-index: 10;
+  }
+
   .column-tab-action-buttons {
     display: flex;
     align-items: center;
     gap: $spacer-2;
-    right: $spacer-3;
-    top: $spacer-2;
-    position: absolute;
+    margin-top: $spacer-2;
+    position: fixed;
+    z-index: 6;
+
+    &.has-closed-right-panel {
+      right: $spacer-3;
+    }
+
+    &.has-open-right-panel {
+      right: calc(#{$spacer-3 + $right-panel-width});
+    }
   }
 
   .expand-collapse-all-button {


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

- Make the `TabsComponent` and the `Table` header sticky when you scroll on pages that use them
- Hide the Expand/Collapse All button in the top right of the `TableDetailPage` when the page is resized to smaller than a set width to not overflow on top of the tabs (this action is still available by clicking the arrow in the header in the top right of the table)
- Small bug fix to close the right side panel on the `TableDetailPage` if it is open when the tab is changed

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
