### PR TITLE
fix: Fix handling of big ints in preview data

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -418,8 +418,8 @@ exports[`eslint`] = {
       [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
-    "js/ducks/tableMetadata/api/v0.ts:3505354085": [
-      [140, 23, -4358, "Expected to return a value at the end of arrow function.", "5381"]
+    "js/ducks/tableMetadata/api/v0.ts:2322129867": [
+      [142, 23, -4399, "Expected to return a value at the end of arrow function.", "5381"]
     ],
     "js/ducks/tableMetadata/owners/index.spec.ts:655040122": [
       [15, 0, 91, "\`../reducer\` import should occur before import of \`./reducer\`", "2216296793"],

--- a/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/frontend/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -28,6 +28,8 @@ import {
   getTypeMetadataFromKey,
 } from './helpers';
 
+const JSONBig = require('json-bigint');
+
 export const API_PATH = '/api/metadata/v0';
 
 type MessageAPI = { msg: string };
@@ -215,6 +217,7 @@ export function getPreviewData(queryParams: TablePreviewQueryParams) {
     url: '/api/preview/v0/',
     method: 'POST',
     data: queryParams,
+    transformResponse: (data) => JSONBig.parse(data),
   })
     .then((response: AxiosResponse<PreviewDataAPI>) => ({
       data: response.data.previewData,

--- a/frontend/amundsen_application/static/js/features/PreviewData/index.tsx
+++ b/frontend/amundsen_application/static/js/features/PreviewData/index.tsx
@@ -12,6 +12,8 @@ import {
 
 import './styles.scss';
 
+const JSONBig = require('json-bigint');
+
 export interface PreviewDataProps {
   isLoading: boolean;
   previewData: PreviewData;
@@ -36,7 +38,7 @@ export const getSanitizedValue = (value) => {
   if (value === 0 || typeof value === 'boolean') {
     sanitizedValue = value.toString();
   } else if (typeof value === 'object') {
-    sanitizedValue = JSON.stringify(value);
+    sanitizedValue = JSONBig.stringify(value);
   } else if (typeof value === 'undefined') {
     sanitizedValue = '';
   } else {

--- a/frontend/amundsen_application/static/package-lock.json
+++ b/frontend/amundsen_application/static/package-lock.json
@@ -13633,7 +13633,7 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "http://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
@@ -16869,6 +16869,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -24105,7 +24110,7 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -24204,7 +24209,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -28504,6 +28509,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -30407,7 +30420,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -32223,7 +32236,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -32850,7 +32863,7 @@
     "react-avatar": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-2.5.1.tgz",
-      "integrity": "sha1-W76MHQpSWT1GCPs9hinamV7rcJU=",
+      "integrity": "sha512-bwH5pWY6uxaKZt+IZBfD+SU3Dpy3FaKbmAzrOI4N8SATUPLXOdGaJHWUl6Vl8hHSwWSsoLh/m7xYHdnn0lofZw==",
       "requires": {
         "babel-runtime": ">=5.0.0",
         "is-retina": "^1.0.3",
@@ -35282,7 +35295,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",

--- a/frontend/amundsen_application/static/package.json
+++ b/frontend/amundsen_application/static/package.json
@@ -146,6 +146,7 @@
     "form-serialize": "^0.7.2",
     "fsevents": "*",
     "jquery": "^3.5.0",
+    "json-bigint": "^1.0.0",
     "moment-timezone": "^0.5.33",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

The default handling of the preview data API response used `JSON.parse()` which does not handle big ints, and this resulted in loss of precision. This change makes use of the [json-bigint](https://www.npmjs.com/package/json-bigint) package to parse and display the values to correctly handle any large numbers.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
