### PR TITLE
feat: extends resource notices to support extra information

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -358,7 +358,7 @@ exports[`eslint`] = {
       [22, 0, 63, "\`../../fixtures/mockRouter\` import should occur before import of \`./ChartList\`", "1389010998"],
       [24, 0, 41, "\`./constants\` import should occur before import of \`.\`", "1965203596"]
     ],
-    "js/pages/DashboardPage/index.tsx:3010480372": [
+    "js/pages/DashboardPage/index.tsx:2797495925": [
       [131, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/pages/HomePage/index.tsx:3641863187": [
@@ -385,7 +385,7 @@ exports[`eslint`] = {
     "js/pages/SearchPage/constants.ts:449734368": [
       [13, 2, 112, "Multiline support is limited to browsers supporting ES5 only.", "2645164555"]
     ],
-    "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1481074794": [
+    "js/pages/TableDetailPage/DataPreviewButton/index.tsx:1653401263": [
       [155, 8, 9, "\'iconClass\' is assigned a value but never used.", "2230586016"],
       [165, 6, 191, "Missing an explicit type attribute for button", "1938977214"]
     ],
@@ -405,7 +405,7 @@ exports[`eslint`] = {
     "js/pages/TableDetailPage/TableOwnerEditor/index.spec.tsx:3131789494": [
       [3, 12, 5, "\'React\' is defined but never used.", "229961444"]
     ],
-    "js/pages/TableDetailPage/index.tsx:3804941350": [
+    "js/pages/TableDetailPage/index.tsx:1823166057": [
       [164, 2, 20, "key should be placed after componentWillUnmount", "3916788587"],
       [218, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],

--- a/frontend/amundsen_application/static/css/_buttons-default.scss
+++ b/frontend/amundsen_application/static/css/_buttons-default.scss
@@ -19,7 +19,6 @@ $outline-width: 2px;
   &.btn-default {
     border-width: 2px;
     font-weight: $font-weight-body-bold;
-    height: 32px;
     padding: 6px $spacer-2;
 
     img.icon {

--- a/frontend/amundsen_application/static/css/_popovers.scss
+++ b/frontend/amundsen_application/static/css/_popovers.scss
@@ -77,19 +77,21 @@
 
 // Modals
 .modal-header {
+  text-align: left;
   border-bottom: none;
   padding: $spacer-3 $spacer-3 $spacer-2;
+}
+
+.modal-title {
+  @extend %text-title-w1;
+}
+
+.modal-body {
+  text-align: left;
+  padding: $spacer-2 $spacer-3;
 }
 
 .modal-footer {
   border-top: none;
   padding: $spacer-2 $spacer-3 $spacer-3;
-}
-
-.modal-body {
-  padding: $spacer-2 $spacer-3;
-}
-
-.modal-title {
-  @extend %text-title-w1;
 }

--- a/frontend/amundsen_application/static/css/_popovers.scss
+++ b/frontend/amundsen_application/static/css/_popovers.scss
@@ -3,6 +3,7 @@
 
 // TODO - Override Bootstrap variables and delete this.
 @import 'variables';
+@import 'typography';
 
 .popover {
   background-color: $body-bg-dark;
@@ -71,4 +72,24 @@
   height: 24px;
   margin: auto;
   width: 24px;
+}
+
+
+// Modals
+.modal-header {
+  border-bottom: none;
+  padding: $spacer-3 $spacer-3 $spacer-2;
+}
+
+.modal-footer {
+  border-top: none;
+  padding: $spacer-2 $spacer-3 $spacer-3;
+}
+
+.modal-body {
+  padding: $spacer-2 $spacer-3;
+}
+
+.modal-title {
+  @extend %text-title-w1;
 }

--- a/frontend/amundsen_application/static/js/components/Alert/alert.story.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/alert.story.tsx
@@ -78,8 +78,14 @@ export const AlertWithActionStory = (): React.ReactNode => (
       <Alert
         message="Alert with payload"
         payload={{
-          testKey: 'testValue',
-          testKey2: 'testHTMLVAlue <a href="http://lyft.com">Lyft</a>',
+          'Table name': 'coco.fact_rides',
+          'Verity checks':
+            '1 out of 4 checks failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+          'Failed DAGs':
+            '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+          'Root cause':
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod',
+          Estimate: 'Target fix by MM/DD/YYYY 00:00',
         }}
       />
     </StorySection>

--- a/frontend/amundsen_application/static/js/components/Alert/alert.story.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/alert.story.tsx
@@ -74,6 +74,15 @@ export const AlertWithActionStory = (): React.ReactNode => (
         }
       />
     </StorySection>
+    <StorySection title="Alert with payload">
+      <Alert
+        message="Alert with payload"
+        payload={{
+          testKey: 'testValue',
+          testKey2: 'testHTMLVAlue <a href="http://lyft.com">Lyft</a>',
+        }}
+      />
+    </StorySection>
   </>
 );
 

--- a/frontend/amundsen_application/static/js/components/Alert/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/index.spec.tsx
@@ -189,6 +189,68 @@ describe('Alert', () => {
 
         expect(actual).toEqual(expected);
       });
+
+      it('should render the alert payload modal', () => {
+        const { wrapper } = setup({
+          payload: testPayload,
+        });
+        const expected = 1;
+
+        wrapper.find('button.btn-link.btn-payload').simulate('click');
+        wrapper.update();
+
+        const actual = wrapper.find('.modal.alert-payload-modal').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should render the alert payload modal header with the payload', () => {
+        const { wrapper } = setup({
+          payload: testPayload,
+        });
+        const expected = 1;
+
+        wrapper.find('button.btn-link.btn-payload').simulate('click');
+        wrapper.update();
+
+        const actual = wrapper
+          .find('.modal.alert-payload-modal .modal-header')
+          .find('.modal-title').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should render the alert payload modal body with the payload', () => {
+        const { wrapper } = setup({
+          payload: testPayload,
+        });
+        const expected = 1;
+
+        wrapper.find('button.btn-link.btn-payload').simulate('click');
+        wrapper.update();
+
+        const actual = wrapper
+          .find('.modal.alert-payload-modal .modal-body')
+          .find('.definition-list').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should render the alert payload modal footer with a close button', () => {
+        const { wrapper } = setup({
+          payload: testPayload,
+        });
+        const expected = 1;
+
+        wrapper.find('button.btn-link.btn-payload').simulate('click');
+        wrapper.update();
+
+        const actual = wrapper
+          .find('.modal.alert-payload-modal .modal-footer')
+          .find('.payload-modal-close').length;
+
+        expect(actual).toEqual(expected);
+      });
     });
   });
 });

--- a/frontend/amundsen_application/static/js/components/Alert/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/index.spec.tsx
@@ -132,11 +132,28 @@ describe('Alert', () => {
         expect(actual).toEqual(expected);
       });
     });
+
+    describe('when passing a payload', () => {
+      const testPayload = {
+        testKey: 'testValue',
+        testKey2: 'testHTMLVAlue <a href="http://lyft.com">Lyft</a>',
+      };
+
+      it('should render the "see details" button link', () => {
+        const { wrapper } = setup({
+          payload: testPayload,
+        });
+        const expected = 1;
+        const actual = wrapper.find('.btn-link.btn-payload').length;
+
+        expect(actual).toEqual(expected);
+      });
+    });
   });
 
   describe('lifetime', () => {
     describe('when clicking on the action button', () => {
-      it('should call the handler', () => {
+      it('should call the onAction handler', () => {
         const handlerSpy = jest.fn();
         const { wrapper } = setup({
           actionText: 'Action Text',
@@ -145,6 +162,28 @@ describe('Alert', () => {
         const expected = 1;
 
         wrapper.find('button.btn-link').simulate('click');
+
+        const actual = handlerSpy.mock.calls.length;
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('when clicking on the see details button of a payload alert', () => {
+      const testPayload = {
+        testKey: 'testValue',
+        testKey2: 'testHTMLVAlue <a href="http://lyft.com">Lyft</a>',
+      };
+
+      it('should call the onAction handler', () => {
+        const handlerSpy = jest.fn();
+        const { wrapper } = setup({
+          onAction: handlerSpy,
+          payload: testPayload,
+        });
+        const expected = 1;
+
+        wrapper.find('button.btn-link.btn-payload').simulate('click');
 
         const actual = handlerSpy.mock.calls.length;
 

--- a/frontend/amundsen_application/static/js/components/Alert/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/index.tsx
@@ -20,6 +20,7 @@ const SEVERITY_TO_SEVERITY_CLASS = {
   [NoticeSeverity.WARNING]: 'is-warning',
   [NoticeSeverity.ALERT]: 'is-alert',
 };
+const OPEN_PAYLOAD_CTA = 'See details';
 
 export interface AlertProps {
   /** Message to show in the alert */
@@ -34,6 +35,8 @@ export interface AlertProps {
   actionHref?: string;
   /** Callback to call when the action is clicked */
   onAction?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Optional extra info to render in a modal */
+  payload?: Record<string, string>;
 }
 
 const Alert: React.FC<AlertProps> = ({
@@ -43,8 +46,27 @@ const Alert: React.FC<AlertProps> = ({
   actionText,
   actionHref,
   actionLink,
+  payload,
 }: AlertProps) => {
   let action: null | React.ReactNode = null;
+
+  const handleSeeDetails = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onAction?.(e);
+
+    console.log('see details!');
+  };
+
+  if (payload) {
+    action = (
+      <button
+        type="button"
+        className="btn btn-link btn-payload"
+        onClick={handleSeeDetails}
+      >
+        {OPEN_PAYLOAD_CTA}
+      </button>
+    );
+  }
 
   if (actionText && onAction) {
     action = (

--- a/frontend/amundsen_application/static/js/components/Alert/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/index.tsx
@@ -58,8 +58,6 @@ const Alert: React.FC<AlertProps> = ({
   const handleSeeDetails = (e: React.MouseEvent<HTMLButtonElement>) => {
     onAction?.(e);
     setShowPayloadModal(true);
-
-    console.log('see details!');
   };
   const handleModalClose = () => {
     setShowPayloadModal(false);

--- a/frontend/amundsen_application/static/js/components/Alert/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/index.tsx
@@ -3,10 +3,12 @@
 
 import * as React from 'react';
 import SanitizedHTML from 'react-sanitized-html';
+import { Modal } from 'react-bootstrap';
 
 import { IconSizes } from 'interfaces';
 import { NoticeSeverity } from 'config/config-types';
 import { AlertIcon, InformationIcon } from 'components/SVGIcons';
+import { DefinitionList, DefinitionType } from 'components/DefinitionList';
 
 import './styles.scss';
 
@@ -21,6 +23,8 @@ const SEVERITY_TO_SEVERITY_CLASS = {
   [NoticeSeverity.ALERT]: 'is-alert',
 };
 const OPEN_PAYLOAD_CTA = 'See details';
+const PAYLOAD_MODAL_TITLE = 'Summary';
+const PAYLOAD_MODAL_CLOSE_BTN = 'Close';
 
 export interface AlertProps {
   /** Message to show in the alert */
@@ -48,12 +52,17 @@ const Alert: React.FC<AlertProps> = ({
   actionLink,
   payload,
 }: AlertProps) => {
+  const [showPayloadModal, setShowPayloadModal] = React.useState(false);
   let action: null | React.ReactNode = null;
 
   const handleSeeDetails = (e: React.MouseEvent<HTMLButtonElement>) => {
     onAction?.(e);
+    setShowPayloadModal(true);
 
     console.log('see details!');
+  };
+  const handleModalClose = () => {
+    setShowPayloadModal(false);
   };
 
   if (payload) {
@@ -110,11 +119,41 @@ const Alert: React.FC<AlertProps> = ({
   const formattedMessage =
     typeof message === 'string' ? <SanitizedHTML html={message} /> : message;
 
+  const payloadDefinitions = payload
+    ? Object.keys(payload).map((key) => ({
+        term: key,
+        description: payload[key],
+      }))
+    : null;
+
   return (
     <div className={`alert ${SEVERITY_TO_SEVERITY_CLASS[severity]}`}>
       {iconComponent}
       <p className="alert-message">{formattedMessage}</p>
       {action && <span className="alert-action">{action}</span>}
+      {payloadDefinitions && (
+        <Modal
+          className="alert-payload-modal"
+          show={showPayloadModal}
+          onHide={handleModalClose}
+        >
+          <Modal.Header closeButton onHide={handleModalClose}>
+            <Modal.Title>{PAYLOAD_MODAL_TITLE}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <DefinitionList definitions={payloadDefinitions} termWidth={120} />
+          </Modal.Body>
+          <Modal.Footer>
+            <button
+              className="btn btn-primary payload-modal-close"
+              type="button"
+              onClick={handleModalClose}
+            >
+              {PAYLOAD_MODAL_CLOSE_BTN}
+            </button>
+          </Modal.Footer>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/frontend/amundsen_application/static/js/components/Alert/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/index.tsx
@@ -8,7 +8,7 @@ import { Modal } from 'react-bootstrap';
 import { IconSizes } from 'interfaces';
 import { NoticeSeverity } from 'config/config-types';
 import { AlertIcon, InformationIcon } from 'components/SVGIcons';
-import { DefinitionList, DefinitionType } from 'components/DefinitionList';
+import { DefinitionList } from 'components/DefinitionList';
 
 import './styles.scss';
 

--- a/frontend/amundsen_application/static/js/components/DefinitionList/definitionList.story.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/definitionList.story.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable no-alert */
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+
+import StorySection from '../StorySection';
+import { DefinitionList } from '.';
+
+export const DefinitionListStory = (): React.ReactNode => (
+  <>
+    <StorySection title="DefinitionList">
+      <DefinitionList
+        definitions={[
+          {
+            term: 'Table name',
+            description: 'coco.fact_rides',
+          },
+          {
+            term: 'Root cause',
+            description:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod',
+          },
+          {
+            term: 'Estimate',
+            description: 'Target fix by MM/DD/YYYY 00:00',
+          },
+        ]}
+      />
+    </StorySection>
+    <StorySection title="DefinitionList with html descriptions">
+      <DefinitionList
+        definitions={[
+          {
+            term: 'Verity checks',
+            description:
+              '1 out of 4 checks failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+          },
+          {
+            term: 'Failed DAGs',
+            description:
+              '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+          },
+        ]}
+      />
+    </StorySection>
+    <StorySection title="DefinitionList with fixed term width">
+      <DefinitionList
+        termWidth={200}
+        definitions={[
+          {
+            term: 'Table name',
+            description: 'coco.fact_rides',
+          },
+          {
+            term: 'Failed DAGs',
+            description:
+              '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+          },
+        ]}
+      />
+    </StorySection>
+  </>
+);
+
+DefinitionListStory.storyName = 'with basic options';
+
+export default {
+  title: 'Components/DefinitionList',
+  component: DefinitionList,
+  decorators: [],
+} as Meta;

--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.spec.tsx
@@ -1,0 +1,153 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import { DefinitionList, DefinitionListProps } from '.';
+
+const setup = (propOverrides?: Partial<DefinitionListProps>) => {
+  const props: DefinitionListProps = {
+    definitions: [{ term: 'testTerm', description: 'testDescription' }],
+    ...propOverrides,
+  };
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  const wrapper = mount(<DefinitionList {...props} />);
+
+  return {
+    props,
+    wrapper,
+  };
+};
+
+describe('DefinitionList', () => {
+  describe('render', () => {
+    it('should render a definition list', () => {
+      const { wrapper } = setup();
+      const expected = 1;
+      const actual = wrapper.find('dl').length;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should render one definition container', () => {
+      const { wrapper } = setup();
+      const expected = 1;
+      const actual = wrapper.find('.definition-list-container').length;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should render one definition term', () => {
+      const { wrapper } = setup();
+      const expected = 1;
+      const actual = wrapper.find('.definition-list-term').length;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should render one definition definition', () => {
+      const { wrapper } = setup();
+      const expected = 1;
+      const actual = wrapper.find('.definition-list-definition').length;
+
+      expect(actual).toEqual(expected);
+    });
+
+    describe('when passing several definitions', () => {
+      it('should render as many containers', () => {
+        const { wrapper } = setup({
+          definitions: [
+            {
+              term: 'Table name',
+              description: 'coco.fact_rides',
+            },
+            {
+              term: 'Root cause',
+              description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod',
+            },
+            {
+              term: 'Estimate',
+              description: 'Target fix by MM/DD/YYYY 00:00',
+            },
+          ],
+        });
+        const expected = 3;
+        const actual = wrapper.find('.definition-list-container').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('should render as many terms-definition pairs', () => {
+        const { wrapper } = setup({
+          definitions: [
+            {
+              term: 'Table name',
+              description: 'coco.fact_rides',
+            },
+            {
+              term: 'Root cause',
+              description:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod',
+            },
+            {
+              term: 'Estimate',
+              description: 'Target fix by MM/DD/YYYY 00:00',
+            },
+          ],
+        });
+        const expected = 3;
+        const actualTerms = wrapper.find('.definition-list-term').length;
+        const actualDefinitions = wrapper.find(
+          '.definition-list-definition'
+        ).length;
+
+        expect(actualTerms).toEqual(expected);
+        expect(actualDefinitions).toEqual(expected);
+      });
+    });
+
+    describe('when passing definitions with html', () => {
+      it('should render them', () => {
+        const { wrapper } = setup({
+          definitions: [
+            {
+              term: 'Verity checks',
+              description:
+                '1 out of 4 checks failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+            },
+            {
+              term: 'Failed DAGs',
+              description:
+                '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+            },
+          ],
+        });
+        const expected = 2;
+        const actualTerms = wrapper.find('.definition-list-term').length;
+        const actualDefinitions = wrapper.find(
+          '.definition-list-definition'
+        ).length;
+
+        expect(actualTerms).toEqual(expected);
+        expect(actualDefinitions).toEqual(expected);
+      });
+    });
+
+    describe('when passing a custom term width', () => {
+      it('should set its width', () => {
+        const { wrapper } = setup({
+          termWidth: 200,
+        });
+        const expected = 'min-width: 200px;';
+        const actual = wrapper
+          .find('.definition-list-term')
+          ?.getDOMNode()
+          ?.getAttribute('style');
+
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
@@ -1,0 +1,48 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import SanitizedHTML from 'react-sanitized-html';
+
+import './styles.scss';
+
+export interface DefinitionType {
+  /** Definition term */
+  term: string;
+  /** Definition body text */
+  description: React.ReactNode;
+}
+
+export interface DefinitionListProps {
+  /** Size to fix the term block, in pixels*/
+  termWidth?: number;
+  /** List of terms and descriptions to render */
+  definitions: DefinitionType[];
+}
+
+export const DefinitionList: React.FC<DefinitionListProps> = ({
+  definitions,
+  termWidth,
+}) => (
+  <dl className="definition-list">
+    {definitions.map(({ term, description }) => (
+      <div className="definition-list-container" key={term}>
+        <dt
+          className="definition-list-term"
+          style={{ minWidth: termWidth ? `${termWidth}px` : 'auto' }}
+        >
+          {term}
+        </dt>
+        <dd className="definition-list-definition">
+          {typeof description === 'string' ? (
+            <SanitizedHTML html={description} />
+          ) : (
+            description
+          )}
+        </dd>
+      </div>
+    ))}
+  </dl>
+);
+
+export default DefinitionList;

--- a/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
@@ -17,7 +17,8 @@
 }
 
 .definition-list-term {
-  @extend %text-body-w3;
+  @extend %text-title-w3;
+  color: $gray40;
   padding-right: $spacer-1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Amundsen project.
+// SPDX-License-Identifier: Apache-2.0
+@import 'variables';
+@import 'typography';
+
+.definition-list {
+  margin: 0;
+}
+
+.definition-list-container {
+  display: flex;
+  padding-bottom: $spacer-2;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+}
+
+.definition-list-term {
+  @extend %text-body-w3;
+  padding-right: $spacer-1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.definition-list-definition {
+  @extend %text-body-w3;
+  margin-left: 0;
+  margin-bottom: 0;
+}

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -206,6 +206,7 @@ export enum NoticeSeverity {
 export interface NoticeType {
   severity: NoticeSeverity;
   messageHtml: string | ((resourceName: string) => string);
+  payload?: Record<string, string>;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -411,6 +411,37 @@ describe('getResourceNotices', () => {
       });
     });
   });
+
+  describe('when there is a notice with payload', () => {
+    it('returns the notice and payload', () => {
+      const resources = [ResourceType.table, ResourceType.dashboard];
+
+      resources.forEach((resource) => {
+        AppConfig.resourceConfig[resource].notices = {
+          'cluster1.datasource1.schema1.table1': {
+            severity: NoticeSeverity.WARNING,
+            messageHtml: 'testMessage',
+            payload: {
+              testKey: 'testValue',
+              testKey2: 'testHTMLVAlue <a href="http://lyft.com">Lyft</a>',
+            },
+          },
+        };
+        const expectedFirstLine = 'testValue';
+        const expectedSecondLine =
+          'testHTMLVAlue <a href="http://lyft.com">Lyft</a>';
+        const notice = ConfigUtils.getResourceNotices(
+          resource,
+          'cluster1.datasource1.schema1.table1'
+        );
+        const actualFirstLine = notice && notice?.payload?.testKey;
+        const actualSecondLine = notice && notice?.payload?.testKey2;
+
+        expect(actualFirstLine).toEqual(expectedFirstLine);
+        expect(actualSecondLine).toEqual(expectedSecondLine);
+      });
+    });
+  });
 });
 
 describe('getFilterConfigByResource', () => {

--- a/frontend/amundsen_application/static/js/features/Feedback/styles.scss
+++ b/frontend/amundsen_application/static/js/features/Feedback/styles.scss
@@ -30,7 +30,7 @@ $label-width: 65px;
   right: 76px;
   top: $nav-bar-height + 4px;
   width: 400px;
-  z-index: 2;
+  z-index: 9;
 
   .feedback-header {
     display: flex;

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/index.tsx
@@ -287,6 +287,7 @@ export class DashboardPage extends React.Component<
               <Alert
                 message={dashboardNotice.messageHtml}
                 severity={dashboardNotice.severity}
+                payload={dashboardNotice.payload}
               />
             )}
             <EditableSection

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataPreviewButton/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataPreviewButton/index.tsx
@@ -202,7 +202,11 @@ export class DataPreviewButton extends React.Component<
     return (
       <>
         {this.renderPreviewButton()}
-        <Modal show={showModal} onHide={this.handleClose}>
+        <Modal
+          className="data-preview-modal"
+          show={showModal}
+          onHide={this.handleClose}
+        >
           <Modal.Header className="text-center" closeButton>
             <Modal.Title>{modalTitle}</Modal.Title>
           </Modal.Header>

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/DataPreviewButton/styles.scss
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/DataPreviewButton/styles.scss
@@ -7,23 +7,18 @@
   display: inline-block;
 }
 
-.modal-dialog {
-  width: 90%;
+.data-preview-modal {
+  .modal-dialog {
+    width: 90%;
+  }
 
   .modal-content {
     min-height: 90%;
+  }
 
-    .modal-title {
-      font-family: $font-family-header;
-      font-size: 20px;
-      font-weight: $font-weight-header-bold;
-    }
-
-    .modal-body {
-      margin: 15px;
-      overflow-y: scroll;
-      padding: 0;
-      text-align: center;
-    }
+  .modal-body {
+    overflow-y: scroll;
+    padding: 0;
+    text-align: center;
   }
 }

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -704,6 +704,7 @@ export class TableDetail extends React.Component<
                 <Alert
                   message={tableNotice.messageHtml}
                   severity={tableNotice.severity}
+                  payload={tableNotice.payload}
                 />
               )}
               <EditableSection

--- a/frontend/docs/application_config.md
+++ b/frontend/docs/application_config.md
@@ -309,6 +309,29 @@ If you want to use a dynamic HTML message that changes depending on the name of 
 
 The above code will show a notice with a dynamic message and a red exclamation icon whenever a final user visits any table within the specified cluster, database, and schema or any dashboard within the specified product, cluster, and groupname. We can also use dynamic messages for notices without the wildcard by replacing the \* with the specific table or dashboard name.
 
+You can also add extra information on the notices, that will be rendered as a modal. Here is a configuration example:
+```
+  resourceConfig: {
+    [ResourceType.table]: {
+      ... //Table Resource Configuration
+      notices: {
+          "<CLUSTER>.<DATABASE>.<SCHEMA>.<TABLENAME>": {
+            severity: NoticeSeverity.ALERT,
+            messageHtml: `This table is deprecated, please use <a href="<LINKTONEWTABLEDETAILPAGE>">this new table</a> instead.`,
+            payload: {
+              testKey: "testValue",
+              testKey2: 'testHTMLVAlue <a href="http://lyft.com">Lyft</a>',
+            },
+          },
+      },
+    },
+
+  },
+```
+
+The above code will show a notice with a "See details" link that will open a modal that renders a list of the payload key/value pairs.
+
+
 This feature's ultimate goal is to allow Amundsen administrators to point their users to more trusted/higher quality resources without removing the old references.
 
 Learn more about the future developments for this feature in [its RFC](https://github.com/amundsen-io/rfcs/blob/master/rfcs/029-resource-notices.md).


### PR DESCRIPTION
### Summary of Changes
Extends the notices feature to support showing extra information about the notices
Creates reusable DefinitionList component
Tweaks button styles
Normalizes Modal styles

### Tests
Added tests

### Screenshots
<img width="885" alt="AMS" src="https://user-images.githubusercontent.com/190833/206010015-01584bf7-f68e-4a3b-b284-6799efe6dffa.png">

<img width="1130" alt="AMS" src="https://user-images.githubusercontent.com/190833/206010177-111a57a2-9fff-4c5c-a322-513422654737.png">


### Documentation
Updated

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
