### PR TITLE
fix: updates helm chart to actually use frontEnd.servicePort value, set default to 5000

### DIFF
--- a/amundsen-kube-helm/templates/helm/templates/service-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/service-frontend.yaml
@@ -22,5 +22,5 @@ spec:
     release: {{ .Release.Name }}
   ports:
     - name: {{ .Chart.Name }}-{{ .Values.frontEnd.serviceName }}-{{ .Values.environment }}-http
-      port: {{ .Values.frontEnd.servicePort }}
+      port: {{ .Values.frontEnd.servicePort | default 5000 }}
       targetPort: 5000

--- a/amundsen-kube-helm/templates/helm/templates/service-frontend.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/service-frontend.yaml
@@ -22,5 +22,5 @@ spec:
     release: {{ .Release.Name }}
   ports:
     - name: {{ .Chart.Name }}-{{ .Values.frontEnd.serviceName }}-{{ .Values.environment }}-http
-      port: 5000
+      port: {{ .Values.frontEnd.servicePort }}
       targetPort: 5000

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -240,7 +240,7 @@ frontEnd:
   imageTag: latest
 
   # frontEnd.servicePort -- The port the frontend service will be exposed on via the loadbalancer.
-  servicePort: 80
+  servicePort: 5000
 
   # frontEnd.replicas -- How many replicas of the frontend service to run.
   replicas: 1


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

<!-- Include a summary of changes -->
This PR adds the existing frontEnd.servicePort value to the frontend service manifest, allowing the user to set the servicePort. At the moment, the user can set this value, but it has no effect. The default of 5000 is now set in the values file as well.

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->
No tests exist around helm chart values.

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->
This PR actually brings the code in line with existing documentation, see `frontEnd.servicePort` here: https://www.amundsen.io/amundsen/k8s_install/#values

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
