### PR TITLE
feat: support table/column lineage for mysql backend

### DIFF
--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -27,4 +27,4 @@ responses>=0.10.6
 jsonref==0.2
 
 amundsen-common>=0.16.0
-amundsen-rds==0.0.7
+amundsen-rds==0.0.8

--- a/databuilder/tests/unit/models/test_table_lineage.py
+++ b/databuilder/tests/unit/models/test_table_lineage.py
@@ -9,7 +9,9 @@ from databuilder.models.graph_serializable import (
     RELATION_TYPE,
 )
 from databuilder.models.table_lineage import TableLineage
-from databuilder.serializers import neo4_serializer, neptune_serializer
+from databuilder.serializers import (
+    mysql_serializer, neo4_serializer, neptune_serializer,
+)
 from databuilder.serializers.neptune_serializer import (
     METADATA_KEY_PROPERTY_NAME_BULK_LOADER_FORMAT, NEPTUNE_CREATION_TYPE_JOB,
     NEPTUNE_CREATION_TYPE_RELATIONSHIP_PROPERTY_NAME_BULK_LOADER_FORMAT, NEPTUNE_HEADER_ID, NEPTUNE_HEADER_LABEL,
@@ -158,3 +160,24 @@ class TestTableLineage(unittest.TestCase):
             relation = self.table_lineage.create_next_relation()
 
         self.assertEqual(actual, expected)
+
+    def test_create_records(self) -> None:
+        expected = [
+            {
+                'table_source_rk': self.start_key,
+                'table_target_rk': self.end_key1
+            },
+            {
+                'table_source_rk': self.start_key,
+                'table_target_rk': self.end_key2,
+            }
+        ]
+
+        actual = []
+        record = self.table_lineage.create_next_record()
+        while record:
+            serialized_record = mysql_serializer.serialize_record(record)
+            actual.append(serialized_record)
+            record = self.table_lineage.create_next_record()
+
+        self.assertEqual(expected, actual)

--- a/metadata/metadata_service/proxy/mysql_proxy.py
+++ b/metadata/metadata_service/proxy/mysql_proxy.py
@@ -5,7 +5,7 @@ import logging
 import time
 from collections import namedtuple
 from random import randint
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 from amundsen_common.entity.resource_type import ResourceType, to_resource_type
 from amundsen_common.models.dashboard import DashboardSummary
@@ -1542,7 +1542,7 @@ class MySQLProxy(BaseProxy):
             else:
                 records = us_query.union_all(ds_query).all()
 
-            tables = {'upstream': [], 'downstream': []}
+            tables: Dict[str, List[LineageItem]] = {'upstream': [], 'downstream': []}
             for record in records:
                 record_res = getattr(record, res_model.__name__)
                 tables[record.direction] \
@@ -1566,7 +1566,7 @@ class MySQLProxy(BaseProxy):
         """
         Return lineage item in topological order.
         """
-        def get_next_edge(node):
+        def get_next_edge(node: str) -> Iterator[Edge]:
             """
             Return edge(in_node, out_node) in tuple
             """

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -21,7 +21,7 @@ with open(requirements_path) as requirements_file:
 
 oidc = ['flaskoidc>=1.0.0']
 atlas = ['apache-atlas==0.0.11']
-rds = ['amundsen-rds==0.0.7',
+rds = ['amundsen-rds==0.0.8',
        'mysqlclient>=1.3.6,<3']
 gremlin = [
     'amundsen-gremlin>=0.0.9',


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

### Summary of Changes

The change is related to issue #2072. It is about supporting table/column lineage for mysql backend end to end.
- databuilder: updated table_lineage model for table/column lineage record iterator and the corresponding sample_data_loader_mysql.py
- metadata_service: updated mysql_proxy.py to add lineage related endpoint.

### Tests
Added unit tests in both databuilder and metadata_service for lineage related change.

### Documentation
N/A
<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
