### PR TITLE
Get the first item from the healthcheck response

### DIFF
--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -129,7 +129,7 @@ class Neo4jProxy(BaseProxy):
         try:
             # dbms.cluster.overview() is only available for enterprise neo4j users
             cluster_overview = self._execute_cypher_query(statement='CALL dbms.cluster.overview()', param_dict={})
-            checks = dict(get_single_record(cluster_overview))
+            checks = dict(cluster_overview[0])
             checks['overview_enabled'] = True
             status = health_check.OK
         except ClientError:


### PR DESCRIPTION
dbms.cluster.overview() will return one record per instance so expecting single record is incorrect
