### PR TITLE
fix: re-fix wrong npm links

### DIFF
--- a/frontend/amundsen_application/static/package-lock.json
+++ b/frontend/amundsen_application/static/package-lock.json
@@ -21556,7 +21556,7 @@
     },
     "react-floater": {
       "version": "0.7.3",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/react-floater/-/react-floater-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.3.tgz",
       "integrity": "sha1-9XlHlgaCWGhm7CFUDnPJBJyp94c=",
       "requires": {
         "deepmerge": "^4.2.2",
@@ -21569,12 +21569,12 @@
       "dependencies": {
         "nested-property": {
           "version": "1.0.1",
-          "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/nested-property/-/nested-property-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-1.0.1.tgz",
           "integrity": "sha1-IAEQW1xpQTQRuHa7qbhvQxavYT8="
         },
         "tree-changes": {
           "version": "0.5.1",
-          "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/tree-changes/-/tree-changes-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.5.1.tgz",
           "integrity": "sha1-4xzIoPVsjEAfCogkPZFl2+pPVww=",
           "requires": {
             "deep-diff": "^1.0.2",
@@ -21609,7 +21609,7 @@
     },
     "react-joyride": {
       "version": "2.3.2",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/react-joyride/-/react-joyride-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.3.2.tgz",
       "integrity": "sha1-elQHuQMqs5nDxiSrIeYN3UDBLVY=",
       "requires": {
         "deep-diff": "^1.0.2",
@@ -21692,7 +21692,7 @@
     },
     "react-proptype-conditional-require": {
       "version": "1.0.4",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz",
       "integrity": "sha1-acLVdB5t9eCPIw82u8KUTuEiJVU="
     },
     "react-redux": {
@@ -21796,7 +21796,7 @@
     },
     "react-switch": {
       "version": "6.0.0",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/react-switch/-/react-switch-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-6.0.0.tgz",
       "integrity": "sha1-vUot6gjyEbijLlXoMU/US8HslH4=",
       "requires": {
         "prop-types": "^15.7.2"
@@ -21804,7 +21804,7 @@
       "dependencies": {
         "loose-envify": {
           "version": "1.4.0",
-          "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/loose-envify/-/loose-envify-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
@@ -21812,7 +21812,7 @@
         },
         "prop-types": {
           "version": "15.8.1",
-          "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/prop-types/-/prop-types-15.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
           "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
           "requires": {
             "loose-envify": "^1.4.0",
@@ -23060,12 +23060,12 @@
     },
     "scroll": {
       "version": "3.0.1",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/scroll/-/scroll-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
       "integrity": "sha1-1a+1n7NZLuPfMciXQ+eLOeTNiiY="
     },
     "scrollparent": {
       "version": "2.0.1",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/scrollparent/-/scrollparent-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.0.1.tgz",
       "integrity": "sha1-cV1bnMV3YPsivczDvvtb/gaxoxc="
     },
     "scss-tokenizer": {
@@ -25069,7 +25069,7 @@
     },
     "tree-changes": {
       "version": "0.7.1",
-      "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/tree-changes/-/tree-changes-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.7.1.tgz",
       "integrity": "sha1-+ogQy+QX6AuaQsSwGPk0x62PoVY=",
       "requires": {
         "fast-deep-equal": "^3.1.3",
@@ -25078,7 +25078,7 @@
       "dependencies": {
         "fast-deep-equal": {
           "version": "3.1.3",
-          "resolved": "https://artifactory-npm.lyft.net/artifactory/api/npm/virtual-npm-lyft/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
         }
       }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

## Description
"Re-fixes" npm registry links after https://github.com/amundsen-io/amundsen/pull/2171 accidentally reverted the previous fix

## Motivation and Context
Solves https://github.com/amundsen-io/amundsen/issues/2141

## How Has This Been Tested?
Built locally

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [x] Updates Documentation and Docstrings
* [x] Adds tests
* [x] Adds instrumentation (logs, or UI events)
