### PR TITLE
feat: adds dynamic notices flag on config

### DIFF
--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -242,6 +242,7 @@ interface BaseResourceConfig {
   filterCategories?: FilterConfig;
   supportedSources?: SourcesConfig;
   notices?: NoticesConfigType;
+  hasDynamicNoticesEnabled?: boolean;
   searchHighlight?: ResourceHighlightConfig;
 }
 

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -18,8 +18,8 @@ export const DEFAULT_DASHBOARD_ICON_CLASS = 'icon-dashboard icon-color';
 const WILDCARD_SIGN = '*';
 const RESOURCE_SEPARATOR = '.';
 const ANNOUNCEMENTS_LINK_LABEL = 'Announcements';
-const hasWildcard = (n) => n.indexOf(WILDCARD_SIGN) > -1;
-const withComputedMessage = (notice: NoticeType, resourceName) => {
+const hasWildcard = (n: string) => n.indexOf(WILDCARD_SIGN) > -1;
+const withComputedMessage = (notice: NoticeType, resourceName: string) => {
   if (typeof notice.messageHtml === 'function') {
     notice.messageHtml = notice.messageHtml(resourceName);
   }
@@ -146,6 +146,20 @@ export function getResourceNotices(
   }
 
   return false;
+}
+
+/**
+ * Communicates whether dynamic notices via API requests is enabled for a given resource
+ * @param resourceType  Any resource type (except query)
+ * @returns             Whether if the resource has dynamic notices
+ */
+export function getDynamicNoticesEnabledByResource(
+  resourceType: Exclude<ResourceType, ResourceType.query>
+): boolean {
+  const { hasDynamicNoticesEnabled = false } =
+    AppConfig.resourceConfig[resourceType];
+
+  return hasDynamicNoticesEnabled;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -13,6 +13,7 @@ import {
   HomePageWidgetsConfig,
 } from './config-types';
 
+const DEFAULT_DYNAMIC_NOTICES_ENABLED_FLAG = false;
 export const DEFAULT_DATABASE_ICON_CLASS = 'icon-database icon-color';
 export const DEFAULT_DASHBOARD_ICON_CLASS = 'icon-dashboard icon-color';
 const WILDCARD_SIGN = '*';
@@ -156,7 +157,7 @@ export function getResourceNotices(
 export function getDynamicNoticesEnabledByResource(
   resourceType: Exclude<ResourceType, ResourceType.query>
 ): boolean {
-  const { hasDynamicNoticesEnabled = false } =
+  const { hasDynamicNoticesEnabled = DEFAULT_DYNAMIC_NOTICES_ENABLED_FLAG } =
     AppConfig.resourceConfig[resourceType];
 
   return hasDynamicNoticesEnabled;

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -444,6 +444,70 @@ describe('getResourceNotices', () => {
   });
 });
 
+describe('dynamicNoticesEnabled', () => {
+  describe('when resource type is Table', () => {
+    it('is false by default', () => {
+      const testResource = ResourceType.table;
+      const expected = false;
+      const actual =
+        ConfigUtils.getDynamicNoticesEnabledByResource(testResource);
+
+      expect(actual).toBe(expected);
+    });
+
+    describe('when set to true', () => {
+      it('should return true', () => {
+        const testResource = ResourceType.table;
+        const expected = true;
+
+        AppConfig.resourceConfig[testResource].hasDynamicNoticesEnabled = true;
+        const actual =
+          ConfigUtils.getDynamicNoticesEnabledByResource(testResource);
+
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('when resource type is any of dashboard, user or feature', () => {
+    it.each([['dashboard'], ['user'], ['feature']])(
+      'it is false by default',
+      (resource: Exclude<ResourceType, ResourceType.query>) => {
+        const expected = false;
+        const actual = ConfigUtils.getDynamicNoticesEnabledByResource(resource);
+
+        expect(actual).toBe(expected);
+      }
+    );
+
+    describe('when set to true', () => {
+      it.each([['dashboard'], ['user'], ['feature']])(
+        'it should return true',
+        (resource: Exclude<ResourceType, ResourceType.query>) => {
+          const expected = true;
+
+          AppConfig.resourceConfig[resource].hasDynamicNoticesEnabled = true;
+          const actual =
+            ConfigUtils.getDynamicNoticesEnabledByResource(resource);
+
+          expect(actual).toBe(expected);
+        }
+      );
+    });
+  });
+
+  describe('when resource is query', () => {
+    it('fails on the TS level', () => {
+      const testResource = ResourceType.query;
+
+      expect(() => {
+        // @ts-expect-error
+        ConfigUtils.getDynamicNoticesEnabledByResource(testResource);
+      }).toThrow();
+    });
+  });
+});
+
 describe('getFilterConfigByResource', () => {
   it('returns the filter categories for a given resource', () => {
     const testResource = ResourceType.table;

--- a/frontend/docs/application_config.md
+++ b/frontend/docs/application_config.md
@@ -336,6 +336,27 @@ This feature's ultimate goal is to allow Amundsen administrators to point their 
 
 Learn more about the future developments for this feature in [its RFC](https://github.com/amundsen-io/rfcs/blob/master/rfcs/029-resource-notices.md).
 
+
+### Dynamic Notices (WIP)
+We are now going to allow for fetching dynamically the notices related to different resources like tables, dashboards, users, and features.
+
+For that, you will first enabled the `hasDynamicNoticesEnabled` flag inside the `resourceConfig` object of the goal resource. This flag is optional and will default to `false` if not set.
+
+Example of this option enabled on tables and dashboards:
+```ts
+  resourceConfig: {
+    [ResourceType.table]: {
+      ... //Table Resource Configuration
+      hasDynamicNoticesEnabled: true,
+    },
+    [ResourceType.dashboard]: {
+      ... //Dashboard Resource Configuration
+      hasDynamicNoticesEnabled: true,
+    },
+  },
+```
+
+
 ## Table Lineage
 
 _TODO: Please add doc_
@@ -412,6 +433,6 @@ Where:
 For "feature tours", the setup would be similar, but `isFeatureTour` would be true, and `disableBeacon` should be false (the default), so that users can start the tour.
 
 ## Homepage Widgets Config
-By default, a set of features are available on the homepage (e.g. the search bar, bookmarks). These can be customized in config-custom.ts by providing an alternate `homePageWidgets` value. The value is a list of `Widget` objects. Non-OSS widgets can be provided in the `widget.options.path` property, and props passed to widget components can be customized with the `widget.options.aditionalProps` property. 
+By default, a set of features are available on the homepage (e.g. the search bar, bookmarks). These can be customized in config-custom.ts by providing an alternate `homePageWidgets` value. The value is a list of `Widget` objects. Non-OSS widgets can be provided in the `widget.options.path` property, and props passed to widget components can be customized with the `widget.options.aditionalProps` property.
 
 If a custom `homePageWidgets` config is provided, the default config will be ignored. So, for example, if you wanted to have all the default widgets plus a custom non-OSS widget component, you should copy all the homePageWidgets from [config-default.ts](https://github.com/amundsen-io/amundsen/blob/main/frontend/amundsen_application/static/js/config/config-default.ts) to your config-custom.ts, and then append your custom component. To omit one of the default widgets, you would copy the default list, and then delete the widget you didn't want.


### PR DESCRIPTION
### Summary of Changes
Adds a configuration option to allow for dynamic fetching of notices for different resources

### Tests
Added configuration util tests

### Documentation
Updated docs

Related to the stretch goals on https://github.com/amundsen-io/rfcs/blob/master/rfcs/029-resource-notices.md
