### PR TITLE
fix: Correct sharded table prefix extraction in Bigquery Usage Extractor

### DIFF
--- a/databuilder/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_usage_extractor.py
@@ -122,7 +122,8 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
             tableId = self._remove_table_decorators(tableId)
 
             if self._is_sharded_table(tableId):
-                tableId = tableId[:-BigQueryTableUsageExtractor.DATE_LENGTH]
+                # Use the prefix of the sharded table as tableId
+                tableId = tableId[:-len(self._get_sharded_table_suffix(tableId))]
 
             if refResource['projectId'] != self.project_id and self.count_reads_only_from_same_project:
                 LOGGER.debug(


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->
Related to issue #1979
Fix for removing the entire date suffix instead of a fixed length in a table name in bq_usage_extractor.py 
### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
