### PR TITLE
feat: Add config to hide non-clickable badges

### DIFF
--- a/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 
-import { getBadgeConfig } from 'config/config-utils';
+import { getBadgeConfig, hideNonClickableBadges } from 'config/config-utils';
 import { BadgeStyle, BadgeStyleConfig } from 'config/config-types';
 
 import { convertText, CaseType } from 'utils/textUtils';
@@ -82,7 +82,11 @@ export default class BadgeList extends React.Component<BadgeListProps> {
             badgeConfig = getBadgeConfig(badge.badge_name);
           }
 
-          if (badge.badge_name && badge.category === COLUMN_BADGE_CATEGORY) {
+          if (
+            badge.badge_name &&
+            badge.category === COLUMN_BADGE_CATEGORY &&
+            !hideNonClickableBadges()
+          ) {
             return (
               <StaticBadge
                 style={badgeConfig.style}

--- a/frontend/amundsen_application/static/js/config/config-custom.ts
+++ b/frontend/amundsen_application/static/js/config/config-custom.ts
@@ -7,6 +7,7 @@ const configCustom: AppConfigCustom = {
     curatedTags: [],
     showAllTags: true,
     showBadgesInHome: true,
+    hideNonClickableBadges: false,
   },
   analytics: {
     plugins: [],

--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -7,6 +7,7 @@ const configDefault: AppConfig = {
     curatedTags: [],
     showAllTags: true,
     showBadgesInHome: true,
+    hideNonClickableBadges: false,
   },
   date: {
     default: 'MMM DD, YYYY',

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -99,11 +99,14 @@ export interface AnalyticsConfig {
  *
  * curatedTags - An array of tags to show in a separate section at the top.
  * showAllTags - Shows all tags when true, or only curated tags if false
+ * showBadgesInHome - Shows all badges in the homepage when true
+ * hideNonClickableBadges - Hides non-clickable badges in the homepage if true
  */
 interface BrowseConfig {
   curatedTags: Array<string>;
   showAllTags: boolean;
   showBadgesInHome: boolean;
+  hideNonClickableBadges: boolean;
 }
 
 /**
@@ -257,13 +260,12 @@ export interface BadgeStyleConfig {
 }
 
 /**
- * BadgeConfig - Configure badge colors and homepage list
+ * BadgeConfig - Configure badge colors
  *
  * An object that maps badges to BadgeStyleConfigs
  */
 interface BadgeConfig {
   [badge: string]: BadgeStyleConfig;
-  hideNonClickableBadges?: boolean;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -257,12 +257,13 @@ export interface BadgeStyleConfig {
 }
 
 /**
- * BadgeConfig - Configure badge colors
+ * BadgeConfig - Configure badge colors and homepage list
  *
  * An object that maps badges to BadgeStyleConfigs
  */
 interface BadgeConfig {
   [badge: string]: BadgeStyleConfig;
+  hideNonClickableBadges?: boolean;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -199,8 +199,8 @@ export function getBadgeConfig(badgeName: string): BadgeStyleConfig {
 /**
  * Returns whether non-clickable badges should be hidden on the homepage
  */
-export function hideNonClickableBadges(): boolean | undefined {
-  return AppConfig.badges.hideNonClickableBadges;
+export function hideNonClickableBadges(): boolean {
+  return AppConfig.browse.hideNonClickableBadges;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -197,6 +197,13 @@ export function getBadgeConfig(badgeName: string): BadgeStyleConfig {
 }
 
 /**
+ * Returns whether non-clickable badges should be hidden on the homepage
+ */
+export function hideNonClickableBadges(): boolean | undefined {
+  return AppConfig.badges.hideNonClickableBadges;
+}
+
+/**
  * Returns whether or not feedback features should be enabled
  */
 export function feedbackEnabled(): boolean {

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -625,6 +625,15 @@ describe('getCuratedTags', () => {
   });
 });
 
+describe('hideNonClickableBadges', () => {
+  it('returns whether to hide non-clickable badges', () => {
+    AppConfig.browse.hideNonClickableBadges = true;
+    expect(ConfigUtils.hideNonClickableBadges()).toBe(
+      AppConfig.browse.hideNonClickableBadges
+    );
+  });
+});
+
 describe('exploreEnabled', () => {
   it('returns whether the explore function is enabled', () => {
     AppConfig.tableProfile.isExploreEnabled = true;

--- a/frontend/docs/application_config.md
+++ b/frontend/docs/application_config.md
@@ -27,6 +27,10 @@ Badges are a special type of tag that cannot be edited through the UI.
 
 _TODO: Please add doc_
 
+## Show badges in homepage
+
+By default, all available badges are shown on the homepage. `browse.showBadgesInHome` configuration can be set to `false` to disable this. In addition, it is possible to hide the "non-clickable" badges using `browse.hideNonClickableBadges` configuration.
+
 ## Custom Logo
 
 1. Add your logo to the folder in `amundsen_application/static/images/`.


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

### Summary of Changes

Adds a new boolean configuration, `hideNonClickableBadges`, to control whether non-clickable (only column type at the moment) badges should be shown on the homepage or not. This potentially improves the user experience and declutters the homepage.

### Tests

Added a new unit test for the config util.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
