### PR TITLE
Fixes UI crashing on "search page" if we multiple filters with the same category are added (issue #2053)

### DIFF
--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.spec.tsx
@@ -199,9 +199,9 @@ describe('SearchFilter', () => {
     });
 
     it('calls createFilterSection with correct key and section for each props.filterSections', () => {
-      props.filterSections.forEach((section) => {
+      props.filterSections.forEach((section, index) => {
         expect(createFilterSectionSpy).toHaveBeenCalledWith(
-          `section:${section.categoryId}`,
+          `section:${section.categoryId}-${index}`,
           section
         );
       });

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.tsx
@@ -92,8 +92,8 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
   };
 
   renderFilterSections = (filterSections) =>
-    filterSections.map((section) =>
-      this.createFilterSection(`section:${section.categoryId}`, section)
+    filterSections.map((section, index) =>
+      this.createFilterSection(`section:${section.categoryId}-${index}`, section)
     );
 
   render = () => {

--- a/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/SearchFilter/index.tsx
@@ -93,7 +93,10 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
 
   renderFilterSections = (filterSections) =>
     filterSections.map((section, index) =>
-      this.createFilterSection(`section:${section.categoryId}-${index}`, section)
+      this.createFilterSection(
+        `section:${section.categoryId}-${index}`,
+        section
+      )
     );
 
   render = () => {


### PR DESCRIPTION
Signed-off-by: Muhammad Mikaal S. Anwar <mikaalanwar@gmail.com>

This PR provides a fix for the [issue](https://github.com/amundsen-io/amundsen/issues/2053) by allowing multiple search filters per category.

### Summary of Changes

The section filter key is updated to be unique (by appending an index) in order to ensure it gets re-rendered properly upon each transition of resource type (switching back and forth from Tables to Dashboards) on the search page.

### Tests

It's a minor change in internal to a component so no further testing was needed. Relevant tests have been updated accordingly.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
