### PR TITLE
fix: Show the column in the center of the table when navigating to a column link

### DIFF
--- a/frontend/amundsen_application/static/js/components/Table/constants.ts
+++ b/frontend/amundsen_application/static/js/components/Table/constants.ts
@@ -17,3 +17,5 @@ export const ARRAY_CLOSER = '] ';
 export const MAP_LABEL = 'map';
 export const MAP_OPENER = ' {';
 export const MAP_CLOSER = '} ';
+
+export const SCROLL_INTO_VIEW_BLOCK = 'center';

--- a/frontend/amundsen_application/static/js/components/Table/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Table/index.tsx
@@ -24,6 +24,7 @@ import {
   MAP_VALUE_NAME,
   MAP_KEY_DISPLAY_NAME,
   MAP_VALUE_DISPLAY_NAME,
+  SCROLL_INTO_VIEW_BLOCK,
 } from './constants';
 import './styles.scss';
 
@@ -798,7 +799,7 @@ const useTableHooks = ({
   const expandRowRef = React.useRef<HTMLTableRowElement>(null);
   React.useEffect(() => {
     if (expandRowRef.current !== null) {
-      expandRowRef.current.scrollIntoView();
+      expandRowRef.current.scrollIntoView({ block: SCROLL_INTO_VIEW_BLOCK });
     }
   }, []);
 


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

When navigating to a link for a specific column, this change will scroll the column row to the center of the table instead of the top so it doesn't hide behind the sticky header.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
