### PR TITLE
fix: Fix last_updated key not found in metadata_dict

### DIFF
--- a/databuilder/databuilder/extractor/hive_table_last_updated_extractor.py
+++ b/databuilder/databuilder/extractor/hive_table_last_updated_extractor.py
@@ -113,7 +113,8 @@ class HiveTableLastUpdatedExtractor(Extractor):
     AND NOT EXISTS (SELECT * FROM PARTITION_KEYS WHERE PARTITION_KEYS.TBL_ID = TBLS.TBL_ID)
     """
 
-    DEFAULT_POSTGRES_ADDTIONAL_WHERE_CLAUSE = """ NOT EXISTS (SELECT * FROM "PARTITIONS" p WHERE p."TBL_ID" = t."TBL_ID")
+    DEFAULT_POSTGRES_ADDTIONAL_WHERE_CLAUSE = """
+    NOT EXISTS (SELECT * FROM "PARTITIONS" p WHERE p."TBL_ID" = t."TBL_ID")
     AND NOT EXISTS (SELECT * FROM "PARTITION_KEYS" pk WHERE pk."TBL_ID" = t."TBL_ID")
     """
 
@@ -367,4 +368,4 @@ class HiveTableLastUpdatedExtractor(Extractor):
             return None
 
         file_metadata = self._fs.info(path)
-        return file_metadata.last_updated
+        return file_metadata.last_updated if file_metadata.last_updated else None

--- a/databuilder/databuilder/filesystem/filesystem.py
+++ b/databuilder/databuilder/filesystem/filesystem.py
@@ -101,8 +101,14 @@ class FileSystem(Scoped):
         :return:
         """
         metadata_dict = self._dask_fs.info(path)
+
+        # Extract last_updated timestamp first since the key might not be in metadata_dict
+        # For s3, this happens when the path is an empty folder
+        last_updated_key = self._metadata_key_mapping[FileSystem.LAST_UPDATED]
+        last_updated_ts = metadata_dict[last_updated_key] if last_updated_key in metadata_dict else None
+
         fm = FileMetadata(path=path,
-                          last_updated=metadata_dict[self._metadata_key_mapping[FileSystem.LAST_UPDATED]],
+                          last_updated=last_updated_ts,
                           size=metadata_dict[self._metadata_key_mapping[FileSystem.SIZE]])
         return fm
 


### PR DESCRIPTION
### Summary of Changes

- Problem
  - The last_updated key might not exist in the `metadata_dict`. For s3, this happens when the path is an empty folder.
- Solution
  - Add an extra filter to return `None` when the last_updated key is not in the dict

### Tests

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
