### PR TITLE
feat: Add configurable prop types to neo4j csv publisher

### DIFF
--- a/databuilder/databuilder/publisher/publisher_config_constants.py
+++ b/databuilder/databuilder/publisher/publisher_config_constants.py
@@ -64,3 +64,10 @@ class Neo4jCsvPublisherConfigs:
     # NEO4J_VALIDATE_SSL is a boolean indicating whether to validate the server's SSL/TLS
     # cert against system CAs
     NEO4J_VALIDATE_SSL = 'neo4j_validate_ssl'
+
+    # This should be a dict using property names as keys mapped to the function name used to configure a specific
+    # type for that property. The values of the properties should be in the correct format that the function accepts.
+    # Example: a config of {'start_time': 'datetime', 'publish_tag': 'date'} where the property values are in the
+    # format <date>T<time> and <date> would apply datetime(n.start_time) and date(n.publish_tag) in the prop merge
+    # statement to create the props as DateTime and Date types instead of strings.
+    NEO4J_PROP_TYPES_TO_CONFIGURE = 'neo4j_prop_types_to_configure'

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.3.1'
+__version__ = '7.4.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.3.0'
+__version__ = '7.3.1'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

Added publisher config `NEO4J_PROP_TYPES_TO_CONFIGURE` to `Neo4jCsvUnwindPublisher`. If used, this should be set to a dict using node or relation property names as keys mapped to the function name used to configure a specific type for that property. The values of the properties should be in the correct format that the function accepts.

For example, a config of `{'start_time': 'datetime', 'publish_tag': 'date'}` where the property values are in the format `<date>T<time>` and `<date>` would apply `datetime(n.start_time)` and `date(n.publish_tag)` in the prop merge statement to create the props as `DateTime` and `Date` types instead of strings.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
