### PR TITLE
fix: disable default tls configuration for Amundsen Helm chart Ingress

### DIFF
--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -403,7 +403,7 @@ elasticsearch:
     
 ##############  Values for ingress ###############
 ingress:
-  # --  set this to true, if you want a ingress that expose HTTP and HTTPS routes from outside the cluster to your amundsen services. Do not use this if you are in a public cloud such as AWS, GCP
+  # --  set this to true, if you want a ingress that expose HTTP (or HTTPS) routes from outside the cluster to your amundsen services. Do not use this if you are in a public cloud such as AWS, GCP
   enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
@@ -412,7 +412,7 @@ ingress:
   hosts:
     - host: amundsen-test.your-domain.com
       paths: [/]
-  tls: 
-    - hosts:
-        - amundsen-test.your-domain.com
-     # secretName: chart-example-tls
+  # tls:
+    # - hosts:
+      # - amundsen-test.your-domain.com
+    # secretName: chart-example-tls


### PR DESCRIPTION
**fix: disable default tls configuration for Amundsen Helm chart Ingress**

### Summary of Changes

By default, the ingress resource is exposed on both :80 & :443 when specifying `ingress: enabled`. The tls configuration of the Ingress resource should be optional by design.

In my case, this caused a 308-exception 'ERROR_TOO_MANY_REDIRECTS' since the network load balancer directing to the host kept bouncing between the two ports.