### PR TITLE
style - Truncate long notice modal text with ellipsis

### DIFF
--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
@@ -37,7 +37,11 @@ export const DefinitionList: React.FC<DefinitionListProps> = ({
           {typeof description === 'string' ? (
             <SanitizedHTML
               html={description}
-              className="definition-list-definition"
+              style={{
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
             />
           ) : (
             description

--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
@@ -35,7 +35,10 @@ export const DefinitionList: React.FC<DefinitionListProps> = ({
         </dt>
         <dd className="definition-list-definition">
           {typeof description === 'string' ? (
-            <SanitizedHTML html={description} />
+            <SanitizedHTML
+              html={description}
+              className="definition-list-definition"
+            />
           ) : (
             description
           )}

--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
@@ -35,14 +35,7 @@ export const DefinitionList: React.FC<DefinitionListProps> = ({
         </dt>
         <dd className="definition-list-definition">
           {typeof description === 'string' ? (
-            <SanitizedHTML
-              html={description}
-              style={{
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            />
+            <SanitizedHTML html={description} className="definition-text" />
           ) : (
             description
           )}

--- a/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
@@ -30,6 +30,10 @@
 
   margin-left: 0;
   margin-bottom: 0;
+  overflow: hidden;
+}
+
+.definition-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
@@ -30,4 +30,7 @@
 
   margin-left: 0;
   margin-bottom: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

## Description
<!--- Describe your changes in detail -->
When the text of an item in the notice modal is too long for its container, it looks better for it to truncate with an ellipsis rather than wrapping.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

### Documentation
<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
