### PR TITLE
feat: Exclude stats icon if configured stat types are the only ones present

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -359,7 +359,7 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:811821585": [
+    "js/config/config-default.ts:2726844505": [
       [381, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
       [382, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],

--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -359,9 +359,9 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:4043116335": [
-      [378, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
-      [379, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
+    "js/config/config-default.ts:811821585": [
+      [381, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
+      [382, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
       [3, 0, 148, "\`.\` import should occur after import of \`./types\`", "4154971894"]
@@ -444,15 +444,15 @@ exports[`eslint`] = {
       [111, 6, 36, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3801508926"],
       [111, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"]
     ],
-    "js/features/ColumnList/ColumnType/parser.ts:2878603257": [
-      [56, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [57, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [79, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [81, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [124, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [125, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [128, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [169, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
+    "js/features/ColumnList/ColumnType/parser.ts:2432419401": [
+      [58, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [59, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [81, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [83, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [126, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
+      [127, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [130, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
+      [171, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/ExpandableUniqueValues/index.spec.tsx:2032191364": [
       [13, 0, 48, "\`./testDataBuilder\` import should occur before import of \`.\`", "3767205268"]
@@ -586,8 +586,8 @@ exports[`eslint`] = {
     "js/pages/SearchPage/SearchPanel/tests/index.spec.tsx:3928473928": [
       [25, 6, 25, "Use object destructuring.", "1230260048"]
     ],
-    "js/pages/SearchPage/constants.ts:648153442": [
-      [14, 2, 112, "Multiline support is limited to browsers supporting ES5 only.", "2645164555"]
+    "js/pages/SearchPage/constants.ts:449734368": [
+      [13, 2, 112, "Multiline support is limited to browsers supporting ES5 only.", "2645164555"]
     ],
     "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1422860355": [
       [89, 4, 25, "Must use destructuring props assignment", "1403663841"],
@@ -643,7 +643,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:3807553113": [
+    "js/pages/TableDetailPage/index.tsx:833718545": [
       [162, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
       [215, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -285,7 +285,7 @@ const configDefault: AppConfig = {
         },
       },
       stats: {
-        statTypesToExcludeForIcon: [],
+        iconNotRequiredTypes: [],
       },
       notices: {},
       searchHighlight: {

--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -284,6 +284,9 @@ const configDefault: AppConfig = {
           iconPath: '/static/images/github.png',
         },
       },
+      stats: {
+        statTypesToExcludeForIcon: [],
+      },
       notices: {},
       searchHighlight: {
         enableHighlight: true,

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -208,12 +208,12 @@ export interface NoticeType {
  * Stats configuration options
  *
  * uniqueValueTypeName - The stat type name for the unique value stat type
- * statTypesToExcludeForIcon - List of stat types where, if they are the only ones present,
+ * iconNotRequiredTypes - List of stat types where, if they are the only ones present,
  * the stats icon will not be displayed. This can be used for commonly occurring stats such as usage.
  */
 type StatsConfig = {
   uniqueValueTypeName?: string;
-  statTypesToExcludeForIcon?: string[];
+  iconNotRequiredTypes?: string[];
 };
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -206,9 +206,14 @@ export interface NoticeType {
 }
 /**
  * Stats configuration options
+ *
+ * uniqueValueTypeName - The stat type name for the unique value stat type
+ * statTypesToExcludeForIcon - List of stat types where, if they are the only ones present,
+ * the stats icon will not be displayed. This can be used for commonly occurring stats such as usage.
  */
 type StatsConfig = {
-  uniqueValueTypeName: string;
+  uniqueValueTypeName?: string;
+  statTypesToExcludeForIcon?: string[];
 };
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -171,6 +171,16 @@ export function getUniqueValueStatTypeName(): string | undefined {
     ?.uniqueValueTypeName;
 }
 
+/**
+ * Returns the list of stat types where, if they are the only ones present, the stats icon will not be displayed
+ * This can be used for commonly occurring stats such as usage
+ * @returns string[] or undefined
+ */
+export function getStatTypesToExcludeForIcon(): string[] | undefined {
+  return AppConfig.resourceConfig[ResourceType.table].stats
+    ?.statTypesToExcludeForIcon;
+}
+
 /*
  * Given a badge name, this will return a badge style and a display name.
  * If these are not specified by config, it will default to some simple rules:

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -176,9 +176,9 @@ export function getUniqueValueStatTypeName(): string | undefined {
  * This can be used for commonly occurring stats such as usage
  * @returns string[] or undefined
  */
-export function getStatTypesToExcludeForIcon(): string[] | undefined {
+export function getIconNotRequiredStatTypes(): string[] | undefined {
   return AppConfig.resourceConfig[ResourceType.table].stats
-    ?.statTypesToExcludeForIcon;
+    ?.iconNotRequiredTypes;
 }
 
 /*

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -430,6 +430,18 @@ describe('getUniqueValueStatTypeName', () => {
   });
 });
 
+describe('getStatTypesToExcludeForIcon', () => {
+  it('returns the stat types where, if they are the only ones present, the stats icon will not be displayed', () => {
+    const expectedValue = ['test'];
+
+    AppConfig.resourceConfig[ResourceType.table].stats = {
+      statTypesToExcludeForIcon: expectedValue,
+    };
+
+    expect(ConfigUtils.getStatTypesToExcludeForIcon()).toBe(expectedValue);
+  });
+});
+
 describe('getTableSortCriterias', () => {
   it('returns the sorting criterias for tables', () => {
     const expectedValue =

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -430,15 +430,15 @@ describe('getUniqueValueStatTypeName', () => {
   });
 });
 
-describe('getStatTypesToExcludeForIcon', () => {
+describe('getIconNotRequiredStatTypes', () => {
   it('returns the stat types where, if they are the only ones present, the stats icon will not be displayed', () => {
     const expectedValue = ['test'];
 
     AppConfig.resourceConfig[ResourceType.table].stats = {
-      statTypesToExcludeForIcon: expectedValue,
+      iconNotRequiredTypes: expectedValue,
     };
 
-    expect(ConfigUtils.getStatTypesToExcludeForIcon()).toBe(expectedValue);
+    expect(ConfigUtils.getIconNotRequiredStatTypes()).toBe(expectedValue);
   });
 });
 

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -252,11 +252,11 @@ describe('ColumnList', () => {
 
     describe('when columns with one usage data entry are passed', () => {
       const { columns } = dataBuilder.withComplexColumnsOneStat().build();
-      const getStatTypesToExcludeForIconConfigSpy = jest.spyOn(
+      const getIconNotRequiredStatTypesConfigSpy = jest.spyOn(
         ConfigUtils,
-        'getStatTypesToExcludeForIcon'
+        'getIconNotRequiredStatTypes'
       );
-      getStatTypesToExcludeForIconConfigSpy.mockImplementation(() => [
+      getIconNotRequiredStatTypesConfigSpy.mockImplementation(() => [
         'column_usage',
       ]);
 
@@ -282,11 +282,11 @@ describe('ColumnList', () => {
 
     describe('when columns with several stats including usage are passed', () => {
       const { columns } = dataBuilder.withSeveralStats().build();
-      const getStatTypesToExcludeForIconConfigSpy = jest.spyOn(
+      const getIconNotRequiredStatTypesConfigSpy = jest.spyOn(
         ConfigUtils,
-        'getStatTypesToExcludeForIcon'
+        'getIconNotRequiredStatTypes'
       );
-      getStatTypesToExcludeForIconConfigSpy.mockImplementation(() => [
+      getIconNotRequiredStatTypesConfigSpy.mockImplementation(() => [
         'column_usage',
       ]);
 

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.spec.tsx
@@ -252,6 +252,13 @@ describe('ColumnList', () => {
 
     describe('when columns with one usage data entry are passed', () => {
       const { columns } = dataBuilder.withComplexColumnsOneStat().build();
+      const getStatTypesToExcludeForIconConfigSpy = jest.spyOn(
+        ConfigUtils,
+        'getStatTypesToExcludeForIcon'
+      );
+      getStatTypesToExcludeForIconConfigSpy.mockImplementation(() => [
+        'column_usage',
+      ]);
 
       it('should render the usage column', () => {
         const { wrapper } = setup({ columns });
@@ -261,9 +268,9 @@ describe('ColumnList', () => {
         expect(actual).toEqual(expected);
       });
 
-      it('should show column statistics icon', () => {
+      it('should not show column statistics icon since column_usage is excluded', () => {
         const { wrapper } = setup({ columns });
-        const expectedLength = 1;
+        const expectedLength = 0;
 
         const iconElementLength = wrapper.find('GraphIcon').length;
         const overlayTriggerLength = wrapper.find('OverlayTrigger').length;
@@ -275,6 +282,13 @@ describe('ColumnList', () => {
 
     describe('when columns with several stats including usage are passed', () => {
       const { columns } = dataBuilder.withSeveralStats().build();
+      const getStatTypesToExcludeForIconConfigSpy = jest.spyOn(
+        ConfigUtils,
+        'getStatTypesToExcludeForIcon'
+      );
+      getStatTypesToExcludeForIconConfigSpy.mockImplementation(() => [
+        'column_usage',
+      ]);
 
       it('should render the usage column', () => {
         const { wrapper } = setup({ columns });
@@ -284,9 +298,9 @@ describe('ColumnList', () => {
         expect(actual).toEqual(expected);
       });
 
-      it('should show column statistics icon', () => {
+      it('should show 1 column statistics icon for the one that has a stat outside of column_usage', () => {
         const { wrapper } = setup({ columns });
-        const expectedLength = columns.length;
+        const expectedLength = 1;
 
         const iconElementLength = wrapper.find('GraphIcon').length;
         const overlayTriggerLength = wrapper.find('OverlayTrigger').length;

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -11,7 +11,7 @@ import Table, {
 } from 'components/Table';
 import {
   getMaxNestedColumns,
-  getStatTypesToExcludeForIcon,
+  getIconNotRequiredStatTypes,
   getTableSortCriterias,
 } from 'config/config-utils';
 
@@ -124,7 +124,7 @@ const getUsageStat = (item) => {
 const hasStatsToDisplayIcon = (stats) => {
   let hasStatsToDisplayIcon = !!stats.length;
 
-  const statTypesToExclude = getStatTypesToExcludeForIcon();
+  const statTypesToExclude = getIconNotRequiredStatTypes();
   if (hasStatsToDisplayIcon && statTypesToExclude) {
     const allStatTypes = stats.map((stat) => stat.stat_type);
     const statsToInclude = allStatTypes.filter(

--- a/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/index.tsx
@@ -11,6 +11,7 @@ import Table, {
 } from 'components/Table';
 import {
   getMaxNestedColumns,
+  getStatTypesToExcludeForIcon,
   getTableSortCriterias,
 } from 'config/config-utils';
 
@@ -120,6 +121,22 @@ const getUsageStat = (item) => {
   return null;
 };
 
+const hasStatsToDisplayIcon = (stats) => {
+  let hasStatsToDisplayIcon = !!stats.length;
+
+  const statTypesToExclude = getStatTypesToExcludeForIcon();
+  if (hasStatsToDisplayIcon && statTypesToExclude) {
+    const allStatTypes = stats.map((stat) => stat.stat_type);
+    const statsToInclude = allStatTypes.filter(
+      (type) => !statTypesToExclude.includes(type)
+    );
+
+    hasStatsToDisplayIcon = !!statsToInclude.length;
+  }
+
+  return hasStatsToDisplayIcon;
+};
+
 const getColumnMetadataIconElement = (key, popoverText, iconElement) => (
   <OverlayTrigger
     key={key}
@@ -155,7 +172,7 @@ const ColumnList: React.FC<ColumnListProps> = ({
       content: {
         title: item.name,
         description: item.description,
-        hasStats: hasItemStats,
+        hasStats: hasStatsToDisplayIcon(item.stats),
       },
       type: {
         type: item.col_type,


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This change adds a config to allow adding a list of stat types where, if they are the only ones present for a column, the stats icon will not be displayed next to that column's name. This is useful in the case of columns only having very common stats, such as column usage, so the users will not click on the column expecting to see more info. The default value is an empty list so this will only affect those who configure it.

### Tests

Added a test for the config, and modified tests for determining whether the icon is displayed for a given column

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
