### PR TITLE
[ADD] Make sqlalchemy_extractor compatible with sqlalchemy>=1.4

### DIFF
--- a/databuilder/databuilder/extractor/sql_alchemy_extractor.py
+++ b/databuilder/databuilder/extractor/sql_alchemy_extractor.py
@@ -5,7 +5,7 @@ import importlib
 from typing import Any
 
 from pyhocon import ConfigFactory, ConfigTree
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
@@ -62,7 +62,11 @@ class SQLAlchemyExtractor(Extractor):
         Create an iterator to execute sql.
         """
         if not hasattr(self, 'results'):
-            self.results = self.connection.execute(self.extract_sql)
+            results = self.connection.execute(text(self.extract_sql))
+            # Makes this forward compatible with sqlalchemy >= 1.4
+            if hasattr(results, "mappings"):
+                results = results.mappings()
+            self.results = results
 
         if hasattr(self, 'model_class'):
             results = [self.model_class(**result)

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.4.5'
+__version__ = '7.4.6'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')


### PR DESCRIPTION
feat: Make sqlalchemy_extractor compatible with sqlalchemy>=1.4
(Moved from  #2209)

## Description
These changes to the `sql_alchemy_extractor` module allow for using the extractors with updated versions of `sqlalchemy`.

## Motivation and Context
This addresses issues such as
* #2108 which require the `text` function to be used to wrap queries in `SQLAlchemy>=2.0`
* Posts on the Slack channel such as [this](https://amundsenworkspace.slack.com/archives/CGFBVT23V/p1698249835872919) and [this](https://amundsenworkspace.slack.com/archives/CGFBVT23V/p1699242309714869) which require the change to explicitly map the `Row` objects to dicts for `SQLAlchemy>=1.4`

## How Has This Been Tested?
Tested using `sampple_mssql_metadata.py` script for
* `SQLAlchemy==1.3.16`
* `SQLAlchemy==2.0.23`

### Documentation
None

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [X] Updates Documentation and Docstrings
* [X] Adds tests
* [X] Adds instrumentation (logs, or UI events)
