### PR TITLE
feat: added optional in_amundsen bool to lineage items

### DIFF
--- a/common/amundsen_common/models/lineage.py
+++ b/common/amundsen_common/models/lineage.py
@@ -18,7 +18,7 @@ class LineageItem:
     usage: Optional[int] = None  # statistic to sort lineage items by
     parent: Optional[str] = None  # key of the parent entity, used to create the relationships in graph
     link: Optional[str] = None  # internal link to redirect to different than the resource details page
-    in_amundsen: Optional[bool] = None # it is possible to have lineage that doesn't exist in Amundsen in that moment
+    in_amundsen: Optional[bool] = None  # it is possible to have lineage that doesn't exist in Amundsen in that moment
 
 
 class LineageItemSchema(AttrsSchema):

--- a/common/amundsen_common/models/lineage.py
+++ b/common/amundsen_common/models/lineage.py
@@ -18,6 +18,7 @@ class LineageItem:
     usage: Optional[int] = None  # statistic to sort lineage items by
     parent: Optional[str] = None  # key of the parent entity, used to create the relationships in graph
     link: Optional[str] = None  # internal link to redirect to different than the resource details page
+    in_amundsen: Optional[bool] = None # it is possible to have lineage that doesn't exist in Amundsen in that moment
 
 
 class LineageItemSchema(AttrsSchema):

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.28.0'
+__version__ = '0.29.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/frontend/amundsen_application/api/metadata/v0.py
+++ b/frontend/amundsen_application/api/metadata/v0.py
@@ -876,6 +876,7 @@ def get_table_lineage() -> Response:
         url = f'{table_endpoint}/{table_key}/lineage?depth={depth}&direction={direction}'
         response = request_metadata(url=url, method=request.method)
         json = response.json()
+        LOGGER.info(json)
         downstream = [marshall_lineage_table(table) for table in json.get('downstream_entities')]
         upstream = [marshall_lineage_table(table) for table in json.get('upstream_entities')]
 

--- a/frontend/amundsen_application/api/metadata/v0.py
+++ b/frontend/amundsen_application/api/metadata/v0.py
@@ -876,7 +876,6 @@ def get_table_lineage() -> Response:
         url = f'{table_endpoint}/{table_key}/lineage?depth={depth}&direction={direction}'
         response = request_metadata(url=url, method=request.method)
         json = response.json()
-        LOGGER.info(json)
         downstream = [marshall_lineage_table(table) for table in json.get('downstream_entities')]
         upstream = [marshall_lineage_table(table) for table in json.get('upstream_entities')]
 

--- a/frontend/amundsen_application/static/js/interfaces/Lineage.ts
+++ b/frontend/amundsen_application/static/js/interfaces/Lineage.ts
@@ -12,6 +12,7 @@ export interface LineageItem {
   usage: number | null;
   source?: string;
   link?: string;
+  in_amundsen?: boolean;
 }
 
 export interface Lineage {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
@@ -15,7 +15,6 @@ export interface LineageListProps {
 }
 
 const isTableLinkDisabled = (table: LineageItem) => {
-
   // check if item is currently indexed in Amundsen, if it's not mark as disabled
   if (table.in_amundsen === false) {
     return true;
@@ -36,7 +35,7 @@ const isTableLinkDisabled = (table: LineageItem) => {
       return disableAppListLinks![key].test(table[key]) === false;
     });
   }
-  
+
   return disabled;
 };
 

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
@@ -15,6 +15,13 @@ export interface LineageListProps {
 }
 
 const isTableLinkDisabled = (table: LineageItem) => {
+
+  // check if item is currently indexed in Amundsen, if it's not mark as disabled
+  if (table.in_amundsen === false) {
+    return true;
+  }
+
+  // use configuration to determine weather a table link is disabled or not
   const disableAppListLinks = getTableLineageDisableAppListLinks();
   let disabled = false;
   if (disableAppListLinks) {
@@ -29,6 +36,7 @@ const isTableLinkDisabled = (table: LineageItem) => {
       return disableAppListLinks![key].test(table[key]) === false;
     });
   }
+  
   return disabled;
 };
 

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.27.0,<0.29.0
+amundsen-common>=0.27.0,<0.30.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
- Allow metadata to return an `in_amundsen` field for each lineage item so that table links can be disabled if a table that showed up in lineage data doesn't currently exist in Amundsen (ex: temporary tables)