### PR TITLE
feat: Add optional configuration to disable Lineage list view links

### DIFF
--- a/frontend/amundsen_application/static/css/_list-group.scss
+++ b/frontend/amundsen_application/static/css/_list-group.scss
@@ -16,5 +16,9 @@
       cursor: pointer;
       z-index: 1;
     }
+
+    &.disabled {
+      pointer-events: none;
+    }
   }
 }

--- a/frontend/amundsen_application/static/css/_list-group.scss
+++ b/frontend/amundsen_application/static/css/_list-group.scss
@@ -17,7 +17,7 @@
       z-index: 1;
     }
 
-    &.disabled {
+    &.is-disabled {
       pointer-events: none;
     }
   }

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -21,6 +21,7 @@ export interface TableListItemProps {
   table: TableResource;
   logging: LoggingParams;
   tableHighlights: HighlightedTable;
+  disabled?: boolean;
 }
 
 export const getLink = (table, logging) =>
@@ -34,10 +35,12 @@ const TableListItem: React.FC<TableListItemProps> = ({
   table,
   logging,
   tableHighlights,
+  disabled,
 }) => (
   <li className="list-group-item clickable">
     <Link
       className="resource-list-item table-list-item"
+      style={{ pointerEvents: disabled ? 'none' : '' }}
       to={getLink(table, logging)}
       onClick={(e) =>
         logClick(e, {

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -37,10 +37,9 @@ const TableListItem: React.FC<TableListItemProps> = ({
   tableHighlights,
   disabled,
 }) => (
-  <li className="list-group-item clickable">
+  <li className={`list-group-item ${disabled ? 'disabled' : 'clickable'}`}>
     <Link
       className="resource-list-item table-list-item"
-      style={{ pointerEvents: disabled ? 'none' : '' }}
       to={getLink(table, logging)}
       onClick={(e) =>
         logClick(e, {

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -37,7 +37,7 @@ const TableListItem: React.FC<TableListItemProps> = ({
   tableHighlights,
   disabled,
 }) => (
-  <li className={`list-group-item ${disabled ? 'disabled' : 'clickable'}`}>
+  <li className={`list-group-item ${disabled ? 'is-disabled' : 'clickable'}`}>
     <Link
       className="resource-list-item table-list-item"
       to={getLink(table, logging)}

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -338,6 +338,10 @@ interface FeatureLineageConfig {
   inAppListEnabled: boolean;
 }
 
+/**
+ * TableLineageDisableAppListLinksConfig - maps table fields to regular expressions
+ * for matching and disabling list links if they don't match
+ */
 interface TableLineageDisableAppListLinksConfig {
   database?: RegExp;
   cluster?: RegExp;

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -338,6 +338,13 @@ interface FeatureLineageConfig {
   inAppListEnabled: boolean;
 }
 
+interface TableLineageDisableAppListLinksConfig {
+  database?: RegExp;
+  cluster?: RegExp;
+  schema?: RegExp;
+  table?: RegExp;
+}
+
 /**
  * TableLineageConfig - Customize the "Table Lineage" links of the "Table Details" page.
  * This feature is intended to link to an external lineage provider.
@@ -360,6 +367,7 @@ interface TableLineageConfig {
   externalEnabled: boolean;
   inAppListEnabled: boolean;
   inAppPageEnabled: boolean;
+  disableAppListLinks?: TableLineageDisableAppListLinksConfig;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -358,6 +358,7 @@ interface TableLineageDisableAppListLinksConfig {
  * isEnabled - Whether to show or hide this section
  * urlGenerator - Generate a URL to the third party lineage website
  * inAppListEnabled - Enable the in app Upstream/Downstream tabs for table lineage. Requires backend support.
+ * disableAppListLinks - Set up table field based regular expression rules to disable lineage list view links.
  */
 interface TableLineageConfig {
   iconPath: string;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
@@ -32,4 +32,11 @@ describe('LineageList', () => {
   it('should render a link', () => {
     expect(wrapper.find('a').exists).toBeTruthy();
   });
+
+  it('should have a disabled link', () => {
+    jest.mock('./index', () => ({
+      isTableLinkDisabled: jest.fn().mockReturnValueOnce(true),
+    }));
+    expect(wrapper.find('is-disabled').exists).toBeTruthy();
+  });
 });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
@@ -1,0 +1,35 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import LineageList from './index';
+
+describe('LineageList', () => {
+  let wrapper;
+  let props;
+  beforeAll(() => {
+    props = {
+      items: [
+        {
+          badges: [],
+          cluster: 'gold',
+          database: 'hive',
+          key: 'hive://gold.test_schema/test_table1',
+          level: 0,
+          name: 'test_table1',
+          parent: null,
+          schema: 'test_schema',
+          source: 'hive',
+          usage: 0,
+        },
+      ],
+      direction: 'both',
+    };
+    wrapper = shallow<typeof LineageList>(<LineageList {...props} />);
+  });
+
+  it('should render a link', () => {
+    expect(wrapper.find('a').exists).toBeTruthy();
+  });
+});

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
@@ -3,37 +3,43 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import LineageList from './index';
+import LineageList, { LineageListProps } from './index';
+
+const setup = (propOverrides?: Partial<LineageListProps>) => {
+  const props: LineageListProps = {
+    items: [
+      {
+        badges: [],
+        cluster: 'gold',
+        database: 'hive',
+        key: 'hive://gold.test_schema/test_table1',
+        level: 0,
+        name: 'test_table1',
+        parent: null,
+        schema: 'test_schema',
+        source: 'hive',
+        usage: 0,
+      },
+    ],
+    direction: 'both',
+    ...propOverrides,
+  };
+  const wrapper = shallow<typeof LineageList>(<LineageList {...props} />);
+
+  return {
+    props,
+    wrapper,
+  };
+};
 
 describe('LineageList', () => {
-  let wrapper;
-  let props;
-  beforeAll(() => {
-    props = {
-      items: [
-        {
-          badges: [],
-          cluster: 'gold',
-          database: 'hive',
-          key: 'hive://gold.test_schema/test_table1',
-          level: 0,
-          name: 'test_table1',
-          parent: null,
-          schema: 'test_schema',
-          source: 'hive',
-          usage: 0,
-        },
-      ],
-      direction: 'both',
-    };
-    wrapper = shallow<typeof LineageList>(<LineageList {...props} />);
-  });
-
   it('should render a link', () => {
+    const { wrapper } = setup();
     expect(wrapper.find('a').exists).toBeTruthy();
   });
 
   it('should have a disabled link', () => {
+    const { wrapper } = setup();
     jest.mock('./index', () => ({
       isTableLinkDisabled: jest.fn().mockReturnValueOnce(true),
     }));

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
@@ -14,40 +14,43 @@ export interface LineageListProps {
   direction: string;
 }
 
+const isTableLinkDisabled = (table: LineageItem) => {
+  const config = AppConfig.tableLineage;
+  let disabled = false;
+  if (config.disableAppListLinks) {
+    disabled = Object.keys(config.disableAppListLinks).some(
+      (key) => config.disableAppListLinks![key].test(table[key]) === false
+    );
+  }
+  return disabled;
+};
+
 const LineageList: React.FC<LineageListProps> = ({
   items,
   direction,
-}: LineageListProps) => {
-  const config = AppConfig.tableLineage;
-  return (
-    <div className="list-group">
-      {items.map((table, index) => {
-        let disabled = false;
-        if (config.disableAppListLinks) {
-          disabled = Object.keys(config.disableAppListLinks).some(
-            (key) => config.disableAppListLinks![key].test(table[key]) === false
-          );
-        }
-        const logging = {
-          index,
-          source: `table_lineage_list_${direction}`,
-        };
-        const tableResource: TableResource = {
-          ...table,
-          type: ResourceType.table,
-          description: '',
-        };
-        return (
-          <TableListItem
-            table={tableResource}
-            logging={logging}
-            key={`lineage-item::${index}`}
-            tableHighlights={getHighlightedTableMetadata(tableResource)}
-            disabled={disabled}
-          />
-        );
-      })}
-    </div>
-  );
-};
+}: LineageListProps) => (
+  <div className="list-group">
+    {items.map((table, index) => {
+      const logging = {
+        index,
+        source: `table_lineage_list_${direction}`,
+      };
+      const tableResource: TableResource = {
+        ...table,
+        type: ResourceType.table,
+        description: '',
+      };
+      return (
+        <TableListItem
+          table={tableResource}
+          logging={logging}
+          key={`lineage-item::${index}`}
+          tableHighlights={getHighlightedTableMetadata(tableResource)}
+          disabled={isTableLinkDisabled(table)}
+        />
+      );
+    })}
+  </div>
+);
+
 export default LineageList;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 
+import AppConfig from 'config/config';
 import { ResourceType, TableResource } from 'interfaces/Resources';
 import { LineageItem } from 'interfaces/Lineage';
 import TableListItem from 'components/ResourceListItem/TableListItem';
@@ -16,27 +17,37 @@ export interface LineageListProps {
 const LineageList: React.FC<LineageListProps> = ({
   items,
   direction,
-}: LineageListProps) => (
-  <div className="list-group">
-    {items.map((table, index) => {
-      const logging = {
-        index,
-        source: `table_lineage_list_${direction}`,
-      };
-      const tableResource: TableResource = {
-        ...table,
-        type: ResourceType.table,
-        description: '',
-      };
-      return (
-        <TableListItem
-          table={tableResource}
-          logging={logging}
-          key={`lineage-item::${index}`}
-          tableHighlights={getHighlightedTableMetadata(tableResource)}
-        />
-      );
-    })}
-  </div>
-);
+}: LineageListProps) => {
+  const config = AppConfig.tableLineage;
+  return (
+    <div className="list-group">
+      {items.map((table, index) => {
+        let disabled = false;
+        if (config.disableAppListLinks) {
+          disabled = Object.keys(config.disableAppListLinks).some(
+            (key) => config.disableAppListLinks![key].test(table[key]) === false
+          );
+        }
+        const logging = {
+          index,
+          source: `table_lineage_list_${direction}`,
+        };
+        const tableResource: TableResource = {
+          ...table,
+          type: ResourceType.table,
+          description: '',
+        };
+        return (
+          <TableListItem
+            table={tableResource}
+            logging={logging}
+            key={`lineage-item::${index}`}
+            tableHighlights={getHighlightedTableMetadata(tableResource)}
+            disabled={disabled}
+          />
+        );
+      })}
+    </div>
+  );
+};
 export default LineageList;


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

This PR adds a new optional configuration to existing `TableLineageConfig`, to set up field based rules, which are used to disable "lineage list view" links based on regular expression matching. This config is particularly useful when some of the table resources should appear in the Lineage graph, however are not ingested into catalog or should not be accessible by users.

### Tests

No test changes are required.

### Documentation

A comment added to the new config explaining the purpose.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
