### PR TITLE
fix: adds loading spinners to table lineage tabs

### DIFF
--- a/frontend/amundsen_application/static/js/components/ResourceList/styles.scss
+++ b/frontend/amundsen_application/static/js/components/ResourceList/styles.scss
@@ -26,7 +26,7 @@
   .empty-message {
     display: flex;
     justify-content: center;
-    margin: $spacer-4 $spacer-4 0;
+    padding: $spacer-4 $spacer-4 0;
     word-break: break-all;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.spec.tsx
@@ -3,46 +3,84 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import LineageList, { LineageListProps } from './index';
+
+import { LineageList, LineageListProps } from './index';
 
 const setup = (propOverrides?: Partial<LineageListProps>) => {
-  const props: LineageListProps = {
-    items: [
-      {
-        badges: [],
-        cluster: 'gold',
-        database: 'hive',
-        key: 'hive://gold.test_schema/test_table1',
-        level: 0,
-        name: 'test_table1',
-        parent: null,
-        schema: 'test_schema',
-        source: 'hive',
-        usage: 0,
-      },
-    ],
-    direction: 'both',
+  const props = {
+    items: [],
+    direction: 'upstream',
     ...propOverrides,
   };
-  const wrapper = shallow<typeof LineageList>(<LineageList {...props} />);
+  const wrapper = shallow(<LineageList {...props} />);
 
-  return {
-    props,
-    wrapper,
-  };
+  return { props, wrapper };
 };
 
 describe('LineageList', () => {
-  it('should render a link', () => {
-    const { wrapper } = setup();
-    expect(wrapper.find('a').exists).toBeTruthy();
-  });
+  describe('render', () => {
+    it('should render without issues', () => {
+      expect(() => {
+        setup();
+      }).not.toThrow();
+    });
 
-  it('should have a disabled link', () => {
-    const { wrapper } = setup();
-    jest.mock('./index', () => ({
-      isTableLinkDisabled: jest.fn().mockReturnValueOnce(true),
-    }));
-    expect(wrapper.find('is-disabled').exists).toBeTruthy();
+    it('should render a link', () => {
+      const { wrapper } = setup({
+        items: [
+          {
+            badges: [],
+            cluster: 'gold',
+            database: 'hive',
+            key: 'hive://gold.test_schema/test_table1',
+            level: 0,
+            name: 'test_table1',
+            parent: null,
+            schema: 'test_schema',
+            source: 'hive',
+            usage: 0,
+          },
+        ],
+        direction: 'both',
+      });
+
+      expect(wrapper.find('a').exists).toBeTruthy();
+    });
+
+    it('should have a disabled link', () => {
+      jest.mock('./index', () => ({
+        isTableLinkDisabled: jest.fn().mockReturnValueOnce(true),
+      }));
+
+      const { wrapper } = setup({
+        items: [
+          {
+            badges: [],
+            cluster: 'gold',
+            database: 'hive',
+            key: 'hive://gold.test_schema/test_table1',
+            level: 0,
+            name: 'test_table1',
+            parent: null,
+            schema: 'test_schema',
+            source: 'hive',
+            usage: 0,
+          },
+        ],
+        direction: 'both',
+      });
+
+      expect(wrapper.find('is-disabled').exists).toBeTruthy();
+    });
+
+    describe('when no elements are passed', () => {
+      it('should show an empty message', () => {
+        const expected = 1;
+        const { wrapper } = setup({});
+        const actual = wrapper.find('.empty-message').length;
+
+        expect(actual).toBe(expected);
+      });
+    });
   });
 });

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
@@ -9,6 +9,8 @@ import { LineageItem } from 'interfaces/Lineage';
 import TableListItem from 'components/ResourceListItem/TableListItem';
 import { getHighlightedTableMetadata } from 'components/ResourceListItem/MetadataHighlightList/utils';
 
+import { NO_LINEAGE_INFO } from '../constants';
+
 export interface LineageListProps {
   items: LineageItem[];
   direction: string;
@@ -39,32 +41,42 @@ const isTableLinkDisabled = (table: LineageItem) => {
   return disabled;
 };
 
-const LineageList: React.FC<LineageListProps> = ({
+export const LineageList: React.FC<LineageListProps> = ({
   items,
   direction,
-}: LineageListProps) => (
-  <div className="list-group">
-    {items.map((table, index) => {
-      const logging = {
-        index,
-        source: `table_lineage_list_${direction}`,
-      };
-      const tableResource: TableResource = {
-        ...table,
-        type: ResourceType.table,
-        description: '',
-      };
-      return (
-        <TableListItem
-          table={tableResource}
-          logging={logging}
-          key={`lineage-item::${index}`}
-          tableHighlights={getHighlightedTableMetadata(tableResource)}
-          disabled={isTableLinkDisabled(table)}
-        />
-      );
-    })}
-  </div>
-);
+}: LineageListProps) => {
+  if (items.length === 0) {
+    return (
+      <div className="resource-list">
+        <div className="empty-message body-placeholder">{NO_LINEAGE_INFO}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="list-group">
+      {items.map((table, index) => {
+        const logging = {
+          index,
+          source: `table_lineage_list_${direction}`,
+        };
+        const tableResource: TableResource = {
+          ...table,
+          type: ResourceType.table,
+          description: '',
+        };
+        return (
+          <TableListItem
+            table={tableResource}
+            logging={logging}
+            key={`lineage-item::${index}`}
+            tableHighlights={getHighlightedTableMetadata(tableResource)}
+            disabled={isTableLinkDisabled(table)}
+          />
+        );
+      })}
+    </div>
+  );
+};
 
 export default LineageList;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/constants.ts
@@ -19,6 +19,7 @@ export const EXPAND_ALL_NESTED_LABEL = 'Expand all nested';
 export const ESC_BUTTON_KEY = 'Escape';
 export const MIN_WIDTH_DISPLAY_BTN = 1100;
 export const MIN_WIDTH_DISPLAY_BTN_WITH_OPEN_PANEL = 1350;
+export const NO_LINEAGE_INFO = 'No lineage info available';
 
 export enum TABLE_TAB {
   COLUMN = 'columns',

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.spec.tsx
@@ -90,6 +90,7 @@ const setup = (
     getColumnLineageDispatch: jest.fn(),
     openRequestDescriptionDialog: jest.fn(),
     searchSchema: jest.fn(),
+    isLoadingLineage: false,
     ...routerProps,
     ...propOverrides,
   };
@@ -102,9 +103,11 @@ const setup = (
 describe('TableDetail', () => {
   describe('renderTabs', () => {
     let wrapper;
+
     beforeAll(() => {
       ({ wrapper } = setup());
     });
+
     it('does not render dashboard tab when disabled', () => {
       jest
         .spyOn(ConfigUtils, 'indexDashboardsEnabled')
@@ -116,17 +119,20 @@ describe('TableDetail', () => {
       ).toBeFalsy();
     });
 
-    it('renders two tabs when dashboards are enabled', () => {
-      jest
-        .spyOn(ConfigUtils, 'indexDashboardsEnabled')
-        .mockImplementation(() => true);
-      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
-      const tabInfo = content.find(TabsComponent).props().tabs;
-      expect(
-        tabInfo.find((tab) => tab.key === TABLE_TAB.DASHBOARD)
-      ).toBeTruthy();
+    describe('when dashboards are enabled', () => {
+      it('renders two tabs', () => {
+        jest
+          .spyOn(ConfigUtils, 'indexDashboardsEnabled')
+          .mockImplementation(() => true);
+        const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+        const tabInfo = content.find(TabsComponent).props().tabs;
+        expect(
+          tabInfo.find((tab) => tab.key === TABLE_TAB.DASHBOARD)
+        ).toBeTruthy();
+      });
     });
-    it('does not render upstream and downstream tabs when disabled', () => {
+
+    it('does not render upstream and downstream tabs', () => {
       jest
         .spyOn(ConfigUtils, 'isTableListLineageEnabled')
         .mockImplementation(() => false);
@@ -137,18 +143,47 @@ describe('TableDetail', () => {
         tabInfo.find((tab) => tab.key === TABLE_TAB.DOWNSTREAM)
       ).toBeFalsy();
     });
-    it('renders upstream and downstream tabs when enabled', () => {
-      jest
-        .spyOn(ConfigUtils, 'isTableListLineageEnabled')
-        .mockImplementation(() => true);
-      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
-      const tabInfo = content.find(TabsComponent).props().tabs;
-      expect(
-        tabInfo.find((tab) => tab.key === TABLE_TAB.UPSTREAM)
-      ).toBeTruthy();
-      expect(
-        tabInfo.find((tab) => tab.key === TABLE_TAB.DOWNSTREAM)
-      ).toBeTruthy();
+
+    describe('when table lineage is enabled', () => {
+      it('renders upstream and downstream tabs', () => {
+        jest
+          .spyOn(ConfigUtils, 'isTableListLineageEnabled')
+          .mockImplementation(() => true);
+        const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+        const tabInfo = content.find(TabsComponent).props().tabs;
+
+        expect(
+          tabInfo.find((tab) => tab.key === TABLE_TAB.UPSTREAM)
+        ).toBeTruthy();
+        expect(
+          tabInfo.find((tab) => tab.key === TABLE_TAB.DOWNSTREAM)
+        ).toBeTruthy();
+      });
+
+      describe('when loading lineage info', () => {
+        it('renders a loading tab in the lineage tabs', () => {
+          jest
+            .spyOn(ConfigUtils, 'isTableListLineageEnabled')
+            .mockImplementation(() => true);
+          const expected = true;
+          const { wrapper } = setup({
+            isLoadingLineage: true,
+          });
+          const content = shallow(
+            <div>{wrapper.instance().renderTabs(1, 2)}</div>
+          );
+          const tabsInfo = content.find(TabsComponent).props().tabs;
+          const actualUpstream = (tabsInfo.find(
+            (tab) => tab.key === TABLE_TAB.UPSTREAM
+          )?.title as JSX.Element).props.className.includes('is-loading');
+          const actualDownstream = (tabsInfo.find(
+            (tab) => tab.key === TABLE_TAB.DOWNSTREAM
+          )?.title as JSX.Element).props.className.includes('is-loading');
+
+          expect(actualUpstream).toBe(expected);
+          expect(actualDownstream).toBe(expected);
+        });
+      });
     });
   });
 
@@ -170,6 +205,7 @@ describe('TableDetail', () => {
 
   describe('lifecycle', () => {
     const setStateSpy = jest.spyOn(TableDetail.prototype, 'setState');
+
     describe('when mounted', () => {
       it('calls loadDashboard with uri from state', () => {
         const { props } = setup();

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -109,6 +109,7 @@ export interface PropsFromState {
   statusCode: number | null;
   tableData: TableMetadata;
   tableLineage: Lineage;
+  isLoadingLineage: boolean;
 }
 export interface DispatchFromProps {
   getTableData: (
@@ -389,6 +390,7 @@ export class TableDetail extends React.Component<
       isLoadingDashboards,
       numRelatedDashboards,
       tableData,
+      isLoadingLineage,
       tableLineage,
     } = this.props;
     const {
@@ -454,30 +456,43 @@ export class TableDetail extends React.Component<
     }
 
     if (isTableListLineageEnabled()) {
-      if (tableLineage.upstream_entities.length > 0) {
-        tabInfo.push({
-          content: (
-            <LineageList
-              items={tableLineage.upstream_entities}
-              direction="upstream"
-            />
-          ),
-          key: Constants.TABLE_TAB.UPSTREAM,
-          title: `Upstream (${tableLineage.upstream_entities.length})`,
-        });
-      }
-      if (tableLineage.downstream_entities.length > 0) {
-        tabInfo.push({
-          content: (
-            <LineageList
-              items={tableLineage.downstream_entities}
-              direction="downstream"
-            />
-          ),
-          key: Constants.TABLE_TAB.DOWNSTREAM,
-          title: `Downstream (${tableLineage.downstream_entities.length})`,
-        });
-      }
+      const upstreamLoadingTitle = isLoadingLineage ? (
+        <div className="tab-title is-loading">
+          Upstream <LoadingSpinner />
+        </div>
+      ) : (
+        `Upstream (${tableLineage.upstream_entities.length})`
+      );
+
+      tabInfo.push({
+        content: (
+          <LineageList
+            items={tableLineage.upstream_entities}
+            direction="upstream"
+          />
+        ),
+        key: Constants.TABLE_TAB.UPSTREAM,
+        title: upstreamLoadingTitle,
+      });
+
+      const downstreamLoadingTitle = isLoadingLineage ? (
+        <div className="tab-title is-loading">
+          Downstream <LoadingSpinner />
+        </div>
+      ) : (
+        `Downstream (${tableLineage.downstream_entities.length})`
+      );
+
+      tabInfo.push({
+        content: (
+          <LineageList
+            items={tableLineage.downstream_entities}
+            direction="downstream"
+          />
+        ),
+        key: Constants.TABLE_TAB.DOWNSTREAM,
+        title: downstreamLoadingTitle,
+      });
     }
 
     return (
@@ -791,6 +806,7 @@ export const mapStateToProps = (state: GlobalState) => ({
   statusCode: state.tableMetadata.statusCode,
   tableData: state.tableMetadata.tableData,
   tableLineage: state.lineage.lineageTree,
+  isLoadingLineage: state.lineage ? state.lineage.isLoading : true,
   numRelatedDashboards: state.tableMetadata.dashboards
     ? state.tableMetadata.dashboards.dashboards.length
     : 0,


### PR DESCRIPTION
### Summary of Changes
Adds loading spinners to the table lineage tabs
Makes it consistent with the dashboard tab loading state 

### Tests
Added tests

### Screenshots

<img width="1323" alt="AMS" src="https://user-images.githubusercontent.com/190833/198372662-f0cde4b4-5438-408b-be30-5ea270e17b5e.png">

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
