### PR TITLE
chore: removes direct access to AppConfig object

### DIFF
--- a/frontend/amundsen_application/static/js/components/OwnerEditor/constants.ts
+++ b/frontend/amundsen_application/static/js/components/OwnerEditor/constants.ts
@@ -1,6 +1,5 @@
 export const DEFAULT_ERROR_TEXT =
   'There was a problem with the request, please reload the page.';
-export const USERID_LABEL = 'email address';
 export const ADD_ITEM = 'Add';
 export const ADD_OWNER = 'Add Owner';
 export const DELETE_ITEM = 'Delete Item';

--- a/frontend/amundsen_application/static/js/components/OwnerEditor/index.tsx
+++ b/frontend/amundsen_application/static/js/components/OwnerEditor/index.tsx
@@ -5,11 +5,11 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Modal } from 'react-bootstrap';
 
-import AppConfig from 'config/config';
 import AvatarLabel, { AvatarLabelProps } from 'components/AvatarLabel';
 import LoadingSpinner from 'components/LoadingSpinner';
 import { ResourceType, UpdateMethod, UpdateOwnerPayload } from 'interfaces';
-import { logClick } from 'utils/analytics';
+import { logClick, logAction } from 'utils/analytics';
+import { getUserIdLabel } from 'config/config-utils';
 
 import { EditableSectionChildProps } from 'components/EditableSection';
 
@@ -98,7 +98,7 @@ export class OwnerEditor extends React.Component<
     }
   };
 
-  cancelEdit = () => {
+  handleCancelEdit = () => {
     const { setEditMode } = this.props;
     const { itemProps } = this.state;
 
@@ -106,9 +106,14 @@ export class OwnerEditor extends React.Component<
     if (setEditMode) {
       setEditMode(false);
     }
+    logAction({
+      command: 'click',
+      target_id: 'cancel-owner-edit',
+      label: 'Cancel Owner Edit',
+    });
   };
 
-  saveEdit = () => {
+  handleSaveEdit = () => {
     const { itemProps, tempItemProps } = this.state;
     const { setEditMode, onUpdateList } = this.props;
 
@@ -140,9 +145,14 @@ export class OwnerEditor extends React.Component<
     };
 
     onUpdateList(updateArray, onSuccessCallback, onFailureCallback);
+    logAction({
+      command: 'click',
+      target_id: 'save-owner-edit',
+      label: 'Save Owner Edit',
+    });
   };
 
-  recordAddItem = (event: React.FormEvent<HTMLFormElement>) => {
+  handleRecordAddItem = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const { tempItemProps } = this.state;
 
@@ -158,6 +168,12 @@ export class OwnerEditor extends React.Component<
         };
 
         this.setState({ tempItemProps: newTempItemProps });
+        logAction({
+          command: 'click',
+          target_id: 'add-owner-email',
+          label: 'Add Owner Email',
+          target_type: 'button',
+        });
       }
     }
   };
