### PR TITLE
feat: thins out the global header to gain vertical space

### DIFF
--- a/frontend/amundsen_application/static/css/_buttons-default.scss
+++ b/frontend/amundsen_application/static/css/_buttons-default.scss
@@ -135,6 +135,7 @@ $outline-width: 2px;
   &.btn-nav-bar-icon {
     padding: $spacer-1;
     display: flex;
+    align-items: center;
 
     svg {
       fill: $white;

--- a/frontend/amundsen_application/static/css/_variables-default.scss
+++ b/frontend/amundsen_application/static/css/_variables-default.scss
@@ -96,7 +96,7 @@ $red-triangle-warning: $sunset60;
 // Header, Body, & Footer
 $nav-bar-color: $indigo100;
 $light-nav-bar-color: $white;
-$nav-bar-height: 60px;
+$nav-bar-height: 48px;
 $body-min-width: 1048px;
 $footer-height: 60px;
 $navbar-item-line-height: 45px;

--- a/frontend/amundsen_application/static/js/features/NavBar/styles.scss
+++ b/frontend/amundsen_application/static/js/features/NavBar/styles.scss
@@ -17,6 +17,7 @@ $light-background: $light-nav-bar-color;
 
 $app-suite-menu-width: 285px;
 $app-suite-logo-size: 24px;
+$link-border-size: 2px;
 
 .nav-bar {
   align-items: center;
@@ -24,7 +25,7 @@ $app-suite-logo-size: 24px;
   display: flex;
   flex-direction: row;
   height: $nav-bar-height;
-  padding: 0 $spacer-4;
+  padding: 0 $spacer-2;
   box-shadow: 0 0 1px 0 rgba(0,0,0,.12),0 2px 3px 0 rgba(0,0,0,.16);
 
   .nav-bar-left {
@@ -41,8 +42,6 @@ $app-suite-logo-size: 24px;
   .nav-bar-right {
     display: flex;
     margin-left: auto;
-    height: 100%;
-    padding-top: 12px;
   }
 
   .nav-bar-right > *:not(:last-child) {
@@ -55,11 +54,16 @@ $app-suite-logo-size: 24px;
     padding: 0 $spacer-1;
     text-decoration: none;
     color: $white;
+    border-bottom: $link-border-size solid transparent;
 
     &:hover,
     &.active {
-      border-bottom: $spacer-half solid $white;
+      border-bottom: $link-border-size solid $white;
     }
+  }
+
+  .btn-group {
+    display: flex;
   }
 
   .nav-bar-avatar {
@@ -163,7 +167,7 @@ $app-suite-logo-size: 24px;
 
       &:hover,
       &.active {
-        border-bottom: $spacer-half solid $text-primary;
+        border-bottom: $link-border-size solid $text-primary;
       }
     }
     .nav-bar-avatar {


### PR DESCRIPTION
## Description
Thins out the Global Header
Fixes alignment on text links
Tweakes spacing

<img width="958" alt="AMS" src="https://user-images.githubusercontent.com/190833/225214707-538fd5ee-187f-423b-9911-767b7115fdfc.png">


## Motivation and Context
Better use of the vertical space

## How Has This Been Tested?
Manually and in the Storybook

### Documentation
N/A

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [x] Updates Documentation and Docstrings
* [x] Adds tests
* [x] Adds instrumentation (logs, or UI events)
