### PR TITLE
Fix: Enable neptune proxy custom sts endpoint

### DIFF
--- a/docs/tutorials/how-to-use-amundsen-with-aws-neptune.md
+++ b/docs/tutorials/how-to-use-amundsen-with-aws-neptune.md
@@ -112,5 +112,6 @@ The NeptuneConfig requires a few environment variables to be set these are:
 * `AWS_REGION` - The AWS region where the Neptune instance is located.
 * `S3_BUCKET_NAME`- The location where the proxy can upload S3 files for bulk uploader
 
-In addition to the Config parameters above, the `IGNORE_NEPTUNE_SHARD` environment variable must be set to 'True'
-if you are using the default databuilder integration.
+In addition to the Config parameters above:
+* `IGNORE_NEPTUNE_SHARD` environment variable must be set to 'True' if you are using the default databuilder integration.
+* `STS_ENDPOINT` can also be set if the default endpoint does not work for your environment. For example: `https://sts.ap-southeast-1.amazonaws.com`. Refer to [AWS Documentation](https://docs.aws.amazon.com/general/latest/gr/sts.html) for a full list of STS endpoints.

--- a/metadata/metadata_service/config.py
+++ b/metadata/metadata_service/config.py
@@ -165,7 +165,8 @@ try:
 
         PROXY_CLIENT_KWARGS = {
             'neptune_bulk_loader_s3_bucket_name': os.environ.get('S3_BUCKET_NAME'),
-            'ignore_neptune_shard': distutils.util.strtobool(os.environ.get('IGNORE_NEPTUNE_SHARD', 'True'))
+            'ignore_neptune_shard': distutils.util.strtobool(os.environ.get('IGNORE_NEPTUNE_SHARD', 'True')),
+            'sts_endpoint': os.environ.get('STS_ENDPOINT')
         }
 
         JANUS_GRAPH_URL = None

--- a/metadata/metadata_service/proxy/neptune_proxy.py
+++ b/metadata/metadata_service/proxy/neptune_proxy.py
@@ -106,9 +106,13 @@ class NeptuneGremlinProxy(AbstractGremlinProxy):
         except Exception:
             raise NotImplementedError(f'Cannot find s3 bucket name!')
 
+        # Get custom sts endpoint, default None
+        sts_endpoint = client_kwargs['sts_endpoint']
+
         # Instantiate bulk loader and graph traversal factory
         bulk_loader_config: Dict[str, Any] = dict(NEPTUNE_SESSION=password, NEPTUNE_URL=host,
-                                                  NEPTUNE_BULK_LOADER_S3_BUCKET_NAME=s3_bucket_name)
+                                                  NEPTUNE_BULK_LOADER_S3_BUCKET_NAME=s3_bucket_name,
+                                                  STS_ENDPOINT=sts_endpoint)
         self.neptune_bulk_loader_api = NeptuneBulkLoaderApi.create_from_config(bulk_loader_config)
         self.neptune_graph_traversal_source_factory = get_neptune_graph_traversal_source_factory(session=password,
                                                                                                  neptune_url=host)


### PR DESCRIPTION
### Summary of Changes

Currently, when users deploy Amundsen with Neptune backend DB,  `NeptuneBulkLoaderApi` is instantiated with the default STS endpoint.

However, this might not work when users deploy the service in government cloud / regional cloud, and the default endpoint is disabled. This PR allows user to specify the STS endpoint in the metadata config file, if they wish to.


### Tests

No tests added because it does not change any application behavior. It only creates an option for user to specify their STS endpoint upfront in the config file.

### Documentation

Added a line in `docs/tutorials/how-to-use-amundsen-with-aws-neptune.md` to explain that users can now specify STS endpoint.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
