### PR TITLE
fix: UnboundLocalError for msg in create_search_response

### DIFF
--- a/search/search_service/proxy/es_proxy_utils.py
+++ b/search/search_service/proxy/es_proxy_utils.py
@@ -96,6 +96,8 @@ def create_search_response(page_index: int,  # noqa: C901
                            resource_types: List[Resource],
                            resource_to_field_mapping: Dict) -> SearchResponse:
     results_per_resource = {}
+    msg = ''
+    status_code = 200
     # responses are returned in the order in which the searches appear in msearch request
     for resource, response in zip(resource_types, responses):
         msg = ''


### PR DESCRIPTION
## Description
Initialize the `msg` and `status_code` variables at the top of the `create_search_response` util function for the search proxy

## Motivation and Context
We were getting this exception: `UnboundLocalError: local variable 'msg' referenced before assignment`
To mitigate this, now initialize the variables that were previously only set within the for loop at the top of the function.

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
