### PR TITLE
fix: For new publisher fix error handling for already created constraints/indices

### DIFF
--- a/databuilder/databuilder/utils/publisher_utils.py
+++ b/databuilder/databuilder/utils/publisher_utils.py
@@ -19,6 +19,9 @@ from databuilder.publisher.publisher_config_constants import PublisherConfigs
 
 LOGGER = logging.getLogger(__name__)
 
+NEO4J_EQUIVALENT_SCHEMA_RULE_ALREADY_EXISTS_ERROR_CODE = 'Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists'
+NEO4J_INDEX_ALREADY_EXISTS_ERROR_CODE = 'Neo.ClientError.Schema.IndexWithNameAlreadyExists'
+
 
 def chunkify_list(records: List[dict], chunk_size: int) -> Iterator[List[dict]]:
     """
@@ -55,7 +58,8 @@ def create_neo4j_node_key_constraint(node_file: str,
 
                         session.write_transaction(execute_neo4j_statement, create_stmt)
                     except Neo4jError as e:
-                        if 'An equivalent constraint already exists' not in e.__str__():
+                        if e.code != NEO4J_EQUIVALENT_SCHEMA_RULE_ALREADY_EXISTS_ERROR_CODE\
+                                and e.code != NEO4J_INDEX_ALREADY_EXISTS_ERROR_CODE:
                             raise
                         # Else, swallow the exception, to make this function idempotent.
                 labels.add(label)

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.2.0'
+__version__ = '7.2.1'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

It appears the new neo4j driver uses a different error message than it did before for indicating that constraints or indices have already been created. This change updates the publisher check to look for the [error status code](https://neo4j.com/docs/status-codes/current/) instead of a line of text.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
