### PR TITLE
feat: use different internal link than the table details page on lineage

### DIFF
--- a/common/amundsen_common/models/api/health_check.py
+++ b/common/amundsen_common/models/api/health_check.py
@@ -30,7 +30,7 @@ class HealthCheck:
         return _HEALTH_CHECK_HTTP_STATUS_MAP[self.status]
 
     def dict(self) -> Dict[str, Any]:
-        return attr.asdict(self)
+        return attr.asdict(self)  # type: ignore
 
 
 class HealthCheckSchema(AttrsSchema):

--- a/common/amundsen_common/models/lineage.py
+++ b/common/amundsen_common/models/lineage.py
@@ -17,6 +17,7 @@ class LineageItem:
     badges: Optional[List[Badge]] = None
     usage: Optional[int] = None  # statistic to sort lineage items by
     parent: Optional[str] = None  # key of the parent entity, used to create the relationships in graph
+    link: Optional[str] = None # internal link to redirect to different than the resource details page
 
 
 class LineageItemSchema(AttrsSchema):

--- a/common/amundsen_common/models/lineage.py
+++ b/common/amundsen_common/models/lineage.py
@@ -17,7 +17,7 @@ class LineageItem:
     badges: Optional[List[Badge]] = None
     usage: Optional[int] = None  # statistic to sort lineage items by
     parent: Optional[str] = None  # key of the parent entity, used to create the relationships in graph
-    link: Optional[str] = None # internal link to redirect to different than the resource details page
+    link: Optional[str] = None  # internal link to redirect to different than the resource details page
 
 
 class LineageItemSchema(AttrsSchema):

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.27.1'
+__version__ = '0.28.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.spec.tsx
@@ -95,6 +95,17 @@ describe('TableListItem', () => {
         `/table_detail/${table.cluster}/${table.database}/${table.schema}/${table.name}?index=${logging.index}&source=${logging.source}`
       );
     });
+    it('should have alternative link', () => {
+      const expected = `search?resource=table&index=0&filters={"is_prioritized":{"value":"false"},"is_view":{"value":"false"},"table":{"value":"tableName_*"}}`;
+      const { props } = setup();
+      const { table, logging } = props;
+      const tableWithLink = {
+        ...table,
+        link: expected,
+      };
+
+      expect(getLink(tableWithLink, logging)).toEqual(expected);
+    });
   });
 
   describe('generateResourceIconClass', () => {

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -39,6 +39,7 @@ export const getName = (table) => {
 
 export const getLink = (table, logging) => {
   const name = getName(table);
+  if (table.link) return table.link;
   return (
     `/table_detail/${table.cluster}/${table.database}/${table.schema}/${name}` +
     `?index=${logging.index}&source=${logging.source}`
@@ -57,7 +58,7 @@ const TableListItem: React.FC<TableListItemProps> = ({
   <li className={`list-group-item ${disabled ? 'is-disabled' : 'clickable'}`}>
     <Link
       className="resource-list-item table-list-item"
-      to={table.link? table.link : getLink(table, logging)}
+      to={getLink(table, logging)}
       onClick={(e) =>
         logClick(e, {
           target_id: 'table_list_item',

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -57,7 +57,7 @@ const TableListItem: React.FC<TableListItemProps> = ({
   <li className={`list-group-item ${disabled ? 'is-disabled' : 'clickable'}`}>
     <Link
       className="resource-list-item table-list-item"
-      to={getLink(table, logging)}
+      to={table.link? table.link : getLink(table, logging)}
       onClick={(e) =>
         logClick(e, {
           target_id: 'table_list_item',

--- a/frontend/amundsen_application/static/js/interfaces/Lineage.ts
+++ b/frontend/amundsen_application/static/js/interfaces/Lineage.ts
@@ -11,6 +11,7 @@ export interface LineageItem {
   parent: string | null;
   usage: number | null;
   source?: string;
+  link?: string;
 }
 
 export interface Lineage {

--- a/frontend/amundsen_application/static/js/interfaces/Resources.ts
+++ b/frontend/amundsen_application/static/js/interfaces/Resources.ts
@@ -73,6 +73,7 @@ export interface TableResource extends Resource {
   schema_description?: string;
   badges?: Badge[];
   highlight?: TableSearchHighlights;
+  link?: string;
 }
 
 export enum SortDirection {

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.27.0,<0.28.0
+amundsen-common>=0.27.0,<0.29.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
- use a link received from metadata that is different than the one that directs you to a new table details page for the table items list