### PR TITLE
Fix: Add rds badge association records

### DIFF
--- a/databuilder/databuilder/models/badge.py
+++ b/databuilder/databuilder/models/badge.py
@@ -8,6 +8,9 @@ from typing import (
 from amundsen_common.utils.atlas import AtlasCommonParams, AtlasCommonTypes
 from amundsen_rds.models import RDSModel
 from amundsen_rds.models.badge import Badge as RDSBadge
+from amundsen_rds.models.column import ColumnBadge as RDSColumnBadge
+from amundsen_rds.models.dashboard import DashboardBadge as RDSDashboardBadge
+from amundsen_rds.models.table import TableBadge as RDSTableBadge
 
 from databuilder.models.atlas_entity import AtlasEntity
 from databuilder.models.atlas_relationship import AtlasRelationship
@@ -155,6 +158,16 @@ class BadgeMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
         records = self.get_badge_records()
         for record in records:
             yield record
+
+            if self.start_label == 'Table':
+                table_badge_record = RDSTableBadge(table_rk=self.start_key, badge_rk=record.rk)
+                yield table_badge_record
+            elif self.start_label == 'Column':
+                column_badge_record = RDSColumnBadge(column_rk=self.start_key, badge_rk=record.rk)
+                yield column_badge_record
+            elif self.start_label == 'Dashboard':
+                dashboard_badge_record = RDSDashboardBadge(dashboard_rk=self.start_key, badge_rk=record.rk)
+                yield dashboard_badge_record
 
     def _create_atlas_classification_entity(self, badge: Badge) -> AtlasEntity:
         attrs_mapping = [

--- a/databuilder/tests/unit/models/test_badge.py
+++ b/databuilder/tests/unit/models/test_badge.py
@@ -229,8 +229,16 @@ class TestBadge(unittest.TestCase):
                 'category': badge1.category
             },
             {
+                'column_rk': 'hive://default.base/test/ds',
+                'badge_rk': BadgeMetadata.BADGE_KEY_FORMAT.format(badge=badge1.name)
+            },
+            {
                 'rk': BadgeMetadata.BADGE_KEY_FORMAT.format(badge=badge2.name),
                 'category': badge2.category
+            },
+            {
+                'column_rk': 'hive://default.base/test/ds',
+                'badge_rk': BadgeMetadata.BADGE_KEY_FORMAT.format(badge=badge2.name)
             }
         ]
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

## Description
<!--- Describe your changes in detail -->

This PR creates a rds table_badge association record when creating a record iterator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently while creating a badge record a table_badge association record is not created. This only adds badges in the 'badge' table in MySql and hence the badges are not visible for each table on the UI when using csvTableBadgeExtractor
https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/extractor/csv_extractor.py#L80.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested changes using csvTableBadgeExtractor and sample table and badge csv files.

### Documentation
<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
* [ ] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
