### PR TITLE
fix: Change TabsComponent styling to only be sticky in certain cases

### DIFF
--- a/frontend/amundsen_application/static/js/components/TabsComponent/styles.scss
+++ b/frontend/amundsen_application/static/js/components/TabsComponent/styles.scss
@@ -3,18 +3,19 @@
 
 @import 'variables';
 
+$side-spacing: 12px;
+
 .tabs-component {
   .nav.nav-tabs {
     border-bottom: 1px solid $stroke;
     background-color: $white;
-    margin-top: 0;
-    padding: $spacer-2 $spacer-2 0 $spacer-2;
-    position: fixed;
+    margin-top: $spacer-2;
+    padding: 0 $side-spacing;
     width: 100%;
     z-index: 5;
 
     > li {
-      margin: 0 12px;
+      margin: 0 $side-spacing;
 
       &.active > a {
         &,
@@ -33,7 +34,7 @@
         color: $text-secondary;
         font-size: $font-size-large;
         margin: 0;
-        padding: 8px;
+        padding: $spacer-1;
 
         &:hover {
           color: $text-primary;
@@ -55,8 +56,6 @@
   }
 
   .tab-content {
-    margin-top: $tab-content-margin-top;
-
     .tab-pane {
       .list-group {
         margin-top: 0;
@@ -65,13 +64,23 @@
   }
 
   .main-content-panel & {
-    .tab-content .list-group-item {
-      &:hover {
-        z-index: 1;
-      }
+    .nav.nav-tabs {
+      margin-top: 0;
+      padding: $spacer-2 $spacer-2 0 $spacer-2;
+      position: fixed;
+    }
 
-      &:first-child {
-        border-top: none;
+    .tab-content {
+      margin-top: $tab-content-margin-top;
+
+      .list-group-item {
+        &:hover {
+          z-index: 1;
+        }
+
+        &:first-child {
+          border-top: none;
+        }
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Changing the `TabsComponent` styling to only be sticky on pages that use scrolling tables or lists, including `TableDetailPage`, `DashboardPage`, and `FeaturePage`.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
