### PR TITLE
chore: Bump neo4j in helm chart to 3.5.26, which aligns with docker compose

### DIFF
--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -292,7 +292,7 @@ neo4j:
   image: neo4j
 
   # neo4j.imageTag -- The image tag of the neo4j container.
-  imageTag: 3.3.0
+  imageTag: 3.5.26
 
   # neo4j.initPluginsContainer -- The image used to install plugins used by neo4j.
   initPluginsContainer:
@@ -307,8 +307,8 @@ neo4j:
       - "/bin/sh"
       - "-c"
       - |
-        curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.3.0.4/apoc-3.3.0.4-all.jar -O
-        curl -L https://github.com/neo4j-contrib/neo4j-graph-algorithms/releases/download/3.3.5.0/graph-algorithms-algo-3.3.5.0.jar -O
+        curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.5.0.17/apoc-3.5.0.17-all.jar -O
+        curl -L https://github.com/neo4j-contrib/neo4j-graph-algorithms/releases/download/3.5.4.0/graph-algorithms-algo-3.5.4.0.jar -O
         curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.250/aws-java-sdk-core-1.11.250.jar -O
         curl -L https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.250/aws-java-sdk-s3-1.11.250.jar -O
         curl -L https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.4/httpclient-4.5.4.jar -O


### PR DESCRIPTION
### Summary of Changes

Bump neo4j in helm chart to 3.5.26, which aligns with docker-compose.

### Tests

This aligns with docker-compose, I believe no test is needed. This has been running in our production environment for a couple of months and it works just like before.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
