### PR TITLE
fix: trimming uuid to 11 digits in superset preview client

### DIFF
--- a/frontend/amundsen_application/base/examples/example_superset_preview_client.py
+++ b/frontend/amundsen_application/base/examples/example_superset_preview_client.py
@@ -34,8 +34,8 @@ class SupersetPreviewClient(BaseSupersetPreviewClient):
         try:
             request_data = {}  # type: Dict[str, Any]
 
-            # Superset's sql_json endpoint requires a unique client_id
-            request_data['client_id'] = uuid.uuid4()
+            # Superset's sql_json endpoint requires a unique client_id and size should be 11
+            request_data['client_id'] = str(uuid.uuid4())[:10]
 
             # Superset's sql_json endpoint requires the id of the database that it will execute the query on
             database_name = 'main'  # OR params.get('database') in a real use case


### PR DESCRIPTION
Summary of Changes
While accessing superset api for preview feature the client_id size is 11 in superset table, so uuid4 is causing problem
Fix trimming the uuid4 to 11 digits

### Tests

### Documentation

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
