### PR TITLE
fix: Don't retrieve column lineage when it is not enabled

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -359,9 +359,9 @@ exports[`eslint`] = {
     "js/components/Tags/index.tsx:3468508233": [
       [38, 4, 21, "Must use destructuring props assignment", "4236634811"]
     ],
-    "js/config/config-default.ts:2726844505": [
-      [381, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
-      [382, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
+    "js/config/config-default.ts:1828402213": [
+      [382, 6, 21, "\'partitionKey\' is defined but never used.", "399589312"],
+      [383, 6, 23, "\'partitionValue\' is defined but never used.", "793372348"]
     ],
     "js/ducks/announcements/index.spec.ts:1898496537": [
       [3, 0, 148, "\`.\` import should occur after import of \`./types\`", "4154971894"]
@@ -643,9 +643,9 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/WatermarkLabel/index.tsx:2189911402": [
       [29, 22, 21, "Must use destructuring props assignment", "587844958"]
     ],
-    "js/pages/TableDetailPage/index.tsx:833718545": [
-      [162, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
-      [215, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/pages/TableDetailPage/index.tsx:3561497819": [
+      [163, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
+      [216, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/utils/textUtils.ts:2545492889": [
       [19, 6, 46, "Unexpected lexical declaration in case block.", "156477898"]

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -183,6 +183,10 @@ describe('TableDetail', () => {
     describe('when preExpandRightPanel is called when a column is preselected', () => {
       it('column lineage is populated and selected column details are set in the state', () => {
         setStateSpy.mockClear();
+        jest
+          .spyOn(ConfigUtils, 'isColumnListLineageEnabled')
+          .mockImplementation(() => true);
+
         const { props, wrapper } = setup();
         wrapper.instance().preExpandRightPanel(mockColumnDetails);
 
@@ -199,6 +203,10 @@ describe('TableDetail', () => {
     describe('when toggleRightPanel is called while the panel is closed', () => {
       it('column lineage is populated and selected column details are set in the state', () => {
         setStateSpy.mockClear();
+        jest
+          .spyOn(ConfigUtils, 'isColumnListLineageEnabled')
+          .mockImplementation(() => true);
+
         const { props, wrapper } = setup();
         wrapper.setState({ isRightPanelOpen: false });
         wrapper.instance().toggleRightPanel(mockColumnDetails);

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -30,6 +30,7 @@ import {
   indexDashboardsEnabled,
   issueTrackingEnabled,
   isTableListLineageEnabled,
+  isColumnListLineageEnabled,
   notificationsEnabled,
   isTableQualityCheckEnabled,
 } from 'config/config-utils';
@@ -323,7 +324,7 @@ export class TableDetail extends React.Component<
     let key = '';
     if (columnDetails) {
       ({ key } = columnDetails);
-      if (!columnDetails.isNestedColumn) {
+      if (isColumnListLineageEnabled() && !columnDetails.isNestedColumn) {
         const { name, tableParams } = columnDetails;
         getColumnLineageDispatch(buildTableKey(tableParams), name);
       }
@@ -352,6 +353,7 @@ export class TableDetail extends React.Component<
       (key && key !== selectedColumnKey) || !isRightPanelOpen;
 
     if (
+      isColumnListLineageEnabled() &&
       shouldPanelOpen &&
       newColumnDetails &&
       !newColumnDetails.isNestedColumn


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Check to see if column lineage is enabled before attempting to retrieve it when toggling open the column details side panel.

### Tests

Modified existing tests to confirm that column lineage is loaded only when column lineage is enabled.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
