### PR TITLE
fix: int is too small for a unix timestamp

### DIFF
--- a/common/amundsen_common/models/dashboard.py
+++ b/common/amundsen_common/models/dashboard.py
@@ -17,7 +17,7 @@ class DashboardSummary:
     name: str = attr.ib()
     url: str = attr.ib()
     description: Optional[str] = None
-    last_successful_run_timestamp: Optional[int] = None
+    last_successful_run_timestamp: Optional[float] = None
     chart_names: Optional[List[str]] = []
 
 

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.30.0'
+__version__ = '0.31.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,7 +5,7 @@
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
 # on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
-amundsen-common>=0.27.0,<0.31.0
+amundsen-common>=0.27.0
 attrs>=19.1.0
 boto3==1.17.23
 click==7.0


### PR DESCRIPTION
Changed dashboard summary model in comment to use `last_successful_run_timestamp: Optional[float] = None` since a value like `1668725028.424` is too large to be casted to an `int`