### PR TITLE
feat: Allow null values set for empty props in neo4j unwind publisher and multiple rels between nodes

### DIFF
--- a/databuilder/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -129,7 +129,7 @@ class FsNeo4jCSVLoader(Loader):
                     relation.type,
                     self._make_key(relation_dict))
 
-            file_suffix = f'{key2[0]}_{key2[1]}_{key2[2]}'
+            file_suffix = f'{key2[0]}_{key2[1]}_{key2[2]}_{key2[3]}'
             relation_writer = self._get_writer(relation_dict,
                                                self._relation_file_mapping,
                                                key2,

--- a/databuilder/databuilder/publisher/publisher_config_constants.py
+++ b/databuilder/databuilder/publisher/publisher_config_constants.py
@@ -28,6 +28,10 @@ class PublishBehaviorConfigs:
     # will be included as properties of the nodes
     ADD_PUBLISHER_METADATA = 'add_publisher_metadata'
 
+    # If enabled, empty properties will be set to NULL and will not show up on the node or relation.
+    # The default behavior when this is False will publish properties with empty values.
+    NULL_EMPTY_PROPS = 'null_empty_props'
+
     # NOTE: Do not use this unless you have a specific use case for it. Amundsen expects two way relationships, and
     # the default value should be set to true to publish relations in both directions. If it is overridden and set
     # to false, reverse relationships will not be published.

--- a/databuilder/databuilder/publisher/publisher_config_constants.py
+++ b/databuilder/databuilder/publisher/publisher_config_constants.py
@@ -28,10 +28,6 @@ class PublishBehaviorConfigs:
     # will be included as properties of the nodes
     ADD_PUBLISHER_METADATA = 'add_publisher_metadata'
 
-    # If enabled, empty properties will be set to NULL and will not show up on the node or relation.
-    # The default behavior when this is False will publish properties with empty values.
-    NULL_EMPTY_PROPS = 'null_empty_props'
-
     # NOTE: Do not use this unless you have a specific use case for it. Amundsen expects two way relationships, and
     # the default value should be set to true to publish relations in both directions. If it is overridden and set
     # to false, reverse relationships will not be published.
@@ -41,6 +37,10 @@ class PublishBehaviorConfigs:
     # created via the UI, e.g. a description or owner added manually by an Amundsen user.
     # Such nodes/relationships will not have a 'published_tag' property that is set by databuilder.
     PRESERVE_ADHOC_UI_DATA = 'preserve_adhoc_ui_data'
+
+    # If enabled, the default behavior will continue to publish properties with empty values.
+    # If False, empty properties will be set to NULL and will not show up on the node or relation.
+    PRESERVE_EMPTY_PROPS = 'preserve_empty_props'
 
 
 class Neo4jCsvPublisherConfigs:


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

- Added publisher config `PRESERVE_EMPTY_PROPS` to `Neo4jCsvUnwindPublisher`
  - True (default): existing behavior of publishing node or relation properties even if they have empty values
  - False: set empty properties to NULL so they will not show up on the nodes or relations
- Allow multiple relations between the same two nodes when not publishing reverse relations
  - Note: must add `key` as an attribute for the relation
  - Now has the relation `key` as part of the merge statement so unique relations will all be published
  - Appends the loader-generated key to the generated file names in case there are more than one for the same groupings of nodes and relations

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
