### PR TITLE
fix: Fix hideNonClickableBadges configuration

### DIFF
--- a/frontend/amundsen_application/static/js/components/Badges/BadgeBrowseList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeBrowseList/index.tsx
@@ -9,7 +9,10 @@ import {
   AVAILABLE_BADGES_TITLE,
   BROWSE_BADGES_TITLE,
 } from 'components/Badges/BadgeBrowseList/constants';
-import { isShowBadgesInHomeEnabled } from 'config/config-utils';
+import {
+  hideNonClickableBadges,
+  isShowBadgesInHomeEnabled,
+} from 'config/config-utils';
 
 export interface BadgeBrowseListProps {
   badges: Badge[];
@@ -26,7 +29,10 @@ const BadgeBrowseListShort: React.FC<BadgeBrowseListProps> = ({
         <h2 className="available-badges-header-title">
           {AVAILABLE_BADGES_TITLE}
         </h2>
-        <BadgeList badges={badges} />
+        <BadgeList
+          badges={badges}
+          hideNonClickableBadges={hideNonClickableBadges()}
+        />
       </article>
     );
   }

--- a/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.spec.tsx
@@ -42,6 +42,7 @@ const setup = (propOverrides?: Partial<BadgeListProps>) => {
   const props = {
     badges,
     onBadgeClick: () => {},
+    hideNonClickableBadges: false,
     ...propOverrides,
   };
   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -110,6 +111,17 @@ describe('BadgeList', () => {
         const { wrapper } = setup({ badges: columnBadges });
         const expected = 2;
         const actual = wrapper.find('.static-badge').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('renders null when hideNonClickableBadges is true', () => {
+        const { wrapper } = setup({
+          badges: columnBadges,
+          hideNonClickableBadges: true,
+        });
+        const expected = 2;
+        const actual = wrapper.find('null').length;
 
         expect(actual).toEqual(expected);
       });

--- a/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 
-import { getBadgeConfig, hideNonClickableBadges } from 'config/config-utils';
+import { getBadgeConfig } from 'config/config-utils';
 import { BadgeStyle, BadgeStyleConfig } from 'config/config-types';
 
 import { convertText, CaseType } from 'utils/textUtils';
@@ -18,6 +18,7 @@ const COLUMN_BADGE_CATEGORY = 'column';
 export interface BadgeListProps {
   badges: Badge[];
   onBadgeClick: (badgeText: string) => void;
+  hideNonClickableBadges?: boolean;
 }
 
 export interface ActionableBadgeProps {
@@ -58,7 +59,7 @@ export default class BadgeList extends React.Component<BadgeListProps> {
   };
 
   render() {
-    const { badges } = this.props;
+    const { badges, hideNonClickableBadges } = this.props;
     const alphabetizedBadges = badges.sort((a, b) => {
       const aName = (a.badge_name ? a.badge_name : a.tag_name) || '';
       const bName = (b.badge_name ? b.badge_name : b.tag_name) || '';
@@ -85,7 +86,7 @@ export default class BadgeList extends React.Component<BadgeListProps> {
           if (
             badge.badge_name &&
             badge.category === COLUMN_BADGE_CATEGORY &&
-            !hideNonClickableBadges()
+            !hideNonClickableBadges
           ) {
             return (
               <StaticBadge


### PR DESCRIPTION
Signed-off-by: Ozan Dogrultan <ozan.dogrultan@deliveryhero.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

At the moment, when `hideNonClickableBadges` is configured to be `true`, the column badges are hidden everywhere in the app. This PR makes to changes to hide them only on the homepage.

### Tests

Existing tests should pass with these changes.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
