### PR TITLE
chore: Use text-unidecode instead of unidecode package to fix license incompatibility

### DIFF
--- a/databuilder/databuilder/extractor/snowflake_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/snowflake_metadata_extractor.py
@@ -10,7 +10,7 @@ from typing import (
 )
 
 from pyhocon import ConfigFactory, ConfigTree
-from unidecode import unidecode
+from text_unidecode import unidecode
 
 from databuilder.extractor import sql_alchemy_extractor
 from databuilder.extractor.base_extractor import Extractor

--- a/databuilder/databuilder/utils/hive_complex_type_parser.py
+++ b/databuilder/databuilder/utils/hive_complex_type_parser.py
@@ -23,7 +23,7 @@ field_type = Forward()
 # Scalar types
 union_list = delimitedList(field_type)
 union_type = nestedExpr(
-    opener=union_keyword + "<", closer=">", content=union_list, ignoreExpr=None
+    opener=union_keyword + "<", closer=">", content=union_list, ignoreExpr=None  # type: ignore
 )
 scalar_quantifier = "(" + Word(nums) + Optional(")" | "," + Word(nums) + ")")
 scalar_type = union_type | OneOrMore(Word(alphanums + "_")) + Optional(scalar_quantifier)
@@ -34,13 +34,13 @@ map_field = originalTextFor(scalar_type)("key") + "," + field_type("type")
 struct_field = field_name("name") + ":" + field_type("type")
 struct_list = delimitedList(Group(struct_field))
 array_type = nestedExpr(
-    opener=array_keyword, closer=">", content=array_field, ignoreExpr=None
+    opener=array_keyword, closer=">", content=array_field, ignoreExpr=None  # type: ignore
 )
 map_type = nestedExpr(
-    opener=map_keyword + "<", closer=">", content=map_field, ignoreExpr=None
+    opener=map_keyword + "<", closer=">", content=map_field, ignoreExpr=None  # type: ignore
 )
 struct_type = nestedExpr(
-    opener=struct_keyword + "<", closer=">", content=struct_list, ignoreExpr=None
+    opener=struct_keyword + "<", closer=">", content=struct_list, ignoreExpr=None  # type: ignore
 )
 
 field_type <<= originalTextFor(array_type | map_type | struct_type | scalar_type)

--- a/databuilder/databuilder/utils/trino_complex_type_parser.py
+++ b/databuilder/databuilder/utils/trino_complex_type_parser.py
@@ -29,13 +29,13 @@ map_field = originalTextFor(scalar_type)("key") + "," + field_type("type")
 struct_field = field_name("name") + field_type("type")
 struct_list = delimitedList(Group(struct_field))
 array_type = nestedExpr(
-    opener=array_keyword, closer=")", content=array_field, ignoreExpr=None
+    opener=array_keyword, closer=")", content=array_field, ignoreExpr=None  # type: ignore
 )
 map_type = nestedExpr(
-    opener=map_keyword + "(", closer=")", content=map_field, ignoreExpr=None
+    opener=map_keyword + "(", closer=")", content=map_field, ignoreExpr=None  # type: ignore
 )
 struct_type = nestedExpr(
-    opener=struct_keyword + "(", closer=")", content=struct_list, ignoreExpr=None
+    opener=struct_keyword + "(", closer=")", content=struct_list, ignoreExpr=None  # type: ignore
 )
 
 field_type <<= originalTextFor(array_type | map_type | struct_type | scalar_type)

--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -20,7 +20,7 @@ statsd>=3.2.1
 retrying>=1.3.3
 unicodecsv>=0.14.1,<1.0
 httplib2>=0.18.0
-text-unidecode
+text-unidecode>=1.3
 Jinja2>=2.10.0,<4
 pandas>=0.21.0,<1.5.0
 responses>=0.10.6

--- a/databuilder/requirements.txt
+++ b/databuilder/requirements.txt
@@ -20,7 +20,7 @@ statsd>=3.2.1
 retrying>=1.3.3
 unicodecsv>=0.14.1,<1.0
 httplib2>=0.18.0
-unidecode
+text-unidecode
 Jinja2>=2.10.0,<4
 pandas>=0.21.0,<1.5.0
 responses>=0.10.6

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.4.3'
+__version__ = '7.4.4'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')


### PR DESCRIPTION
## Description
- Update databuilder to use `text-unidecode` instead of `unidecode` due to license incompatibility issues

- Unrelated to the main change, now also ignoring the `None` type passed to `pyparsing`'s `nestedExpr` function. In the docstring for this function, it specifically says `if no expressions are to be ignored, then pass ``None`` for this argument.` so the type definition for the function is incorrect and this is a workaround

## Motivation and Context
This fixes license incompatibility issues, since Amundsen is licensed under Apache 2.0 and `unidecode` is GPL. See this issue for further context: https://github.com/amundsen-io/amundsen/issues/2148

## How Has This Been Tested?
Python tests pass

### Documentation
N/A

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
