### PR TITLE
feat: Make default depth configurable for table lineage graph view

### DIFF
--- a/frontend/amundsen_application/static/js/config/config-default.ts
+++ b/frontend/amundsen_application/static/js/config/config-default.ts
@@ -359,6 +359,7 @@ const configDefault: AppConfig = {
       table: string
     ) =>
       `https://DEFAULT_LINEAGE_URL?schema=${schema}&cluster=${cluster}&db=${database}&table=${table}`,
+    defaultLineageDepth: 5,
   },
   columnLineage: {
     inAppListEnabled: false,

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -388,6 +388,7 @@ interface TableLineageConfig {
   ) => string;
   inAppPageEnabled: boolean;
   disableAppListLinks?: TableLineageDisableAppListLinksConfig;
+  defaultLineageDepth: number;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -491,6 +491,13 @@ export function getTableLineageDisableAppListLinks() {
 }
 
 /**
+ * Returns the depth of lineage you should see in the lineage page
+ */
+export function getTableLineageDefaultDepth() {
+  return AppConfig.tableLineage.defaultLineageDepth
+}
+
+/**
  * Returns the lineage link for a given column
  */
 export function getColumnLineageLink(

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -494,7 +494,7 @@ export function getTableLineageDisableAppListLinks() {
  * Returns the depth of lineage you should see in the lineage page
  */
 export function getTableLineageDefaultDepth() {
-  return AppConfig.tableLineage.defaultLineageDepth
+  return AppConfig.tableLineage.defaultLineageDepth;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -834,6 +834,15 @@ describe('isTableLineagePageEnabled', () => {
   });
 });
 
+describe('getTableLineageDefaultDepth', () => {
+  it('returns getTableLineageDefaultDepth defined in config', () => {
+    const actual = ConfigUtils.getTableLineageDefaultDepth();
+    const expected = AppConfig.tableLineage.defaultLineageDepth;
+
+    expect(actual).toBe(expected);
+  });
+});
+
 describe('isColumnLineagePageEnabled', () => {
   it('returns isColumnLineagePageEnabled defined in config', () => {
     const actual = ConfigUtils.isColumnLineagePageEnabled();

--- a/frontend/amundsen_application/static/js/ducks/lineage/index.spec.ts
+++ b/frontend/amundsen_application/static/js/ducks/lineage/index.spec.ts
@@ -62,7 +62,7 @@ describe('tableMetadata ducks', () => {
 
   describe('actions', () => {
     it('getTableLineage - returns the action to get table lineage', () => {
-      const action = getTableLineage(testKey);
+      const action = getTableLineage(testKey, 5);
       const { payload } = action;
 
       expect(action.type).toBe(GetTableLineage.REQUEST);
@@ -159,7 +159,7 @@ describe('tableMetadata ducks', () => {
 
     describe('getTableLineageWorker', () => {
       it('executes flow for getting table lineage', () => {
-        testSaga(getTableLineageWorker, getTableLineage(testKey))
+        testSaga(getTableLineageWorker, getTableLineage(testKey, 5))
           .next()
           .call(API.getTableLineage, testKey, 1, 'both')
           .next({ data: testLineage, statusCode: 200 })
@@ -169,7 +169,7 @@ describe('tableMetadata ducks', () => {
       });
 
       it('handles request error', () => {
-        testSaga(getTableLineageWorker, getTableLineage(testKey))
+        testSaga(getTableLineageWorker, getTableLineage(testKey, 5))
           .next()
           .call(API.getTableLineage, testKey, 1, 'both')
           // @ts-ignore

--- a/frontend/amundsen_application/static/js/ducks/lineage/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/lineage/reducer.ts
@@ -30,7 +30,7 @@ export const initialState: LineageReducerState = {
 /* ACTIONS */
 export function getTableLineage(
   key: string,
-  depth: number = 1,
+  depth: number,
   direction: string = 'both'
 ): GetTableLineageRequest {
   return {

--- a/frontend/amundsen_application/static/js/pages/LineagePage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/LineagePage/index.tsx
@@ -17,6 +17,7 @@ import Breadcrumb from 'features/Breadcrumb';
 
 import GraphLoading from 'components/Lineage/GraphLoading';
 import GraphContainer from 'components/Lineage/GraphContainer';
+import { getTableLineageDefaultDepth } from 'config/config-utils';
 import { buildTableKey } from 'utils/navigationUtils';
 
 import * as Constants from './constants';
@@ -61,9 +62,10 @@ export const LineagePage: React.FC<
   const { params } = match;
   const pageTitle = `Lineage Information | ${params.schema}.${params.table}`;
   const [tableKey] = React.useState(buildTableKey(params));
+  const defaultDepth = getTableLineageDefaultDepth();
 
   React.useEffect(() => {
-    tableLineageGet(tableKey, 5);
+    tableLineageGet(tableKey, defaultDepth);
   }, [tableKey]);
 
   const hasError = statusCode !== OK_STATUS_CODE;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -117,7 +117,10 @@ export interface DispatchFromProps {
     searchIndex?: string,
     source?: string
   ) => GetTableDataRequest;
-  getTableLineageDispatch: (key: string, depth: number) => GetTableLineageRequest;
+  getTableLineageDispatch: (
+    key: string,
+    depth: number
+  ) => GetTableLineageRequest;
   getColumnLineageDispatch: (
     key: string,
     columnName: string

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/index.tsx
@@ -117,7 +117,7 @@ export interface DispatchFromProps {
     searchIndex?: string,
     source?: string
   ) => GetTableDataRequest;
-  getTableLineageDispatch: (key: string) => GetTableLineageRequest;
+  getTableLineageDispatch: (key: string, depth: number) => GetTableLineageRequest;
   getColumnLineageDispatch: (
     key: string,
     columnName: string


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes
For certain deployments the graph view can get unreadable when it displays nodes at too great a depth. The app hardcodes the table lineage graph depth to 5 currently. This PR makes that value configurable using the config-types pattern that the rest of the front end uses.

There is some discussion about the feature in a previous PR that I botched:
https://github.com/amundsen-io/amundsen/pull/2069

### Tests
Added a unit test for the function that gets the default graph depth

### Documentation

<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
