### PR TITLE
fix: Do not attempt to retrieve feature lineage when it is not enabled

### DIFF
--- a/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
+++ b/frontend/amundsen_application/static/js/pages/FeaturePage/index.tsx
@@ -269,7 +269,9 @@ export const FeaturePage: React.FC<FeaturePageProps> = ({
       setKey(newKey);
       getFeatureDispatch(newKey, index, source);
       getFeatureCodeDispatch(newKey);
-      getFeatureLineageDispatch(newKey);
+      if (isFeatureListLineageEnabled()) {
+        getFeatureLineageDispatch(newKey);
+      }
       getFeaturePreviewDispatch({
         version,
         feature_group: group,


### PR DESCRIPTION
## Description
There was a bug on the feature page where lineage was retrieved even when not enabled, throwing an error when there was nothing available at the endpoint.

## Motivation and Context
Fixes errors when feature lineage is not enabled

## How Has This Been Tested?
Ran the code locally and saw the feature lineage API was no longer being called after the change

### Documentation
N/A

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
