### PR TITLE
feat: Make sqlalchemy_extractor compatible with sqlalchemy>=1.4

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.17
       id: go
     - name: Install addlicense
       run: |

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -21,6 +21,7 @@ routing PRs, questions, etc. to the right place.
 - Tamika Tannis (https://github.com/ttannis)
 - Tao Feng (https://github.com/feng-tao)
 - Verdan Mahmood (https://github.com/verdan)
+- Alagappan (https://github.com/alagappan)
 
 # Amundsen Emeritus Contributors
 - Dorian Johnson (https://github.com/dorianj)

--- a/databuilder/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/databuilder/extractor/sql_alchemy_extractor.py
@@ -5,7 +5,7 @@ import importlib
 from typing import Any
 
 from pyhocon import ConfigFactory, ConfigTree
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -62,7 +62,11 @@ class SQLAlchemyExtractor(Extractor):
         Create an iterator to execute sql.
         """
         if not hasattr(self, 'results'):
-            self.results = self.connection.execute(self.extract_sql)
+            results = self.connection.execute(text(self.extract_sql))
+            # Makes this forward compatible with sqlalchemy >= 1.4
+            if hasattr(results, "mappings"):
+                results = results.mappings()
+            self.results = results
 
         if hasattr(self, 'model_class'):
             results = [self.model_class(**result)


### PR DESCRIPTION
feat: Make sqlalchemy_extractor compatible with sqlalchemy>=1.4

## Description
These changes to the `sql_alchemy_extractor` module allow for using the extractors with updated versions of `sqlalchemy`.

## Motivation and Context
This addresses issues such as
* #2108 which require the `text` function to be used to wrap queries in `SQLAlchemy>=2.0`
* Posts on the Slack channel such as [this](https://amundsenworkspace.slack.com/archives/CGFBVT23V/p1698249835872919) and [this](https://amundsenworkspace.slack.com/archives/CGFBVT23V/p1699242309714869) which require the change to explicitly map the `Row` objects to dicts for `SQLAlchemy>=1.4`

## How Has This Been Tested?
Tested using `sampple_mssql_metadata.py` script for
* `SQLAlchemy==1.3.16`
* `SQLAlchemy==2.0.23`

### Documentation
None

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [X] Updates Documentation and Docstrings
* [X] Adds tests
* [X] Adds instrumentation (logs, or UI events)
