### PR TITLE
Fix: Change default value for 'description' in BigQuery_metadata_extractor results

### DIFF
--- a/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/bigquery_metadata_extractor.py
@@ -85,7 +85,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                     cluster=tableRef['projectId'],
                     schema=tableRef['datasetId'],
                     name=table_id,
-                    description=table.get('description', ''),
+                    description=table.get('description', None),
                     columns=cols,
                     is_view=table['type'] == 'VIEW')
 
@@ -106,7 +106,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
         if column['type'] == 'RECORD':
             col = ColumnMetadata(
                 name=col_name,
-                description=column.get('description', ''),
+                description=column.get('description', None),
                 col_type=get_column_type(column),
                 sort_order=total_cols)
             cols.append(col)
@@ -121,7 +121,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
         else:
             col = ColumnMetadata(
                 name=col_name,
-                description=column.get('description', ''),
+                description=column.get('description', None),
                 col_type=get_column_type(column),
                 sort_order=total_cols)
             cols.append(col)

--- a/databuilder/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/databuilder/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -266,7 +266,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEqual(result.cluster, 'your-project-here')
         self.assertEqual(result.schema, 'fdgdfgh')
         self.assertEqual(result.name, 'nested_recs')
-        self.assertEqual(result.description.text, '')
+        self.assertEqual(result.description, None)
         self.assertEqual(result.columns, [])
         self.assertEqual(result.is_view, False)
 
@@ -282,7 +282,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEqual(result.cluster, 'your-project-here')
         self.assertEqual(result.schema, 'fdgdfgh')
         self.assertEqual(result.name, 'nested_recs')
-        self.assertEqual(result.description.text, "")
+        self.assertEqual(result.description, None)
         self.assertEqual(result.columns, [])
         self.assertEqual(result.is_view, False)
 
@@ -308,7 +308,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEqual(result.cluster, 'your-project-here')
         self.assertEqual(result.schema, 'fdgdfgh')
         self.assertEqual(result.name, 'nested_recs')
-        self.assertEqual(result.description.text, "")
+        self.assertEqual(result.description, None)
 
         first_col = result.columns[0]
         self.assertEqual(first_col.name, 'test')


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes
Changed the default type of table and column description in BigQuery_metadata_extractor to None.
This change was made so that the table and columns descriptions entered through the UI persist in the backend db (mysql in our case).
Currently because the default is an empty string every time metadata is extracted from BigQuery the descriptions entered through the UI are overwritten by the empty string.
This can be avoided by making sure description is set to None if it does not exist.
https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/models/description_metadata.py#L75

<!-- Include a summary of changes -->

### Tests

<!-- What tests did you add or modify and why? If no tests were added or modified, explain why. -->

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
