### PR TITLE
Fix toggle filter and styling; update tests

### DIFF
--- a/frontend/amundsen_application/static/js/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/frontend/amundsen_application/static/js/components/ToggleSwitch/ToggleSwitch.tsx
@@ -3,6 +3,7 @@
 
 import * as React from 'react';
 import Switch from 'react-switch';
+import './styles.scss';
 
 export interface ToggleSwitchProps {
   checked: boolean;

--- a/frontend/amundsen_application/static/js/components/ToggleSwitch/styles.scss
+++ b/frontend/amundsen_application/static/js/components/ToggleSwitch/styles.scss
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+.toggle-switch {
+  margin-right: 0;
+  margin-left: auto;
+}

--- a/frontend/amundsen_application/static/js/pages/SearchPage/ResourceSelector/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/ResourceSelector/index.tsx
@@ -72,7 +72,7 @@ export class ResourceSelector extends React.Component<ResourceSelectorProps> {
           }
           onChange={this.onChange}
         />
-        <span className="subtitle-2">{option.label}</span>
+        <span className="text-subtitle-w2">{option.label}</span>
         <span className="body-secondary-3 pull-right">{option.count}</span>
       </label>
     </div>

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/CheckBoxFilter/index.tsx
@@ -52,7 +52,7 @@ export class CheckBoxFilter extends React.Component<CheckBoxFilterProps> {
         value={value}
         onChange={this.onCheckboxChange}
       >
-        <span className="subtitle-2">{label}</span>
+        <span className="text-subtitle-w2">{label}</span>
       </CheckBoxItem>
     );
   };

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/ToggleFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/ToggleFilter/index.spec.tsx
@@ -26,9 +26,10 @@ describe('ToggleFilter', () => {
     const props: ToggleFilterProps = {
       categoryId: 'pii',
       filterName: 'PII',
-      helpText: 'Filters out all resources cotaining PII',
+      helpText: 'Filters out all resources containing PII',
       checked: true,
       applyFilters: jest.fn(),
+      clearFilters: jest.fn(),
       ...propOverrides,
     };
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -68,11 +69,17 @@ describe('ToggleFilter', () => {
   });
 
   describe('handleChange', () => {
-    it('calls props.applyFilters with expected parameters', () => {
+    it('calls props.applyFilters with expected parameters when checked is true', () => {
       const { props, wrapper } = setup();
       const applyFiltersSpy = jest.spyOn(props, 'applyFilters');
+      wrapper.instance().handleChange(true);
+      expect(applyFiltersSpy).toHaveBeenCalledWith(props.categoryId, ['true']);
+    });
+    it('calls props.clearFilters with expected parameters when checked is false', () => {
+      const { props, wrapper } = setup();
+      const clearFiltersSpy = jest.spyOn(props, 'clearFilters');
       wrapper.instance().handleChange(false);
-      expect(applyFiltersSpy).toHaveBeenCalledWith(props.categoryId, ['false']);
+      expect(clearFiltersSpy).toHaveBeenCalledWith(props.categoryId);
     });
   });
 
@@ -104,6 +111,11 @@ describe('ToggleFilter', () => {
     it('sets applyFilters on the props', () => {
       const dispatch = jest.fn(() => Promise.resolve());
       const expected = mapDispatchToProps(dispatch).applyFilters;
+      expect(expected).toBeInstanceOf(Function);
+    });
+    it('sets clearFilters on the props', () => {
+      const dispatch = jest.fn(() => Promise.resolve());
+      const expected = mapDispatchToProps(dispatch).clearFilters;
       expect(expected).toBeInstanceOf(Function);
     });
   });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/ToggleFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/ToggleFilter/index.tsx
@@ -29,6 +29,7 @@ interface StateFromProps {
 
 interface DispatchFromProps {
   applyFilters: (categoryId: string, value: string[]) => UpdateFilterRequest;
+  clearFilters: (categoryId: string) => UpdateFilterRequest;
 }
 // TODO change to FC
 
@@ -36,8 +37,12 @@ export type ToggleFilterProps = OwnProps & DispatchFromProps & StateFromProps;
 
 export class ToggleFilter extends React.Component<ToggleFilterProps> {
   handleChange = (checked) => {
-    const { categoryId, applyFilters } = this.props;
-    applyFilters(categoryId, [checked.toString()]);
+    const { categoryId, applyFilters, clearFilters } = this.props;
+    if (checked) {
+      applyFilters(categoryId, [checked.toString()]);
+    } else {
+      clearFilters(categoryId);
+    }
   };
 
   render = () => {
@@ -68,6 +73,11 @@ export const mapDispatchToProps = (dispatch: any) =>
         updateFilterByCategory({
           searchFilters: [{ categoryId, value: value || undefined }],
         }),
+      clearFilters: (categoryId: string) => {
+        return updateFilterByCategory({
+          searchFilters: [{ categoryId, value: undefined }],
+        });
+      },
     },
     dispatch
   );

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/ToggleFilter/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/ToggleFilter/styles.scss
@@ -8,11 +8,14 @@ $info-button-small-size: 18px;
 
 .toggle-filter {
   display: flex;
+  margin-bottom: 0;
+
   .btn.info-button {
     height: $info-button-small-size;
     width: $info-button-small-size;
     margin: 0 $spacer-half 0 $spacer-half;
   }
+
   .info-svg-icon {
     height: $info-button-small-size;
     width: $info-button-small-size;

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchPanel/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchPanel/styles.scss
@@ -21,7 +21,11 @@
 
   .checkbox,
   .radio {
-    margin-bottom: $spacer-1;
-    margin-top: $spacer-1;
+    margin-bottom: $spacer-half;
+    margin-top: $spacer-half;
+
+    &:first-child {
+      margin-top: $spacer-1;
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Ben Dye <bdye@lyft.com>

Summary of Changes
Previously, toggle filters on the search page were functioning counterintuitively. When toggled to false, they excluded all results that did not have the filtered category set to false, rather than including all results, true and false.

Tests
Existing tests cover the toggle filters and still pass. I added some additional tests for the clearFilters callback and its expected behavior.

Documentation
Didn't modify any documentation.

CheckList
Make sure you have checked all steps below to ensure a timely review.

 PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
 PR includes a summary of changes.
 PR adds unit tests, updates existing unit tests, OR documents why no test additions or modifications are needed.
 In case of new functionality, my PR adds documentation that describes how to use it.
All the public functions and the classes in the PR contain docstrings that explain what it does
