### PR TITLE
Refactor Neo4jProxy table owners query for easier customization

### DIFF
--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -159,10 +159,7 @@ class Neo4jProxy(BaseProxy):
         cols, last_neo4j_record = self._exec_col_query(table_uri)
 
         readers = self._exec_usage_query(table_uri)
-        LOGGER.info(f'about to call _exec_owners_query(). {table_uri=}')
         owners = self._exec_owners_query(table_uri)
-
-        LOGGER.info(f'{len(owners)=}')
 
         wmk_results, table_writer, table_apps, timestamp_value, tags, source, \
             badges, prog_descs, resource_reports = self._exec_table_query(table_uri)
@@ -356,12 +353,8 @@ class Neo4jProxy(BaseProxy):
 
         owners_neo4j_records = get_single_record(owners_neo4j_records)
 
-        LOGGER.info(f'{owners_neo4j_records=}')
-
         owners = []  # type: List[User]
         for owner_neo4j_record in owners_neo4j_records.get('owner_records', []):
-            LOGGER.info(f'{owner_neo4j_record=}')
-            LOGGER.info(f'{owner_neo4j_record["email"]=}')
             owner_data = self._get_user_details(user_id=owner_neo4j_record['email'])
             owner = self._build_user_from_record(record=owner_data)
             owners.append(owner)
@@ -404,10 +397,6 @@ class Neo4jProxy(BaseProxy):
                                                                'tag_normal_type': 'default'})
 
         table_records = get_single_record(table_records)
-
-        import pprint
-        print('table_records:')
-        pprint.pprint(table_records)
 
         wmk_results = []
         wmk_records = table_records['wmk_records']

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -159,7 +159,10 @@ class Neo4jProxy(BaseProxy):
         cols, last_neo4j_record = self._exec_col_query(table_uri)
 
         readers = self._exec_usage_query(table_uri)
+        LOGGER.info(f'about to call _exec_owners_query(). {table_uri=}')
         owners = self._exec_owners_query(table_uri)
+
+        LOGGER.info(f'{len(owners)=}')
 
         wmk_results, table_writer, table_apps, timestamp_value, tags, source, \
             badges, prog_descs, resource_reports = self._exec_table_query(table_uri)
@@ -350,8 +353,15 @@ class Neo4jProxy(BaseProxy):
         """)
         owners_neo4j_records = self._execute_cypher_query(statement=owners_query,
                                                           param_dict={'tbl_key': table_uri})
+
+        owners_neo4j_records = get_single_record(owners_neo4j_records)
+
+        LOGGER.info(f'{owners_neo4j_records=}')
+
         owners = []  # type: List[User]
-        for owner_neo4j_record in owners_neo4j_records:
+        for owner_neo4j_record in owners_neo4j_records.get('owner_records', []):
+            LOGGER.info(f'{owner_neo4j_record=}')
+            LOGGER.info(f'{owner_neo4j_record["email"]=}')
             owner_data = self._get_user_details(user_id=owner_neo4j_record['email'])
             owner = self._build_user_from_record(record=owner_data)
             owners.append(owner)
@@ -394,6 +404,10 @@ class Neo4jProxy(BaseProxy):
                                                                'tag_normal_type': 'default'})
 
         table_records = get_single_record(table_records)
+
+        import pprint
+        print('table_records:')
+        pprint.pprint(table_records)
 
         wmk_results = []
         wmk_records = table_records['wmk_records']

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.12.1'
+__version__ = '3.12.2'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -358,6 +358,7 @@ class TestNeo4jProxy(unittest.TestCase):
 
     def test_get_table(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
+            # mock database return values such that we match ordering of queries executed in Neo4jProxy.get_table
             mock_execute.side_effect = [
                 self.col_usage_return_value,
                 [],

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -171,13 +171,6 @@ class TestNeo4jProxy(unittest.TestCase):
                 }
             ],
             'last_updated_timestamp': 1,
-            'owner_records': [
-                {
-                    'key': 'tester@example.com',
-                    'email': 'tester@example.com',
-                    'updated_at': 0,
-                }
-            ],
             'tag_records': [
                 {
                     'key': 'test',
@@ -236,6 +229,14 @@ class TestNeo4jProxy(unittest.TestCase):
             ]
         }]
 
+        owners_results = [{'owner_records': [
+            {
+                'key': 'tester@example.com',
+                'email': 'tester@example.com',
+                'updated_at': 0,
+            }
+        ], }]
+
         last_updated_timestamp = '01'
 
         self.col_usage_return_value = [
@@ -249,6 +250,8 @@ class TestNeo4jProxy(unittest.TestCase):
         self.last_updated_timestamp = last_updated_timestamp
 
         self.table_common_usage = table_common_usage
+
+        self.owners_return_value = owners_results
 
         self.col_bar_id_1_expected_type_metadata = self._get_col_bar_id_1_expected_type_metadata()
         self.col_bar_id_2_expected_type_metadata = self._get_col_bar_id_2_expected_type_metadata()
@@ -358,6 +361,7 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_execute.side_effect = [
                 self.col_usage_return_value,
                 [],
+                self.owners_return_value,
                 self.table_level_return_value,
                 self.table_common_usage,
                 []
@@ -445,6 +449,7 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_execute.side_effect = [
                 col_usage_return_value,
                 [],
+                self.owners_return_value,
                 self.table_level_return_value,
                 self.table_common_usage,
                 []


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

## Description
<!--- Describe your changes in detail -->
For some users of Amundsen, it may prove helpful to customize logic for deciding who a table's "owners" are. This can be accomplished by breaking up the table metadata API's query to make a modular query for only the owners (as is already done when getting table readers, in `Neo4jProxy._exec_usage_query`).

The results of the new `Neo4jProxy._exec_owners_query` are then combined back into the return value of the `Neo4jProxy.get_table method`, preventing any disruption to the JSON shape expected by the frontend. 

## Motivation and Context
This solves the problem of companies that use Neo4j-based Amundsen being unable to customize what data is returned as a table's owners. For example if a company wanted to apply a custom sorting logic to multiple owners, or impute table ownership based on specialized business logic. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated existing unit tests such that they still pass. 

I also tested the service running locally and called it via an Amundsen frontend UI that was running locally. 

### Documentation
<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->
None

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
