### PR TITLE
fix: Use managed read transactions for queries in metadata service

### DIFF
--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -63,8 +63,7 @@ def execute_statement(tx: Transaction, stmt: str, params: dict = None) -> List[R
     LOGGER.debug('Executing statement: %s with params %s', stmt, params)
 
     result = tx.run(stmt, parameters=params)
-
-    return result.data()
+    return [record for record in result]
 
 
 def get_single_record(records_list: List[Record]) -> Record:

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -27,7 +27,7 @@ from amundsen_common.models.user import UserSchema
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
 from flask import current_app, has_app_context
-from neo4j import GraphDatabase, Record  # noqa: F401
+from neo4j import GraphDatabase, Record, Transaction  # noqa: F401
 from neo4j.api import (SECURITY_TYPE_SECURE,
                        SECURITY_TYPE_SELF_SIGNED_CERTIFICATE, parse_neo4j_uri)
 from neo4j.exceptions import ClientError
@@ -54,6 +54,17 @@ LAST_UPDATED_EPOCH_MS = 'publisher_last_updated_epoch_ms'
 PUBLISHED_TAG_PROPERTY_NAME = 'published_tag'
 
 LOGGER = logging.getLogger(__name__)
+
+
+def execute_statement(tx: Transaction, stmt: str, params: dict = None) -> List[Record]:
+    """
+    Executes statement against Neo4j. If execution fails, it rollsback and raises exception.
+    """
+    LOGGER.debug('Executing statement: %s with params %s', stmt, params)
+
+    result = tx.run(stmt, parameters=params)
+
+    return result.data()
 
 
 def get_single_record(records_list: List[Record]) -> Record:
@@ -551,14 +562,16 @@ class Neo4jProxy(BaseProxy):
     def _execute_cypher_query(self, *,
                               statement: str,
                               param_dict: Dict[str, Any]) -> List[Record]:
+        """
+        Execute Cypher queries using managed read transactions
+        """
         if LOGGER.isEnabledFor(logging.DEBUG):
             LOGGER.debug('Executing Cypher query: {statement} with params {params}: '.format(statement=statement,
                                                                                              params=param_dict))
         start = time.time()
         try:
             with self._driver.session(database=self._database_name) as session:
-                result = session.run(query=statement, **param_dict)
-                return [record for record in result]
+                return session.read_transaction(execute_statement, statement, param_dict)
 
         finally:
             # TODO: Add support on statsd

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.12.0'
+__version__ = '3.12.1'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
## Description
Updating metadata GET APIs to use managed read transactions in the Neo4j proxy to provide retry capabilities.

## Motivation and Context
We were having an issue with errors with our health check where our Neo4j instance was showing that our client connection was closing, so trying this out to see if it fixes the issue. In any case, it is the Neo4j recommended way of executing transactions.

## How Has This Been Tested?
- Ran the existing tests
- Started the service locally and hit multiple of the GET endpoints to verify that results were returned

### Documentation
N/A

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [X] Updates Documentation and Docstrings
* [X] Adds tests
* [X] Adds instrumentation (logs, or UI events)
