### PR TITLE
fix: rendering of bullet on the Features page

### DIFF
--- a/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
@@ -284,7 +284,7 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
           </h1>
           <p className="header-subtitle text-body-w3">
             {getDisplayNameByResource(ResourceType.feature)}
-            {sourcesWithDisplay.length > 0 && '&bull;&nbsp;'}
+            {sourcesWithDisplay.length > 0 && <>&nbsp;&bull;&nbsp;</>}
             {sourcesWithDisplay.join(', ')}
             {feature.badges.length > 0 && <BadgeList badges={feature.badges} />}
           </p>


### PR DESCRIPTION
### Summary of Changes
Fixes erroneous rendering of bullet on Features page

### Tests
Manually

Before:
<img width="855" alt="AMS" src="https://user-images.githubusercontent.com/190833/215585758-7c7b530a-afad-4c91-8025-277d1a11d42b.png">

After:
<img width="751" alt="AMS" src="https://user-images.githubusercontent.com/190833/215585833-b649e059-b875-4b1b-8532-b3fc639d8e0f.png">