@@ -190,14 +206,12 @@ export class OwnerEditor extends React.Component<
 
     return (
       <Modal.Body>
-        <form className="component-form" onSubmit={this.recordAddItem}>
+        <form className="component-form" onSubmit={this.handleRecordAddItem}>
           {/* eslint-disable jsx-a11y/no-autofocus */}
           <input
             id="add-item-input"
             autoFocus
-            placeholder={`Please enter ${
-              AppConfig.userIdLabel || Constants.USERID_LABEL
-            }`}
+            placeholder={`Please enter ${getUserIdLabel()}`}
             ref={this.inputRef}
           />
           {/* eslint-enable jsx-a11y/no-autofocus */}
@@ -302,7 +316,7 @@ export class OwnerEditor extends React.Component<
           <Modal
             className="owner-editor-modal"
             show={isEditing}
-            onHide={this.cancelEdit}
+            onHide={this.handleCancelEdit}
           >
             <Modal.Header className="text-center" closeButton={false}>
               <Modal.Title>{Constants.OWNED_BY}</Modal.Title>
@@ -312,14 +326,14 @@ export class OwnerEditor extends React.Component<
               <button
                 type="button"
                 className="btn btn-default"
-                onClick={this.cancelEdit}
+                onClick={this.handleCancelEdit}
               >
                 {Constants.CANCEL_TEXT}
               </button>
               <button
                 type="button"
                 className="btn btn-primary"
-                onClick={this.saveEdit}
+                onClick={this.handleSaveEdit}
               >
                 {Constants.SAVE_TEXT}
               </button>

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/FeatureListItem/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/FeatureListItem/index.spec.tsx
@@ -21,6 +21,7 @@ const MOCK_ICON_CLASS = 'test-class';
 jest.mock('config/config-utils', () => ({
   getSourceDisplayName: jest.fn(() => MOCK_DISPLAY_NAME),
   getSourceIconClass: jest.fn(() => MOCK_ICON_CLASS),
+  getFilterConfigByResource: jest.fn(),
 }));
 
 describe('FeatureListItem', () => {

--- a/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/ResourceListItem/TableListItem/index.spec.tsx
@@ -24,6 +24,7 @@ const MOCK_ICON_CLASS = 'test-class';
 jest.mock('config/config-utils', () => ({
   getSourceDisplayName: () => MOCK_DISPLAY_NAME,
   getSourceIconClass: () => MOCK_ICON_CLASS,
+  getFilterConfigByResource: jest.fn(),
 }));
 
 const getDBIconClassSpy = jest.spyOn(ConfigUtils, 'getSourceIconClass');

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -286,7 +286,7 @@ interface BadgeConfig {
  * DateConfig - Configure various date formats
  *
  */
-interface DateFormatConfig {
+export interface DateFormatConfig {
   default: string;
   dateTimeLong: string;
   dateTimeShort: string;
@@ -376,7 +376,7 @@ interface TableLineageDisableAppListLinksConfig {
  * inAppListMessages - when an in app list is enabled this will add a custom message at the end of the lineage tabs content.
  * disableAppListLinks - Set up table field based regular expression rules to disable lineage list view links.
  */
-interface TableLineageConfig {
+export interface TableLineageConfig {
   iconPath: string;
   isBeta: boolean;
   urlGenerator: (

--- a/frontend/amundsen_application/static/js/config/config-types.ts
+++ b/frontend/amundsen_application/static/js/config/config-types.ts
@@ -42,7 +42,7 @@ export interface AppConfig {
   tableLineage: TableLineageConfig;
   tableProfile: TableProfileConfig;
   tableQualityChecks: TableQualityChecksConfig;
-  userIdLabel?: string /* Temporary configuration due to lacking string customization/translation support */;
+  userIdLabel: string /* Temporary configuration due to lacking string customization/translation support */;
 }
 
 /**

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -12,6 +12,8 @@ import {
   NoticeType,
   TourConfig,
   HomePageWidgetsConfig,
+  TableLineageConfig,
+  DateFormatConfig,
 } from './config-types';
 
 const DEFAULT_DYNAMIC_NOTICES_ENABLED_FLAG = false;
@@ -495,13 +497,6 @@ export function isFeatureListLineageEnabled() {
 }
 
 /**
- * Returns whether the in-app table lineage list is enabled.
- */
-export function isTableListLineageEnabled() {
-  return AppConfig.tableLineage.inAppListEnabled;
-}
-
-/**
  * Returns whether the in-app column list lineage is enabled.
  */
 export function isColumnListLineageEnabled() {
@@ -509,17 +504,31 @@ export function isColumnListLineageEnabled() {
 }
 
 /**
- * Returns whether the in-app table lineage page is enabled.
- */
-export function isTableLineagePageEnabled() {
-  return AppConfig.tableLineage.inAppPageEnabled;
-}
-
-/**
  * Returns whether the in-app column lineage page is enabled.
  */
 export function isColumnLineagePageEnabled() {
   return AppConfig.columnLineage.inAppPageEnabled;
+}
+
+/**
+ * Returns tableLineage configuration
+ */
+export function getTableLineageConfiguration(): TableLineageConfig {
+  return AppConfig.tableLineage;
+}
+
+/**
+ * Returns whether the in-app table lineage list is enabled.
+ */
+export function isTableListLineageEnabled() {
+  return AppConfig.tableLineage.inAppListEnabled;
+}
+
+/**
+ * Returns whether the in-app table lineage page is enabled.
+ */
+export function isTableLineagePageEnabled() {
+  return AppConfig.tableLineage.inAppPageEnabled;
 }
 
 /**
@@ -629,4 +638,11 @@ export function getHomePageWidgets(): HomePageWidgetsConfig {
  */
 export function getUserIdLabel(): string {
   return AppConfig.userIdLabel;
+}
+
+/**
+ * Returns the date configuration
+ */
+export function getDateConfiguration(): DateFormatConfig {
+  return AppConfig.date;
 }

--- a/frontend/amundsen_application/static/js/config/config-utils.ts
+++ b/frontend/amundsen_application/static/js/config/config-utils.ts
@@ -623,3 +623,10 @@ export function getSearchResultsPerPage(): number {
 export function getHomePageWidgets(): HomePageWidgetsConfig {
   return AppConfig.homePageWidgets;
 }
+
+/**
+ * Returns the user Id Label ("email address" by default)
+ */
+export function getUserIdLabel(): string {
+  return AppConfig.userIdLabel;
+}

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -939,19 +939,19 @@ describe('getLogoTitle', () => {
   });
 });
 
-describe('isTableListLineageEnabled', () => {
-  it('returns isTableListLineageEnabled defined in config', () => {
-    const actual = ConfigUtils.isTableListLineageEnabled();
-    const expected = AppConfig.tableLineage.inAppListEnabled;
+describe('getTableLineageConfiguration', () => {
+  it('returns getTableLineageConfiguration defined in config', () => {
+    const actual = ConfigUtils.getTableLineageConfiguration();
+    const expected = AppConfig.tableLineage;
 
     expect(actual).toBe(expected);
   });
 });
 
-describe('isColumnListLineageEnabled', () => {
-  it('returns isColumnListLineageEnabled defined in config', () => {
-    const actual = ConfigUtils.isColumnListLineageEnabled();
-    const expected = AppConfig.columnLineage.inAppListEnabled;
+describe('isTableListLineageEnabled', () => {
+  it('returns isTableListLineageEnabled defined in config', () => {
+    const actual = ConfigUtils.isTableListLineageEnabled();
+    const expected = AppConfig.tableLineage.inAppListEnabled;
 
     expect(actual).toBe(expected);
   });
@@ -970,6 +970,15 @@ describe('getTableLineageDefaultDepth', () => {
   it('returns getTableLineageDefaultDepth defined in config', () => {
     const actual = ConfigUtils.getTableLineageDefaultDepth();
     const expected = AppConfig.tableLineage.defaultLineageDepth;
+
+    expect(actual).toBe(expected);
+  });
+});
+
+describe('isColumnListLineageEnabled', () => {
+  it('returns isColumnListLineageEnabled defined in config', () => {
+    const actual = ConfigUtils.isColumnListLineageEnabled();
+    const expected = AppConfig.columnLineage.inAppListEnabled;
 
     expect(actual).toBe(expected);
   });
@@ -1151,23 +1160,51 @@ describe('getHomePageWidgets', () => {
 
     expect(actual).toBe(expected);
   });
+});
 
-  describe('getUserIdLabel', () => {
-    it('returns email address by default', () => {
+describe('getUserIdLabel', () => {
+  it('returns email address by default', () => {
+    const actual = ConfigUtils.getUserIdLabel();
+    const expected = 'email address';
+
+    expect(actual).toBe(expected);
+  });
+
+  describe('when defined in config', () => {
+    it('returns userIdLabel defined in config', () => {
+      AppConfig.userIdLabel = 'test';
       const actual = ConfigUtils.getUserIdLabel();
-      const expected = 'email address';
+      const expected = AppConfig.userIdLabel;
 
       expect(actual).toBe(expected);
     });
+  });
+});
 
-    describe('when defined in config', () => {
-      it('returns userIdLabel defined in config', () => {
-        AppConfig.userIdLabel = 'test';
-        const actual = ConfigUtils.getUserIdLabel();
-        const expected = AppConfig.userIdLabel;
+describe('getDateConfiguration', () => {
+  it('returns default date configuration by default', () => {
+    const actual = ConfigUtils.getDateConfiguration();
+    const expected = {
+      dateTimeLong: 'MMMM Do YYYY [at] h:mm:ss a',
+      dateTimeShort: 'MMM DD, YYYY ha z',
+      default: 'MMM DD, YYYY',
+    };
 
-        expect(actual).toBe(expected);
-      });
+    expect(actual).toEqual(expected);
+  });
+
+  describe('when defined in config', () => {
+    it('returns userIdLabel defined in config', () => {
+      const expected = {
+        dateTimeLong: 'YYYY [at] h:mm',
+        dateTimeShort: 'DD, YY ha z',
+        default: 'DD, YYYY',
+      };
+
+      AppConfig.date = expected;
+      const actual = ConfigUtils.getDateConfiguration();
+
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/frontend/amundsen_application/static/js/config/index.spec.ts
+++ b/frontend/amundsen_application/static/js/config/index.spec.ts
@@ -1151,4 +1151,23 @@ describe('getHomePageWidgets', () => {
 
     expect(actual).toBe(expected);
   });
+
+  describe('getUserIdLabel', () => {
+    it('returns email address by default', () => {
+      const actual = ConfigUtils.getUserIdLabel();
+      const expected = 'email address';
+
+      expect(actual).toBe(expected);
+    });
+
+    describe('when defined in config', () => {
+      it('returns userIdLabel defined in config', () => {
+        AppConfig.userIdLabel = 'test';
+        const actual = ConfigUtils.getUserIdLabel();
+        const expected = AppConfig.userIdLabel;
+
+        expect(actual).toBe(expected);
+      });
+    });
+  });
 });

--- a/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
+++ b/frontend/amundsen_application/static/js/ducks/search/filters/reducer.ts
@@ -1,8 +1,8 @@
-import AppConfig from 'config/config';
 import {
   SubmitSearchResource,
   SubmitSearchResourceRequest,
 } from 'ducks/search/types';
+import { getFilterConfigByResource } from 'config/config-utils';
 import {
   FilterOperationType,
   ResourceType,
@@ -50,7 +50,7 @@ export interface ResourceFilterReducerState {
 export function getDefaultFiltersForResource(
   resourceType: ResourceType
 ): ResourceFilterReducerState {
-  const { filterCategories } = AppConfig.resourceConfig[resourceType];
+  const filterCategories = getFilterConfigByResource(resourceType);
   const initialValue = {};
   const defaultFilters =
     filterCategories

--- a/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/ColumnList/ColumnDetailsPanel/index.spec.tsx
@@ -86,6 +86,7 @@ jest.mock('config/config-utils', () => ({
   isColumnListLineageEnabled: () => mockLineageEnabled,
   getMaxLength: jest.fn(),
   notificationsEnabled: () => mockNotificationsEnabled,
+  getFilterConfigByResource: jest.fn(),
 }));
 
 describe('ColumnDetailsPanel', () => {

--- a/frontend/amundsen_application/static/js/features/MyBookmarks/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/MyBookmarks/index.spec.tsx
@@ -21,6 +21,7 @@ import { MyBookmarks, MyBookmarksProps, mapStateToProps } from '.';
 jest.mock('config/config-utils', () => ({
   getDisplayNameByResource: jest.fn(() => 'Resource'),
   indexDashboardsEnabled: jest.fn(),
+  getFilterConfigByResource: jest.fn(),
 }));
 
 const setup = (propOverrides?: Partial<MyBookmarksProps>) => {

--- a/frontend/amundsen_application/static/js/features/Tags/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/features/Tags/index.spec.tsx
@@ -8,6 +8,7 @@ import { mapStateToProps, mapDispatchToProps } from '.';
 jest.mock('config/config-utils', () => ({
   showAllTags: jest.fn(),
   getCuratedTags: () => ['curated_tag_1'],
+  getFilterConfigByResource: jest.fn(),
 }));
 
 describe('TagsListContainer', () => {

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/index.spec.tsx
@@ -31,6 +31,7 @@ jest.mock('config/config-utils', () => ({
   getSourceDisplayName: jest.fn(() => MOCK_DISPLAY_NAME),
   getSourceIconClass: jest.fn(() => MOCK_ICON_CLASS),
   getResourceNotices: jest.fn(() => {}),
+  getFilterConfigByResource: jest.fn(),
 }));
 const setStateSpy = jest.spyOn(DashboardPage.prototype, 'setState');
 

--- a/frontend/amundsen_application/static/js/pages/DashboardPage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/DashboardPage/index.spec.tsx
@@ -32,6 +32,11 @@ jest.mock('config/config-utils', () => ({
   getSourceIconClass: jest.fn(() => MOCK_ICON_CLASS),
   getResourceNotices: jest.fn(() => {}),
   getFilterConfigByResource: jest.fn(),
+  getDateConfiguration: jest.fn(() => ({
+    dateTimeLong: 'MMMM Do YYYY [at] h:mm:ss a',
+    dateTimeShort: 'MMM DD, YYYY ha z',
+    default: 'MMM DD, YYYY',
+  })),
 }));
 const setStateSpy = jest.spyOn(DashboardPage.prototype, 'setState');
 

--- a/frontend/amundsen_application/static/js/pages/ProfilePage/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/ProfilePage/index.spec.tsx
@@ -30,6 +30,7 @@ import {
 jest.mock('config/config-utils', () => ({
   getDisplayNameByResource: jest.fn(() => 'Resource'),
   indexDashboardsEnabled: jest.fn(),
+  getFilterConfigByResource: jest.fn(),
 }));
 
 describe('ProfilePage', () => {

--- a/frontend/amundsen_application/static/js/pages/SearchPage/ResourceSelector/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/SearchPage/ResourceSelector/index.spec.tsx
@@ -24,6 +24,7 @@ jest.mock('config/config-utils', () => ({
   indexUsersEnabled: jest.fn(),
   indexFeaturesEnabled: jest.fn(),
   indexDashboardsEnabled: jest.fn(),
+  getFilterConfigByResource: jest.fn(),
 }));
 
 const setup = (propOverrides?: Partial<ResourceSelectorProps>) => {

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/FrequentUsers/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/FrequentUsers/index.tsx
@@ -7,7 +7,7 @@ import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
 import { TableReader } from 'interfaces';
-import AppConfig from 'config/config';
+import { indexUsersEnabled } from 'config/config-utils';
 import { logClick } from 'utils/analytics';
 
 import './styles.scss';
@@ -25,7 +25,7 @@ export function renderReader(
   let link = user.profile_url;
   let target = '_blank';
 
-  if (AppConfig.indexUsers.enabled) {
+  if (indexUsersEnabled()) {
     link = `/user/${user.user_id}?source=frequent_users`;
     target = '';
   }
@@ -61,7 +61,7 @@ const FrequentUsers: React.FC<FrequentUsersProps> = ({
   readers,
 }: FrequentUsersProps) => {
   if (readers.length === 0) {
-    return <label className="body-3">No frequent users exist</label>;
+    return <span className="body-3">No frequent users exist</span>;
   }
 
   return <div className="frequent-users">{readers.map(renderReader)}</div>;

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageLink/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageLink/index.tsx
@@ -4,8 +4,8 @@
 import * as React from 'react';
 
 import AvatarLabel from 'components/AvatarLabel';
-import AppConfig from 'config/config';
 import { TableMetadata } from 'interfaces/TableMetadata';
+import { getTableLineageConfiguration } from 'config/config-utils';
 import { logClick } from 'utils/analytics';
 
 export interface LineageLinkProps {
@@ -15,14 +15,15 @@ export interface LineageLinkProps {
 export const LineageLink: React.FC<LineageLinkProps> = ({
   tableData,
 }: LineageLinkProps) => {
-  const config = AppConfig.tableLineage;
+  const { urlGenerator, externalEnabled, iconPath } =
+    getTableLineageConfiguration();
 
-  if (!config.externalEnabled) {
+  if (!externalEnabled) {
     return null;
   }
 
   const { database, cluster, schema, name } = tableData;
-  const href = config.urlGenerator(database, cluster, schema, name);
+  const href = urlGenerator(database, cluster, schema, name);
 
   if (!href) {
     return null;
@@ -39,7 +40,7 @@ export const LineageLink: React.FC<LineageLinkProps> = ({
       onClick={logClick}
       rel="noreferrer"
     >
-      <AvatarLabel label={label} src={config.iconPath} />
+      <AvatarLabel label={label} src={iconPath} />
     </a>
   );
 };

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/LineageList/index.tsx
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
-import AppConfig from 'config/config';
-import { getTableLineageDisableAppListLinks } from 'config/config-utils';
+import {
+  getTableLineageDisableAppListLinks,
+  getTableLineageConfiguration,
+} from 'config/config-utils';
 import { ResourceType, TableResource } from 'interfaces/Resources';
 import { LineageItem } from 'interfaces/Lineage';
 import TableListItem from 'components/ResourceListItem/TableListItem';
@@ -72,10 +74,11 @@ export const LineageList: React.FC<LineageListProps> = ({
       </div>
     );
   }
+  const { inAppListMessageGenerator } = getTableLineageConfiguration();
 
   const message =
     tableDetails &&
-    AppConfig.tableLineage.inAppListMessageGenerator?.(
+    inAppListMessageGenerator?.(
       direction,
       tableDetails.database,
       tableDetails.cluster,

--- a/frontend/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/pages/TableDetailPage/TableHeaderBullets/index.spec.tsx
@@ -23,6 +23,7 @@ const TABLE_VIEW_TEXT = 'table view';
 jest.mock('config/config-utils', () => ({
   getDisplayNameByResource: jest.fn(),
   getSourceDisplayName: jest.fn(),
+  getFilterConfigByResource: jest.fn(),
 }));
 
 let noDatabase;

--- a/frontend/amundsen_application/static/js/utils/dateUtils.ts
+++ b/frontend/amundsen_application/static/js/utils/dateUtils.ts
@@ -1,5 +1,6 @@
 import * as Moment from 'moment-timezone';
-import AppConfig from 'config/config';
+
+import { getDateConfiguration } from 'config/config-utils';
 
 const timezone = Moment.tz.guess();
 
@@ -40,18 +41,21 @@ export function getMomentDate(config: DateConfig): Moment.Moment {
 
 export function formatDate(config: DateConfig) {
   const date = getMomentDate(config);
+  const { default: defaultValue } = getDateConfiguration();
 
-  return date.format(AppConfig.date.default);
+  return date.format(defaultValue);
 }
 
 export function formatDateTimeShort(config: DateConfig) {
   const date = getMomentDate(config);
+  const { dateTimeShort } = getDateConfiguration();
 
-  return date.format(AppConfig.date.dateTimeShort);
+  return date.format(dateTimeShort);
 }
 
 export function formatDateTimeLong(config: DateConfig) {
   const date = getMomentDate(config);
+  const { dateTimeLong } = getDateConfiguration();
 
-  return date.format(AppConfig.date.dateTimeLong);
+  return date.format(dateTimeLong);
 }

--- a/frontend/amundsen_application/static/js/utils/index.spec.ts
+++ b/frontend/amundsen_application/static/js/utils/index.spec.ts
@@ -12,6 +12,11 @@ import * as StatUtils from './stats';
 jest.mock('config/config-utils', () => ({
   getUniqueValueStatTypeName: jest.fn(() => 'distinctValues'),
   getNumberFormat: jest.fn(() => null),
+  getDateConfiguration: jest.fn(() => ({
+    dateTimeLong: 'MMMM Do YYYY [at] h:mm:ss a',
+    dateTimeShort: 'MMM DD, YYYY ha z',
+    default: 'MMM DD, YYYY',
+  })),
 }));
 
 describe('textUtils', () => {


### PR DESCRIPTION
## Description
Removes the last instances of code using the AppConfig directly
Improved tracking on the OwnerEditor
Fixes some ESLint issues

## Motivation and Context
Last part of a long refactor to use util functions instead of the AppConfig file

## How Has This Been Tested?
Manually
Added tests

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [x] Updates Documentation and Docstrings
* [x] Adds tests
* [x] Adds instrumentation (logs, or UI events)
