### PR TITLE
Fix - Handle ES missing index edge case (bug fix)

### DIFF
--- a/search/search_service/proxy/es_proxy_v2_1.py
+++ b/search/search_service/proxy/es_proxy_v2_1.py
@@ -363,7 +363,7 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
         multisearch = MultiSearch(using=self.elasticsearch)
 
         for resource in resource_types:
-            # guard clause to prevent search in missing indices 
+            # guard clause to prevent search in missing indices
             aliases_in_es = self.elasticsearch.indices.get_alias().keys()
             if self.get_index_alias_for_resource(resource_type=resource) not in aliases_in_es:
                 continue

--- a/search/search_service/proxy/es_proxy_v2_1.py
+++ b/search/search_service/proxy/es_proxy_v2_1.py
@@ -363,6 +363,11 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
         multisearch = MultiSearch(using=self.elasticsearch)
 
         for resource in resource_types:
+            # guard clause to prevent search in missing indices 
+            aliases_in_es = self.elasticsearch.indices.get_alias().keys()
+            if self.get_index_alias_for_resource(resource_type=resource) not in aliases_in_es:
+                continue
+
             # build a query for each resource to search
             query_for_resource = self._build_elasticsearch_query(resource=resource,
                                                                  query_term=query_term,

--- a/search/search_service/proxy/es_proxy_v2_1.py
+++ b/search/search_service/proxy/es_proxy_v2_1.py
@@ -363,7 +363,7 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
         multisearch = MultiSearch(using=self.elasticsearch)
 
         for resource in resource_types:
-            # guard clause to prevent search in missing indices
+            # guard clause to prevent search in missing indices/aliases
             aliases_in_es = self.elasticsearch.indices.get_alias().keys()
             if self.get_index_alias_for_resource(resource_type=resource) not in aliases_in_es:
                 continue

--- a/search/search_service/proxy/es_proxy_v2_1.py
+++ b/search/search_service/proxy/es_proxy_v2_1.py
@@ -364,8 +364,9 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
 
         for resource in resource_types:
             # guard clause to prevent search in missing indices or aliases
-            aliases_in_es = self.elasticsearch.indices.get_alias().keys()
-            if self.get_index_alias_for_resource(resource_type=resource) not in aliases_in_es:
+            aliases_in_es = {alias['alias'] for alias in self.elasticsearch.cat.aliases(format="json")}
+            resource_alias = self.get_index_alias_for_resource(resource_type=resource)
+            if resource_alias not in aliases_in_es:
                 continue
 
             # build a query for each resource to search
@@ -373,7 +374,7 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
                                                                  query_term=query_term,
                                                                  filters=filters)
             # wrap the query in a search object
-            search = Search(index=self.get_index_alias_for_resource(resource_type=resource)).query(query_for_resource)
+            search = Search(index=resource_alias).query(query_for_resource)
 
             # highlighting
             if highlight_options:

--- a/search/search_service/proxy/es_proxy_v2_1.py
+++ b/search/search_service/proxy/es_proxy_v2_1.py
@@ -363,7 +363,7 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
         multisearch = MultiSearch(using=self.elasticsearch)
 
         for resource in resource_types:
-            # guard clause to prevent search in missing indices/aliases
+            # guard clause to prevent search in missing indices or aliases
             aliases_in_es = self.elasticsearch.indices.get_alias().keys()
             if self.get_index_alias_for_resource(resource_type=resource) not in aliases_in_es:
                 continue

--- a/search/search_service/proxy/es_proxy_v2_1.py
+++ b/search/search_service/proxy/es_proxy_v2_1.py
@@ -367,6 +367,7 @@ class ElasticsearchProxyV2_1(ElasticsearchProxyV2):
             aliases_in_es = {alias['alias'] for alias in self.elasticsearch.cat.aliases(format="json")}
             resource_alias = self.get_index_alias_for_resource(resource_type=resource)
             if resource_alias not in aliases_in_es:
+                LOGGER.info(f"There are no indices in elasticsearch against resource_type: {resource}")
                 continue
 
             # build a query for each resource to search

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '4.1.2'
+__version__ = '4.1.3'
 
 oidc = ['flaskoidc>=1.0.0']
 

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '4.1.1'
+__version__ = '4.1.2'
 
 oidc = ['flaskoidc>=1.0.0']
 


### PR DESCRIPTION
## Description
This pull request handles an edge case with basic search. If more than one `resource_types` is configured for amundsen (e.g Tables and Dashboards) and one of them have missing indices (i.e. no data got ingested for either of them in an initial run), it will crash the basic search from working for all `resource_types`. In a clean deployment (blank neo4j and elasticsearch), it is possible to not have data for all configured resource types at once. In such a case the search should not return any results for the resource_type with missing data instead of crashing basic search altogether. This PR addresses this problem and ensures that we trigger an elasticsearch "search" against only those `resource_types` which have a corresponding index/alias present in the elasticsearch database.

## Motivation and Context
For a fresh deployment of amundsen, in case any of the configured resource types is missing indices in elasticsearch, it will prevent the search from running altogether. Also, the error statement tends to be a bit confusing: 

`[ERROR] es_proxy_v2_1.execute_multisearch_query:349 (1:Thread-48) - Failed to execute ES search queries. TransportError(N/A, 'index_not_found_exception')`

As it does not mention which particular index (or alias) was missing. In my case, dashboards were missing but I was under the impression that maybe the search service was not looking in the right place because there were some indices in my elasticsearch instance already, which were searchable using other debugging tools (such as [elasticvue](https://elasticvue.com/)). I came across the aforementioned issue and wanted to push a fix for this. There wasn't a corresponding open issue against this already, but there is a reference to a similar issue [here](https://github.com/amundsen-io/amundsen/pull/1817#issuecomment-1126889050).

## How Has This Been Tested?
I prepared a clean environment locally by deleting all neo4j and elasticsearch data. Next, I ran an ingestion run for only one resource type (without knowing that I'd have to run it for all `resource_types` to actually get it working). In my case, I ingested tables only, without ingesting dashboards. And then I noticed that the advanced search (sidebar) was working but the main, basic search bar wasn't. Upon investigation, I narrowed it down and implemented this fix. Now, the main/basic search works fine even if I don't ingest dashboards. 

### Documentation
No updates to the documentation were needed. 

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
