### PR TITLE
fix: better styling for disabled items

### DIFF
--- a/frontend/amundsen_application/static/css/_list-group.scss
+++ b/frontend/amundsen_application/static/css/_list-group.scss
@@ -16,9 +16,5 @@
       cursor: pointer;
       z-index: 1;
     }
-
-    &.is-disabled {
-      pointer-events: none;
-    }
   }
 }

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -57,7 +57,9 @@ const TableListItem: React.FC<TableListItemProps> = ({
 }) => (
   <li className="list-group-item">
     <Link
-      className={`resource-list-item table-list-item ${disabled ? 'is-disabled' : 'clickable'}`}
+      className={`resource-list-item table-list-item ${
+        disabled ? 'is-disabled' : 'clickable'
+      }`}
       to={getLink(table, logging)}
       onClick={(e) =>
         logClick(e, {

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.tsx
@@ -55,9 +55,9 @@ const TableListItem: React.FC<TableListItemProps> = ({
   tableHighlights,
   disabled,
 }) => (
-  <li className={`list-group-item ${disabled ? 'is-disabled' : 'clickable'}`}>
+  <li className="list-group-item">
     <Link
-      className="resource-list-item table-list-item"
+      className={`resource-list-item table-list-item ${disabled ? 'is-disabled' : 'clickable'}`}
       to={getLink(table, logging)}
       onClick={(e) =>
         logClick(e, {

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/styles.scss
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/styles.scss
@@ -18,7 +18,7 @@ $resource-item-height: 110px;
     pointer-events: none;
     cursor: not-allowed;
     .resource-icon {
-      filter: grayscale(80%);
+      filter: grayscale(1);
     }
     .resource-info .resource-info-text .resource-name {
       color: $text-secondary;

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/styles.scss
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/styles.scss
@@ -14,6 +14,17 @@ $resource-item-height: 110px;
   padding: $spacer-3;
   text-decoration: none;
 
+  &.is-disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    .resource-icon {
+      filter: grayscale(80%);
+    }
+    .resource-info .resource-info-text .resource-name {
+      color: $text-secondary;
+    }
+  }
+
   .description {
     em {
       background-color: $indigo10;


### PR DESCRIPTION
- when a list item is disabled it should look different than the ones that are still enabled to avoid user confusion

<img width="757" alt="Screen Shot 2022-10-18 at 1 18 56 PM" src="https://user-images.githubusercontent.com/22477579/196535805-8bc6c36f-abd6-4cf0-be86-8aa97cfc4490.png">
