### PR TITLE
Fix: Corrected position of arguments in _par

### DIFF
--- a/metadata/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata/metadata_service/proxy/gremlin_proxy.py
@@ -1958,8 +1958,8 @@ class AbstractGremlinProxy(BaseProxy):
 
         raise NotImplementedError(f"Don't know how to handle UserResourceRel={relation}")
 
-    def _parse_lineage(self, resource_type: ResourceType, type_: str, upstream_tables: List[LineageItem], path: Path,
-                       downstream_tables: List[LineageItem]) -> Tuple[List[LineageItem], List[LineageItem]]:
+    def _parse_lineage(self, resource_type: ResourceType, type_: str, upstream_tables: List[LineageItem],
+                       downstream_tables: List[LineageItem], path: Path) -> Tuple[List[LineageItem], List[LineageItem]]:
         """
         Helper function to parse the lineage path
         :param resource_type: Type of the entity for which lineage is being retrieved
@@ -2035,8 +2035,11 @@ class AbstractGremlinProxy(BaseProxy):
             if path_list == []:
                 continue
             for path in path_list:
-                upstream_tables, downstream_tables = self._parse_lineage(resource_type, type_,
-                                                                         upstream_tables, downstream_tables, path)
+                upstream_tables, downstream_tables = self._parse_lineage(resource_type=resource_type, 
+                                                                         type_=type_,
+                                                                         upstream_tables=upstream_tables,
+                                                                         downstream_tables=downstream_tables, 
+                                                                         path=path)
 
         return Lineage(**{"key": id,
                           "upstream_entities": upstream_tables,

--- a/metadata/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata/metadata_service/proxy/gremlin_proxy.py
@@ -2035,10 +2035,10 @@ class AbstractGremlinProxy(BaseProxy):
             if path_list == []:
                 continue
             for path in path_list:
-                upstream_tables, downstream_tables = self._parse_lineage(resource_type=resource_type, 
+                upstream_tables, downstream_tables = self._parse_lineage(resource_type=resource_type,
                                                                          type_=type_,
                                                                          upstream_tables=upstream_tables,
-                                                                         downstream_tables=downstream_tables, 
+                                                                         downstream_tables=downstream_tables,
                                                                          path=path)
 
         return Lineage(**{"key": id,


### PR DESCRIPTION
### Summary of Changes

- Swapped order of `path` and `downstream_tables` arguments in `_parse_lineage` function. 
- Added in kwargs when calling function to increase robustness.

### Tests

Test suites not relevant for this bug fix, but changes have been tested internally with Neptune server.

### Documentation

No documentation to add as there is no change in behavior. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
