### PR TITLE
chore: Upgrade flask to 2.2.5 and remove py37 support

### DIFF
--- a/.github/workflows/common_pull_request.yml
+++ b/.github/workflows/common_pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/databuilder_pull_request.yml
+++ b/.github/workflows/databuilder_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup python 3.7
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/.github/workflows/frontend_pull_request.yml
+++ b/.github/workflows/frontend_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x", "3.8.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/metadata_pull_request.yml
+++ b/.github/workflows/metadata_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Checkout master
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/noop_pull_request.yml
+++ b/.github/workflows/noop_pull_request.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6.x", "3.7.x", "3.8.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Do nothing
         run: exit 0

--- a/.github/workflows/search_pull_request.yml
+++ b/.github/workflows/search_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/Dockerfile.frontend.local
+++ b/Dockerfile.frontend.local
@@ -14,7 +14,7 @@ RUN npm run dev-build
 
 COPY ./frontend /app
 
-FROM python:3.7-slim
+FROM python:3.8-slim
 WORKDIR /app
 
 COPY ./frontend /app

--- a/Dockerfile.frontend.public
+++ b/Dockerfile.frontend.public
@@ -8,7 +8,7 @@ RUN npm install
 COPY ./frontend/amundsen_application/static /app/amundsen_application/static
 RUN npm run build
 
-FROM python:3.7-slim as base
+FROM python:3.8-slim as base
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/Dockerfile.metadata.public
+++ b/Dockerfile.metadata.public
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.8-slim as base
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/Dockerfile.search.public
+++ b/Dockerfile.search.public
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We want your input about what is important, for that, add your votes using the ð
 * [Top Questions](https://github.com/amundsen-io/amundsen/issues?q=is%3Aissue+is%3Aclosed+sort%3Areactions-%2B1-desc+label%3Atype%3Aquestion+label%3Astatus%3Aneeds_votes)
 
 ## Requirements
-- Python 3.7
+- Python 3.8
 - Node v12
 
 ## User Interface

--- a/common/README.md
+++ b/common/README.md
@@ -8,7 +8,7 @@ Amundsen Common library holds common codes among micro services in Amundsen.
 For information about Amundsen and our other services, visit the [main repository](https://github.com/amundsen-io/amundsen). Please also see our instructions for a [quick start](https://github.com/amundsen-io/amundsen/blob/master/docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](https://github.com/amundsen-io/amundsen/blob/master/docs/architecture.md#architecture).
 
 ## Requirements
-- Python >= 3.6
+- Python >= 3.8
 
 ## Doc
 - https://www.amundsen.io/amundsen/

--- a/common/amundsen_common/log/action_log_callback.py
+++ b/common/amundsen_common/log/action_log_callback.py
@@ -8,7 +8,7 @@ so that registered callbacks can be used all through the same python process.
 
 import logging
 import sys
-from typing import Callable, List, Any
+from typing import Callable, Any
 
 from pkg_resources import iter_entry_points
 
@@ -16,8 +16,8 @@ from amundsen_common.log.action_log_model import ActionLogParams
 
 LOGGER = logging.getLogger(__name__)
 
-__pre_exec_callbacks = []  # type: List[Callable[..., Any]]
-__post_exec_callbacks = []  # type: List[Callable[..., Any]]
+__pre_exec_callbacks = []  # type: list[Callable[..., Any]]
+__post_exec_callbacks = []  # type: list[Callable[..., Any]]
 
 
 def register_pre_exec_callback(action_log_callback: Callable[..., Any]) -> None:

--- a/common/amundsen_common/log/action_log_callback.py
+++ b/common/amundsen_common/log/action_log_callback.py
@@ -8,7 +8,7 @@ so that registered callbacks can be used all through the same python process.
 
 import logging
 import sys
-from typing import Callable, Any
+from typing import Callable, List, Any
 
 from pkg_resources import iter_entry_points
 
@@ -16,8 +16,8 @@ from amundsen_common.log.action_log_model import ActionLogParams
 
 LOGGER = logging.getLogger(__name__)
 
-__pre_exec_callbacks = []  # type: list[Callable[..., Any]]
-__post_exec_callbacks = []  # type: list[Callable[..., Any]]
+__pre_exec_callbacks: List[Callable[..., Any]] = []
+__post_exec_callbacks: List[Callable[..., Any]] = []
 
 
 def register_pre_exec_callback(action_log_callback: Callable[..., Any]) -> None:

--- a/common/setup.cfg
+++ b/common/setup.cfg
@@ -31,28 +31,28 @@ output = build/coverage.xml
 directory = build/coverage_html
 
 [mypy]
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-no_implicit_optional = true
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+no_implicit_optional = True
 
 [semantic_release]
 version_variable = "./setup.py:__version__"
-upload_to_pypi = true
-upload_to_release = true
+upload_to_pypi = True
+upload_to_release = True
 commit_subject = New release for {version}
 commit_message = Signed-off-by: github-actions <github-actions@github.com>
 commit_author = github-actions <github-actions@github.com>
 
 [mypy-marshmallow.*]
-ignore_missing_imports = true
+ignore_missing_imports = True
 
 [mypy-marshmallow3_annotations.*]
-ignore_missing_imports = true
+ignore_missing_imports = True
 
 [mypy-setuptools.*]
-ignore_missing_imports = true
+ignore_missing_imports = True
 
 [mypy-tests.*]
-disallow_untyped_defs = false
+disallow_untyped_defs = False

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.31.0'
+__version__ = '1.0.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')
@@ -38,7 +38,7 @@ setup(
         # This will allow for any consuming projects to use this library as
         # long as they have a version of pyfoobar equal to or greater than 1.x
         # and less than 2.x installed.
-        'Flask>=1.0.2',
+        'Flask>=2.2.5',
         'attrs>=19.0.0',
         'marshmallow>=3.0',
         'marshmallow3-annotations>=1.1.0'
@@ -46,6 +46,6 @@ setup(
     extras_require={
         'all': requirements_dev
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     package_data={'amundsen_common': ['py.typed']},
 )

--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -11,7 +11,7 @@ Amundsen Databuilder is a data ingestion library, which is inspired by [Apache G
 For information about Amundsen and our other services, visit the [main repository](https://github.com/amundsen-io/amundsen#amundsen) `README.md` . Please also see our instructions for a [quick start](https://github.com/amundsen-io/amundsen/blob/master/docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](https://github.com/amundsen-io/amundsen/blob/master/docs/architecture.md#architecture).
 
 ## Requirements
-- Python >= 3.6.x
+- Python >= 3.8.x
 - elasticsearch 7.x
 
 ## Doc

--- a/databuilder/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
+++ b/databuilder/databuilder/extractor/dashboard/tableau/tableau_dashboard_utils.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+import abc
 import json
 import re
 from typing import (
@@ -99,7 +100,7 @@ class TableauGraphQLApiExtractor(Extractor):
             'Content-Type': 'application/json',
             'X-Tableau-Auth': self._auth_token
         }
-        params = {
+        params: Dict[str, Any] = {
             'headers': headers
         }
         if self._verify_request is not None:
@@ -108,6 +109,7 @@ class TableauGraphQLApiExtractor(Extractor):
         response = requests.post(url=self._metadata_url, data=query_payload, **params)
         return response.json()['data']
 
+    @abc.abstractmethod
     def execute(self) -> Iterator[Dict[str, Any]]:
         """
         Must be overriden by any extractor using this class. This should parse the result and yield each entity's
@@ -187,7 +189,7 @@ class TableauDashboardAuth:
             'Content-Type': 'application/json'
         }
         # verify = False is needed bypass occasional (valid) self-signed cert errors. TODO: actually fix it!!
-        params = {
+        params: Dict[str, Any] = {
             'headers': headers
         }
         if self._verify_request is not None:

--- a/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -503,8 +503,8 @@ class DeltaLakeMetadataExtractor(Extractor):
             _table_columns = table.columns
         else:
             _table_columns = []
-        columns_with_valid_type = list(map(lambda l: l.name,
-                                           filter(lambda l: str(l.data_type).lower() in valid_types, _table_columns)
+        columns_with_valid_type = list(map(lambda n: n.name,
+                                           filter(lambda d: str(d.data_type).lower() in valid_types, _table_columns)
                                            )
                                        )
 

--- a/databuilder/databuilder/extractor/kafka_schema_registry_extractor.py
+++ b/databuilder/databuilder/extractor/kafka_schema_registry_extractor.py
@@ -58,6 +58,8 @@ class KafkaSchemaRegistryExtractor(Extractor):
     def extract(self) -> Union[TableMetadata, None]:
         if not self._extract_iter:
             self._extract_iter = self._get_extract_iter()
+        if self._extract_iter is None:
+            return None
         try:
             return next(self._extract_iter)
         except StopIteration:

--- a/databuilder/databuilder/extractor/mysql_search_data_extractor.py
+++ b/databuilder/databuilder/extractor/mysql_search_data_extractor.py
@@ -43,31 +43,31 @@ def _table_search_query(session: Session, table_filter: List, offset: int, limit
     """
     # table
     query = session.query(Table).filter(*table_filter).options(
-        load_only(Table.rk, Table.name, Table.schema_rk)
+        load_only(Table.rk, Table.name, Table.schema_rk)  # type: ignore
     )
 
     # description
     query = query.options(
         subqueryload(Table.description).options(
-            load_only(TableDescription.description)
+            load_only(TableDescription.description)  # type: ignore
         )
     ).options(
         subqueryload(Table.programmatic_descriptions).options(
-            load_only(TableProgrammaticDescription.description)
+            load_only(TableProgrammaticDescription.description)  # type: ignore
         )
     )
 
     # schema, cluster, database
     query = query.options(
         subqueryload(Table.schema).options(
-            load_only(Schema.name, Schema.cluster_rk),
+            load_only(Schema.name, Schema.cluster_rk),  # type: ignore
             subqueryload(Schema.description).options(
-                load_only(SchemaDescription.description)
+                load_only(SchemaDescription.description)  # type: ignore
             ),
             subqueryload(Schema.cluster).options(
-                load_only(Cluster.name, Cluster.database_rk),
+                load_only(Cluster.name, Cluster.database_rk),  # type: ignore
                 subqueryload(Cluster.database).options(
-                    load_only(Database.name)
+                    load_only(Database.name)  # type: ignore
                 )
             )
         )
@@ -76,9 +76,9 @@ def _table_search_query(session: Session, table_filter: List, offset: int, limit
     # column
     query = query.options(
         subqueryload(Table.columns).options(
-            load_only(TableColumn.rk, TableColumn.name),
+            load_only(TableColumn.rk, TableColumn.name),  # type: ignore
             subqueryload(TableColumn.description).options(
-                load_only(ColumnDescription.description)
+                load_only(ColumnDescription.description)  # type: ignore
             )
         )
     )
@@ -86,25 +86,25 @@ def _table_search_query(session: Session, table_filter: List, offset: int, limit
     # tag, badge
     query = query.options(
         subqueryload(Table.tags).options(
-            load_only(Tag.rk, Tag.tag_type)
+            load_only(Tag.rk, Tag.tag_type)  # type: ignore
         )
     ).options(
         subqueryload(Table.badges).options(
-            load_only(Badge.rk)
+            load_only(Badge.rk)  # type: ignore
         )
     )
 
     # usage
     query = query.options(
         subqueryload(Table.usage).options(
-            load_only(TableUsage.read_count)
+            load_only(TableUsage.read_count)  # type: ignore
         )
     )
 
     # timestamp
     query = query.options(
         subqueryload(Table.timestamp).options(
-            load_only(TableTimestamp.last_updated_timestamp)
+            load_only(TableTimestamp.last_updated_timestamp)  # type: ignore
         )
     )
 
@@ -187,24 +187,24 @@ def _dashboard_search_query(session: Session, dashboard_filter: List, offset: in
     """
     # dashboard
     query = session.query(Dashboard).filter(*dashboard_filter).options(
-        load_only(Dashboard.rk,
-                  Dashboard.name,
-                  Dashboard.dashboard_url,
-                  Dashboard.dashboard_group_rk)
+        load_only(Dashboard.rk,  # type: ignore
+                  Dashboard.name,  # type: ignore
+                  Dashboard.dashboard_url,  # type: ignore
+                  Dashboard.dashboard_group_rk)  # type: ignore
     )
 
     # group, cluster
     query = query.options(
         subqueryload(Dashboard.group).options(
-            load_only(DashboardGroup.rk,
-                      DashboardGroup.name,
-                      DashboardGroup.dashboard_group_url,
-                      DashboardGroup.cluster_rk),
+            load_only(DashboardGroup.rk,  # type: ignore
+                      DashboardGroup.name,  # type: ignore
+                      DashboardGroup.dashboard_group_url,  # type: ignore
+                      DashboardGroup.cluster_rk),  # type: ignore
             subqueryload(DashboardGroup.description).options(
-                load_only(DashboardGroupDescription.description)
+                load_only(DashboardGroupDescription.description)  # type: ignore
             ),
             subqueryload(DashboardGroup.cluster).options(
-                load_only(DashboardCluster.name)
+                load_only(DashboardCluster.name)  # type: ignore
             )
         )
     )
@@ -212,30 +212,30 @@ def _dashboard_search_query(session: Session, dashboard_filter: List, offset: in
     # description
     query = query.options(
         subqueryload(Dashboard.description).options(
-            load_only(DashboardDescription.description)
+            load_only(DashboardDescription.description)  # type: ignore
         )
     )
 
     # execution
     query = query.options(
         subqueryload(Dashboard.execution).options(
-            load_only(DashboardExecution.rk, DashboardExecution.timestamp)
+            load_only(DashboardExecution.rk, DashboardExecution.timestamp)  # type: ignore
         )
     )
 
     # usage
     query = query.options(
         subqueryload(Dashboard.usage).options(
-            load_only(DashboardUsage.read_count)
+            load_only(DashboardUsage.read_count)  # type: ignore
         )
     )
 
     # query, chart
     query = query.options(
         subqueryload(Dashboard.queries).options(
-            load_only(DashboardQuery.name),
+            load_only(DashboardQuery.name),  # type: ignore
             subqueryload(DashboardQuery.charts).options(
-                load_only(DashboardChart.name)
+                load_only(DashboardChart.name)  # type: ignore
             )
         )
     )
@@ -243,11 +243,11 @@ def _dashboard_search_query(session: Session, dashboard_filter: List, offset: in
     # tag, badge
     query = query.options(
         subqueryload(Dashboard.tags).options(
-            load_only(Tag.rk, Tag.tag_type)
+            load_only(Tag.rk, Tag.tag_type)  # type: ignore
         )
     ).options(
         subqueryload(Dashboard.badges).options(
-            load_only(Badge.rk)
+            load_only(Badge.rk)  # type: ignore
         )
     )
 
@@ -384,7 +384,7 @@ def _user_search_query(session: Session, user_filter: List, offset: int, limit: 
     # manager
     query = query.options(
         subqueryload(User.manager).options(
-            load_only(User.email)
+            load_only(User.email)  # type: ignore
         )
     )
 
@@ -403,7 +403,7 @@ def _user_search(session: Session, published_tag: str, limit: int) -> List[Dict]
 
     user_filter = [User.full_name.isnot(None)]
     if published_tag:
-        user_filter.append(User.published_tag == published_tag)
+        user_filter.append(User.published_tag == published_tag)  # type: ignore
 
     user_results = []
 

--- a/databuilder/databuilder/models/dashboard/dashboard_chart.py
+++ b/databuilder/databuilder/models/dashboard/dashboard_chart.py
@@ -142,11 +142,11 @@ class DashboardChart(GraphSerializable, TableSerializable, AtlasSerializable):
             )
         )
         if self._chart_name:
-            record.name = self._chart_name
+            record.name = self._chart_name  # type: ignore
         if self._chart_type:
-            record.type = self._chart_type
+            record.type = self._chart_type  # type: ignore
         if self._chart_url:
-            record.url = self._chart_url
+            record.url = self._chart_url  # type: ignore
 
         yield record
 

--- a/databuilder/databuilder/models/dashboard/dashboard_metadata.py
+++ b/databuilder/databuilder/models/dashboard/dashboard_metadata.py
@@ -80,7 +80,7 @@ class DashboardMetadata(GraphSerializable, TableSerializable, AtlasSerializable)
                  dashboard_group: str,
                  dashboard_name: str,
                  description: Union[str, None],
-                 tags: List = None,
+                 tags: Optional[List] = None,
                  cluster: str = 'gold',
                  product: Optional[str] = '',
                  dashboard_group_id: Optional[str] = None,
@@ -387,7 +387,7 @@ class DashboardMetadata(GraphSerializable, TableSerializable, AtlasSerializable)
                 cluster_rk=self._get_cluster_key()
             )
             if self.dashboard_group_url:
-                dashboard_group_record.dashboard_group_url = self.dashboard_group_url
+                dashboard_group_record.dashboard_group_url = self.dashboard_group_url  # type: ignore
 
             yield dashboard_group_record
 
@@ -406,10 +406,10 @@ class DashboardMetadata(GraphSerializable, TableSerializable, AtlasSerializable)
             dashboard_group_rk=self._get_dashboard_group_key()
         )
         if self.created_timestamp:
-            dashboard_record.created_timestamp = self.created_timestamp
+            dashboard_record.created_timestamp = self.created_timestamp  # type: ignore
 
         if self.dashboard_url:
-            dashboard_record.dashboard_url = self.dashboard_url
+            dashboard_record.dashboard_url = self.dashboard_url  # type: ignore
 
         yield dashboard_record
 

--- a/databuilder/databuilder/models/dashboard/dashboard_query.py
+++ b/databuilder/databuilder/models/dashboard/dashboard_query.py
@@ -128,9 +128,9 @@ class DashboardQuery(GraphSerializable, TableSerializable, AtlasSerializable):
             )
         )
         if self._url:
-            record.url = self._url
+            record.url = self._url  # type: ignore
         if self._query_text:
-            record.query_text = self._query_text
+            record.query_text = self._query_text  # type: ignore
 
         yield record
 

--- a/databuilder/databuilder/models/feature/feature_metadata.py
+++ b/databuilder/databuilder/models/feature/feature_metadata.py
@@ -52,9 +52,9 @@ class FeatureMetadata(GraphSerializable):
                  status: Optional[str] = None,
                  entity: Optional[str] = None,
                  data_type: Optional[str] = None,
-                 availability: List[str] = None,  # list of databases
+                 availability: Optional[List[str]] = None,  # list of databases
                  description: Optional[str] = None,
-                 tags: List[str] = None,
+                 tags: Optional[List[str]] = None,
                  created_timestamp: Optional[int] = None,
                  last_updated_timestamp: Optional[int] = None,
                  **kwargs: Any

--- a/databuilder/databuilder/models/schema/schema.py
+++ b/databuilder/databuilder/models/schema/schema.py
@@ -3,7 +3,7 @@
 
 import re
 from typing import (
-    Any, Iterator, Union,
+    Any, Iterator, Optional, Union,
 )
 
 from amundsen_common.utils.atlas import AtlasCommonParams, AtlasTableTypes
@@ -32,8 +32,8 @@ class SchemaModel(GraphSerializable, TableSerializable, AtlasSerializable):
     def __init__(self,
                  schema_key: str,
                  schema: str,
-                 description: str = None,
-                 description_source: str = None,
+                 description: Optional[str] = None,
+                 description_source: Optional[str] = None,
                  **kwargs: Any
                  ) -> None:
         self._schema_key = schema_key

--- a/databuilder/databuilder/models/table_lineage.py
+++ b/databuilder/databuilder/models/table_lineage.py
@@ -3,7 +3,7 @@
 
 from abc import abstractmethod
 from typing import (
-    Iterator, List, Union,
+    Iterator, List, Optional, Union,
 )
 
 from amundsen_common.utils.atlas import AtlasCommonParams, AtlasTableTypes
@@ -142,7 +142,7 @@ class TableLineage(BaseLineage):
 
     def __init__(self,
                  table_key: str,
-                 downstream_deps: List = None,  # List of table keys
+                 downstream_deps: Optional[List] = None,  # List of table keys
                  ) -> None:
         self.table_key = table_key
         # a list of downstream dependencies, each of which will follow
@@ -196,7 +196,7 @@ class ColumnLineage(BaseLineage):
 
     def __init__(self,
                  column_key: str,
-                 downstream_deps: List = None,  # List of column keys
+                 downstream_deps: Optional[List] = None,  # List of column keys
                  ) -> None:
         self.column_key = column_key
         # a list of downstream dependencies, each of which will follow

--- a/databuilder/databuilder/models/table_metadata.py
+++ b/databuilder/databuilder/models/table_metadata.py
@@ -279,9 +279,9 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
                  schema: str,
                  name: str,
                  description: Union[str, None],
-                 columns: Iterable[ColumnMetadata] = None,
+                 columns: Optional[Iterable[ColumnMetadata]] = None,
                  is_view: bool = False,
-                 tags: Union[List, str] = None,
+                 tags: Union[List, str, None] = None,
                  description_source: Union[str, None] = None,
                  **kwargs: Any
                  ) -> None:
@@ -801,9 +801,6 @@ class TableMetadata(GraphSerializable, TableSerializable, AtlasSerializable):
         )
 
         return entity
-
-    def _create_next_atlas_relation(self) -> Iterator[AtlasRelationship]:
-        pass
 
     def _create_atlas_relation_iterator(self) -> Iterator[AtlasRelationship]:
         for tag in self.tags:

--- a/databuilder/databuilder/models/table_stats.py
+++ b/databuilder/databuilder/models/table_stats.py
@@ -32,10 +32,10 @@ class TableStats(GraphSerializable, TableSerializable):
                  stat_val: str,
                  is_metric: bool,
                  db: str = 'hive',
-                 schema: str = None,
+                 schema: Optional[str] = None,
                  cluster: str = 'gold',
-                 start_epoch: str = None,
-                 end_epoch: str = None
+                 start_epoch: Optional[str] = None,
+                 end_epoch: Optional[str] = None
                  ) -> None:
         if schema is None:
             self.schema, self.table = table_name.split('.')
@@ -53,7 +53,6 @@ class TableStats(GraphSerializable, TableSerializable):
         self.is_metric = is_metric
         self._node_iter = self._create_node_iterator()
         self._relation_iter = self._create_relation_iterator()
-        self._record_iter = self._create_record_iterator()
 
     def create_next_node(self) -> Optional[GraphNode]:
         # return the string representation of the data
@@ -69,10 +68,7 @@ class TableStats(GraphSerializable, TableSerializable):
             return None
 
     def create_next_record(self) -> Union[RDSModel, None]:
-        try:
-            return next(self._record_iter)
-        except StopIteration:
-            return None
+        return None
 
     def get_table_stat_model_key(self) -> str:
         return TableStats.KEY_FORMAT.format(db=self.db,
@@ -123,9 +119,6 @@ class TableStats(GraphSerializable, TableSerializable):
         )
         yield relationship
 
-    def _create_record_iterator(self) -> Iterator[RDSModel]:
-        pass
-
 
 class TableColumnStats(GraphSerializable, TableSerializable):
     """
@@ -144,7 +137,7 @@ class TableColumnStats(GraphSerializable, TableSerializable):
                  end_epoch: str,
                  db: str = 'hive',
                  cluster: str = 'gold',
-                 schema: str = None
+                 schema: Optional[str] = None
                  ) -> None:
         if schema is None:
             self.schema, self.table = table_name.split('.')

--- a/databuilder/databuilder/models/user.py
+++ b/databuilder/databuilder/models/user.py
@@ -132,7 +132,7 @@ class User(GraphSerializable, TableSerializable, AtlasSerializable):
 
     @classmethod
     def get_user_model_key(cls,
-                           email: str = None
+                           email: Optional[str] = None
                            ) -> str:
         if not email:
             return ''
@@ -197,10 +197,10 @@ class User(GraphSerializable, TableSerializable, AtlasSerializable):
         # or the flag allows to update empty values
         for attr, value in record_attr_map.items():
             if value or not self.do_not_update_empty_attribute:
-                record.__setattr__(attr.key, value)
+                record.__setattr__(attr.key, value)  # type: ignore
 
         if self.manager_email:
-            record.manager_rk = self.get_user_model_key(email=self.manager_email)
+            record.manager_rk = self.get_user_model_key(email=self.manager_email)  # type: ignore
 
         return record
 

--- a/databuilder/databuilder/publisher/mysql_csv_publisher.py
+++ b/databuilder/databuilder/publisher/mysql_csv_publisher.py
@@ -187,8 +187,8 @@ class MySQLCSVPublisher(Publisher):
         :return:
         """
         record = model(**record_dict)
-        record.published_tag = self._publish_tag
-        record.publisher_last_updated_epoch_ms = int(time.time() * 1000)
+        record.published_tag = self._publish_tag  # type: ignore
+        record.publisher_last_updated_epoch_ms = int(time.time() * 1000)  # type: ignore
         return record
 
     def _execute(self, session: Session) -> None:

--- a/databuilder/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/databuilder/publisher/neo4j_csv_publisher.py
@@ -9,7 +9,7 @@ from io import open
 from os import listdir
 from os.path import isfile, join
 from typing import (
-    Dict, List, Set,
+    Dict, List, Optional, Set,
 )
 
 import neo4j
@@ -468,7 +468,7 @@ class Neo4jCsvPublisher(Publisher):
     def _execute_statement(self,
                            stmt: str,
                            tx: Transaction,
-                           params: dict = None,
+                           params: Optional[dict] = None,
                            expect_result: bool = False) -> Transaction:
         """
         Executes statement against Neo4j. If execution fails, it rollsback and raise exception.

--- a/databuilder/databuilder/publisher/neo4j_preprocessor.py
+++ b/databuilder/databuilder/publisher/neo4j_preprocessor.py
@@ -111,7 +111,7 @@ class NoopRelationPreprocessor(RelationPreprocessor):
                                end_key: str,
                                relation: str,
                                reverse_relation: str) -> Tuple[str, Dict[str, str]]:
-        pass
+        return '', {}
 
     def is_perform_preprocess(self) -> bool:
         return False
@@ -143,7 +143,7 @@ class DeleteRelationPreprocessor(RelationPreprocessor):
     """)
 
     def __init__(self,
-                 label_tuples: List[Tuple[str, str]] = None,
+                 label_tuples: Optional[List[Tuple[str, str]]] = None,
                  where_clause: str = '') -> None:
         super(DeleteRelationPreprocessor, self).__init__()
         self._label_tuples = set(label_tuples) if label_tuples else set()

--- a/databuilder/databuilder/rest_api/rest_api_query.py
+++ b/databuilder/databuilder/rest_api/rest_api_query.py
@@ -4,7 +4,7 @@
 import copy
 import logging
 from typing import (
-    Any, Callable, Dict, Iterator, List, Union,
+    Any, Callable, Dict, Iterator, List, Optional, Union,
 )
 
 import requests
@@ -62,8 +62,8 @@ class RestApiQuery(BaseRestApiQuery):
                  fail_no_result: bool = False,
                  skip_no_result: bool = False,
                  json_path_contains_or: bool = False,
-                 can_skip_failure: Callable = None,
-                 query_merger: QueryMerger = None,
+                 can_skip_failure: Optional[Callable] = None,
+                 query_merger: Optional[QueryMerger] = None,
                  **kwargs: Any
                  ) -> None:
         """
@@ -149,7 +149,7 @@ class RestApiQuery(BaseRestApiQuery):
                 try:
                     response = self._send_request(url=url)
                 except Exception as e:
-                    if self._can_skip_failure and self._can_skip_failure(exception=e):
+                    if self._can_skip_failure is not None and self._can_skip_failure(exception=e):
                         continue
                     raise e
 

--- a/databuilder/databuilder/task/mysql_staleness_removal_task.py
+++ b/databuilder/databuilder/task/mysql_staleness_removal_task.py
@@ -149,8 +149,8 @@ class MySQLStalenessRemovalTask(Task):
         :param target_model_class:
         :return:
         """
-        total_records_count = self._session.query(func.count('*')).select_from(target_model_class).scalar()
-        stale_records_count = self._session.query(func.count('*')).select_from(target_model_class) \
+        total_records_count = self._session.query(func.count()).select_from(target_model_class).scalar()
+        stale_records_count = self._session.query(func.count()).select_from(target_model_class) \
             .filter(self._get_stale_records_filter_condition(target_model_class=target_model_class)).scalar()
 
         staleness_pct = 0

--- a/databuilder/databuilder/transformer/base_transformer.py
+++ b/databuilder/databuilder/transformer/base_transformer.py
@@ -36,7 +36,7 @@ class NoopTransformer(Transformer):
         return record
 
     def get_scope(self) -> str:
-        pass
+        return ''
 
 
 class ChainedTransformer(Transformer):

--- a/databuilder/databuilder/utils/publisher_utils.py
+++ b/databuilder/databuilder/utils/publisher_utils.py
@@ -5,7 +5,7 @@ import logging
 from os import listdir
 from os.path import isfile, join
 from typing import (
-    Iterator, List, Set,
+    Iterator, List, Optional, Set,
 )
 
 import pandas
@@ -82,7 +82,7 @@ def create_props_param(record_dict: dict, additional_publisher_metadata_fields: 
 
 def execute_neo4j_statement(tx: Transaction,
                             stmt: str,
-                            params: dict = None) -> None:
+                            params: Optional[dict] = None) -> None:
     """
     Executes statement against Neo4j. If execution fails, it rollsback and raises exception.
     """

--- a/databuilder/setup.cfg
+++ b/databuilder/setup.cfg
@@ -40,7 +40,7 @@ output = build/coverage.xml
 directory = build/coverage_html
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 exclude = example

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -69,7 +69,7 @@ neptune = [
 ]
 
 feast = [
-    'feast==0.17.0',
+    'feast==0.34.1',
     'fastapi!=0.76.*'
 ]
 

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -17,7 +17,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 with open(requirements_path, 'r') as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-kafka = ['confluent-kafka==1.5.0']
+kafka = ['confluent-kafka==2.3.0']
 
 cassandra = ['cassandra-driver==3.20.1']
 

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.4.6'
+__version__ = '8.0.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')
@@ -114,7 +114,7 @@ setup(
     include_package_data=True,
     dependency_links=[],
     install_requires=requirements,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     extras_require={
         'all': all_deps,
         'dev': requirements_dev,
@@ -139,6 +139,8 @@ setup(
         'schema_registry': schema_registry,
     },
     classifiers=[
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -17,7 +17,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 with open(requirements_path, 'r') as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-kafka = ['confluent-kafka==1.0.0']
+kafka = ['confluent-kafka==1.5.0']
 
 cassandra = ['cassandra-driver==3.20.1']
 
@@ -63,7 +63,7 @@ neptune = [
     'Flask==1.0.2',
     'gremlinpython==3.4.3',
     'requests-aws4auth==1.1.0',
-    'typing-extensions==4.0.0',
+    'typing-extensions==4.1.0',
     'overrides==2.5',
     'boto3==1.17.23'
 ]

--- a/databuilder/tests/unit/rest_api/test_query_merger.py
+++ b/databuilder/tests/unit/rest_api/test_query_merger.py
@@ -49,7 +49,7 @@ class TestQueryMerger(unittest.TestCase):
                 results[1],
             )
 
-    def test_exception_rasied_with_duplicate_merge_key(self) -> None:
+    def test_exception_raised_with_duplicate_merge_key(self) -> None:
         """
          Two records in query_to_merge results have {'dashboard_id': 'd2'},
          exception should be raised
@@ -70,7 +70,7 @@ class TestQueryMerger(unittest.TestCase):
             query = RestApiQuery(query_to_join=self.query_to_join, url=self.url, params={},
                                  json_path=self.json_path, field_names=self.field_names,
                                  query_merger=query_merger)
-            self.assertRaises(Exception, query.execute())
+            self.assertRaises(Exception, query.execute())  # type: ignore
 
     def test_exception_raised_with_missing_merge_key(self) -> None:
         """
@@ -92,7 +92,7 @@ class TestQueryMerger(unittest.TestCase):
             query = RestApiQuery(query_to_join=self.query_to_join, url=self.url, params={},
                                  json_path=self.json_path, field_names=self.field_names,
                                  query_merger=query_merger)
-            self.assertRaises(Exception, query.execute())
+            self.assertRaises(Exception, query.execute())  # type: ignore
 
 
 if __name__ == '__main__':

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ The frontend service leverages a separate [search service](./../search) for allo
 For information about Amundsen and our other services, refer to this [README.md](https://github.com/amundsen-io/amundsen). Please also see our instructions for a [quick start](https://www.amundsen.io/amundsen/installation/) setup  of Amundsen with dummy data, and an [overview of the architecture](https://www.amundsen.io/amundsen/architecture/).
 
 ## Requirements
-- Python >= 3.6
+- Python >= 3.8
 - Node = v12
 - npm >= 6.x.x
 

--- a/frontend/amundsen_application/__init__.py
+++ b/frontend/amundsen_application/__init__.py
@@ -10,6 +10,7 @@ import sys
 
 from flask import Blueprint, Flask
 from flask_restful import Api
+from typing import Optional
 
 from amundsen_application.api import init_routes
 from amundsen_application.api.announcements.v0 import announcements_blueprint
@@ -48,7 +49,7 @@ STATIC_ROOT = os.getenv('STATIC_ROOT', 'static')
 static_dir = os.path.join(PROJECT_ROOT, STATIC_ROOT)
 
 
-def create_app(config_module_class: str = None, template_folder: str = None) -> Flask:
+def create_app(config_module_class: Optional[str] = None, template_folder: Optional[str] = None) -> Flask:
     """ Support for importing arguments for a subclass of flask.Flask """
     args = ast.literal_eval(FLASK_APP_KWARGS_DICT_STR) if FLASK_APP_KWARGS_DICT_STR else {}
 

--- a/frontend/amundsen_application/api/metadata/v0.py
+++ b/frontend/amundsen_application/api/metadata/v0.py
@@ -162,7 +162,7 @@ def _get_table_metadata(*, table_key: str, index: int, source: str) -> Dict[str,
         # envoy client BadResponse is a subclass of ValueError
         message = 'Encountered exception: ' + str(e)
         results_dict['msg'] = message
-        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)
+        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
         logging.exception(message)
         return results_dict
 
@@ -189,7 +189,7 @@ def _get_table_metadata(*, table_key: str, index: int, source: str) -> Dict[str,
         results_dict['msg'] = message
         logging.exception(message)
         # explicitly raise the exception which will trigger 500 api response
-        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)
+        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
         return results_dict
 
 
@@ -833,7 +833,7 @@ def _get_related_dashboards_metadata(*, url: str) -> Dict[str, Any]:
         # envoy client BadResponse is a subclass of ValueError
         message = 'Encountered exception: ' + str(e)
         results_dict['msg'] = message
-        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)
+        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
         logging.exception(message)
         return results_dict
 
@@ -858,7 +858,7 @@ def _get_related_dashboards_metadata(*, url: str) -> Dict[str, Any]:
         results_dict['msg'] = message
         logging.exception(message)
         # explicitly raise the exception which will trigger 500 api response
-        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)
+        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
         return results_dict
 
 
@@ -1143,7 +1143,7 @@ def _get_feature_metadata(*, feature_key: str, index: int, source: str) -> Dict[
         # envoy client BadResponse is a subclass of ValueError
         message = 'Encountered exception: ' + str(e)
         results_dict['msg'] = message
-        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)
+        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
         logging.exception(message)
         return results_dict
 
@@ -1169,5 +1169,5 @@ def _get_feature_metadata(*, feature_key: str, index: int, source: str) -> Dict[
         results_dict['msg'] = message
         logging.exception(message)
         # explicitly raise the exception which will trigger 500 api response
-        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)
+        results_dict['status_code'] = getattr(e, 'code', HTTPStatus.INTERNAL_SERVER_ERROR)  # type: ignore
         return results_dict

--- a/frontend/amundsen_application/api/utils/metadata_utils.py
+++ b/frontend/amundsen_application/api/utils/metadata_utils.py
@@ -203,7 +203,7 @@ def marshall_lineage_table(table_dict: Dict) -> Dict:
     return table_dict
 
 
-def _convert_prog_descriptions(prog_descriptions: List = None) -> Dict:
+def _convert_prog_descriptions(prog_descriptions: Optional[List] = None) -> Dict:
     """
     Apply the PROGRAMMATIC_DISPLAY configuration to convert to the structure.
     :param prog_descriptions: A list of objects representing programmatic descriptions

--- a/frontend/amundsen_application/api/utils/request_utils.py
+++ b/frontend/amundsen_application/api/utils/request_utils.py
@@ -1,13 +1,13 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict
+from typing import Dict, Optional
 
 import requests
 from flask import current_app as app
 
 
-def get_query_param(args: Dict, param: str, error_msg: str = None) -> str:
+def get_query_param(args: Dict, param: str, error_msg: Optional[str] = None) -> str:
     value = args.get(param)
     if value is None:
         msg = 'A {0} parameter must be provided'.format(param) if error_msg is None else error_msg

--- a/frontend/amundsen_application/base/base_preview_client.py
+++ b/frontend/amundsen_application/base/base_preview_client.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-from typing import Dict
+from typing import Dict, Optional
 
 from flask import Response
 
@@ -13,7 +13,7 @@ class BasePreviewClient(abc.ABC):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def get_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> Response:
+    def get_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> Response:
         """
         Returns a Response object, where the response data represents a json object
         with the preview data accessible on 'preview_data' key. The preview data should
@@ -22,7 +22,7 @@ class BasePreviewClient(abc.ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def get_feature_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> Response:
+    def get_feature_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> Response:
         """
         Returns a Response object, where the response data represents a json object
         with the preview data accessible on 'preview_data' key. The preview data should

--- a/frontend/amundsen_application/base/base_redash_preview_client.py
+++ b/frontend/amundsen_application/base/base_redash_preview_client.py
@@ -234,7 +234,7 @@ class BaseRedashPreviewClient(BasePreviewClient):
         resp = r.get(results_url, headers=self.headers)
         return resp.json()
 
-    def get_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> FlaskResponse:
+    def get_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> FlaskResponse:
         """
         Returns a FlaskResponse object, where the response data represents a json object
         with the preview data accessible on 'preview_data' key. The preview data should
@@ -270,5 +270,5 @@ class BaseRedashPreviewClient(BasePreviewClient):
             LOGGER.error('ERROR getting Redash preview: %s', e)
             return make_response(jsonify({'preview_data': {}}), HTTPStatus.INTERNAL_SERVER_ERROR)
 
-    def get_feature_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> FlaskResponse:
+    def get_feature_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> FlaskResponse:
         pass

--- a/frontend/amundsen_application/base/base_s3_preview_client.py
+++ b/frontend/amundsen_application/base/base_s3_preview_client.py
@@ -4,7 +4,7 @@
 import abc
 import logging
 from http import HTTPStatus
-from typing import Dict
+from typing import Dict, Optional
 
 from amundsen_application.base.base_preview_client import BasePreviewClient
 from amundsen_application.models.preview_data import (PreviewData,
@@ -25,7 +25,7 @@ class BaseS3PreviewClient(BasePreviewClient):
         """
         pass  # pragma: no cover
 
-    def get_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> FlaskResponse:
+    def get_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> FlaskResponse:
         try:
             preview_data = self.get_s3_preview_data(params=params)
             try:
@@ -40,7 +40,7 @@ class BaseS3PreviewClient(BasePreviewClient):
             logging.error("error getting s3 preview data " + str(err))
             return make_response(jsonify({'preview_data': {}}), HTTPStatus.INTERNAL_SERVER_ERROR)
 
-    def get_feature_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> FlaskResponse:
+    def get_feature_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> FlaskResponse:
         """
         BaseS3PreviewClient only supports data preview currently but this function needs to be stubbed to
         implement the BasePreviewClient interface

--- a/frontend/amundsen_application/base/base_superset_preview_client.py
+++ b/frontend/amundsen_application/base/base_superset_preview_client.py
@@ -8,7 +8,7 @@ from flask import Response as FlaskResponse, make_response, jsonify
 from http import HTTPStatus
 from marshmallow import ValidationError
 from requests import Response
-from typing import Dict
+from typing import Dict, Optional
 
 from amundsen_application.base.base_preview_client import BasePreviewClient
 from amundsen_application.models.preview_data import ColumnItem, PreviewData, PreviewDataSchema
@@ -26,7 +26,7 @@ class BaseSupersetPreviewClient(BasePreviewClient):
         """
         pass  # pragma: no cover
 
-    def get_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> FlaskResponse:
+    def get_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> FlaskResponse:
         """
         Returns a FlaskResponse object, where the response data represents a json object
         with the preview data accessible on 'preview_data' key. The preview data should
@@ -58,5 +58,5 @@ class BaseSupersetPreviewClient(BasePreviewClient):
         except Exception:
             return make_response(jsonify({'preview_data': {}}), HTTPStatus.INTERNAL_SERVER_ERROR)
 
-    def get_feature_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> FlaskResponse:
+    def get_feature_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> FlaskResponse:
         pass

--- a/frontend/amundsen_application/base/examples/example_dremio_preview_client.py
+++ b/frontend/amundsen_application/base/examples/example_dremio_preview_client.py
@@ -3,7 +3,7 @@
 
 from http import HTTPStatus
 import logging
-from typing import Dict  # noqa: F401
+from typing import Dict, Optional  # noqa: F401
 
 from flask import Response, jsonify, make_response, current_app as app
 from marshmallow import ValidationError
@@ -50,7 +50,7 @@ class DremioPreviewClient(BasePreviewClient):
             with open(tls_root_certs_path, "rb") as f:
                 self.connection_args["tls_root_certs"] = f.read()
 
-    def get_preview_data(self, params: Dict, optionalHeaders: Dict = None) -> Response:
+    def get_preview_data(self, params: Dict, optionalHeaders: Optional[Dict] = None) -> Response:
         """Preview data from Dremio source
         """
         database = params.get('database')

--- a/frontend/amundsen_application/base/examples/example_mail_client.py
+++ b/frontend/amundsen_application/base/examples/example_mail_client.py
@@ -8,7 +8,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from http import HTTPStatus
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from flask import Response, jsonify, make_response
 
@@ -23,9 +23,9 @@ class MailClient(BaseMailClient):
     def send_email(self,
                    html: str,
                    subject: str,
-                   optional_data: Dict = None,
-                   recipients: List[str] = None,
-                   sender: str = None) -> Response:
+                   optional_data: Optional[Dict] = None,
+                   recipients: Optional[List[str]] = None,
+                   sender: Optional[str] = None) -> Response:
         if not sender:
             sender = os.environ.get('AMUNDSEN_EMAIL') or ''  # set me
         if not recipients:

--- a/frontend/amundsen_application/config.py
+++ b/frontend/amundsen_application/config.py
@@ -13,8 +13,8 @@ from amundsen_application.tests.test_utils import get_test_user
 
 class MatchRuleObject:
     def __init__(self,
-                 schema_regex=None,  # type: str
-                 table_name_regex=None,   # type: str
+                 schema_regex: Optional[str] = None,
+                 table_name_regex: Optional[str] = None,
                  ) -> None:
         self.schema_regex = schema_regex
         self.table_name_regex = table_name_regex
@@ -163,7 +163,7 @@ class LocalConfig(Config):
     # If installing using the Docker bootstrap, this should be modified to the docker host ip.
     LOCAL_HOST = '0.0.0.0'
 
-    JS_CONFIG_OVERRIDE_ENABLED = distutils.util.strtobool(os.environ.get('JS_CONFIG_OVERRIDE_ENABLED', 'False'))
+    JS_CONFIG_OVERRIDE_ENABLED = bool(distutils.util.strtobool(os.environ.get('JS_CONFIG_OVERRIDE_ENABLED', 'False')))
 
     FRONTEND_BASE = os.environ.get('FRONTEND_BASE',
                                    'http://{LOCAL_HOST}:{PORT}'.format(

--- a/frontend/amundsen_application/log/action_log_model.py
+++ b/frontend/amundsen_application/log/action_log_model.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+from typing import Any, Optional
 
 
 class ActionLogParams(object):
@@ -12,13 +12,13 @@ class ActionLogParams(object):
     def __init__(self, *,
                  command: str,
                  start_epoch_ms: int,
-                 end_epoch_ms: int = None,
+                 end_epoch_ms: Optional[int] = None,
                  user: str,
                  host_name: str,
                  pos_args_json: str,
                  keyword_args_json: str,
                  output: Any = None,
-                 error: Exception = None) -> None:
+                 error: Optional[Exception] = None) -> None:
         self.command = command
         self.start_epoch_ms = start_epoch_ms
         self.end_epoch_ms = end_epoch_ms

--- a/frontend/amundsen_application/models/preview_data.py
+++ b/frontend/amundsen_application/models/preview_data.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from marshmallow import Schema, fields, EXCLUDE
-from typing import List
+from typing import List, Optional
 
 
 class ColumnItem:
-    def __init__(self, column_name: str = None, column_type: str = None) -> None:
+    def __init__(self, column_name: Optional[str] = None, column_type: Optional[str] = None) -> None:
         self.column_name = column_name
         self.column_type = column_type
 

--- a/frontend/setup.cfg
+++ b/frontend/setup.cfg
@@ -21,7 +21,7 @@ output = build/coverage.xml
 directory = build/coverage_html
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -45,7 +45,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-__version__ = '4.3.0'
+__version__ = '5.0.0'
 
 jira = ['jira==3.0.1']
 asana = ['asana==0.10.3']
@@ -75,12 +75,14 @@ setup(
         'asana': asana,
         'all': all_deps,
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points="""
         [action_log.post_exec.plugin]
         logging_action_log=amundsen_application.log.action_log_callback:logging_action_log
     """,
     classifiers=[
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -50,9 +50,9 @@ __version__ = '5.0.0'
 jira = ['jira==3.0.1']
 asana = ['asana==0.10.3']
 oidc = ['flaskoidc>=1.0.0']
-pyarrrow = ['pyarrow==3.0.0']
+pyarrow = ['pyarrow==14.0.2']
 bigquery_preview = ['google-cloud-bigquery>=2.13.1,<3.0.0', 'flatten-dict==0.3.0']
-all_deps = requirements + requirements_common + requirements_dev + oidc + pyarrrow + bigquery_preview + jira + asana
+all_deps = requirements + requirements_common + requirements_dev + oidc + pyarrow + bigquery_preview + jira + asana
 
 setup(
     name='amundsen-frontend',
@@ -69,7 +69,7 @@ setup(
     extras_require={
         'oidc': oidc,
         'dev': requirements_dev,
-        'pyarrow': pyarrrow,
+        'pyarrow': pyarrow,
         'bigquery_preview': bigquery_preview,
         'jira': jira,
         'asana': asana,

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -45,7 +45,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-__version__ = '4.2.1'
+__version__ = '4.3.0'
 
 jira = ['jira==3.0.1']
 asana = ['asana==0.10.3']

--- a/frontend/tests/unit/api/issue/test_issue.py
+++ b/frontend/tests/unit/api/issue/test_issue.py
@@ -285,8 +285,8 @@ class IssueTest(unittest.TestCase):
 
         with local_app.test_client() as test:
             response = test.post('/api/issue/issue',
-                                 content_type='multipart/form-data',
-                                 data={
+                                 content_type='application/json',
+                                 json={
                                      'description': 'test description',
                                      'owner_ids': ['user1@email.com', 'user2@email.com'],
                                      'frequent_user_ids': ['user1@email.com', 'user2@email.com'],

--- a/frontend/tests/unit/api/preview/dashboard/test_v0.py
+++ b/frontend/tests/unit/api/preview/dashboard/test_v0.py
@@ -65,4 +65,4 @@ class TestV0(unittest.TestCase):
 
 class DummyPreviewMethodFactory(BasePreviewMethodFactory):
     def get_instance(self, *, uri: str) -> BasePreview:
-        pass
+        return MagicMock()

--- a/frontend/tests/unit/api/preview/test_v0.py
+++ b/frontend/tests/unit/api/preview/test_v0.py
@@ -51,7 +51,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/')
+            post_response = test.post('/api/preview/v0/', json={})
             self.assertEqual(post_response.status_code, HTTPStatus.OK)
             self.assertEqual(post_response.json, expected_response_json)
 
@@ -69,7 +69,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/')
+            post_response = test.post('/api/preview/v0/', json={})
             self.assertEqual(post_response.status_code,
                              HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertEqual(post_response.json, expected_response_json)
@@ -90,7 +90,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/feature_preview')
+            post_response = test.post('/api/preview/v0/feature_preview', json={})
             self.assertEqual(post_response.status_code, HTTPStatus.OK)
             self.assertEqual(post_response.json, expected_response_json)
 
@@ -108,7 +108,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/feature_preview')
+            post_response = test.post('/api/preview/v0/feature_preview', json={})
             self.assertEqual(post_response.status_code,
                              HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertEqual(post_response.json, expected_response_json)

--- a/frontend/tests/unit/api/quality/test_v0.py
+++ b/frontend/tests/unit/api/quality/test_v0.py
@@ -1,12 +1,12 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import abstractmethod
 from amundsen_application.base.base_quality_client import BaseQualityClient
 from amundsen_application.api.quality import v0
 from amundsen_application import create_app
 from flask import Response
 from http import HTTPStatus
+from unittest.mock import MagicMock
 import unittest
 import json
 
@@ -18,13 +18,11 @@ class DummyQualityClient(BaseQualityClient):
     Dummy concrete class that can be instantiated.
     """
 
-    @abstractmethod
     def get_table_quality_checks_summary(self, *, table_key: str) -> Response:
-        pass
+        return MagicMock()
 
-    @abstractmethod
     def get_table_quality_checks(self, *, table_key: str) -> bytes:
-        pass
+        return MagicMock()
 
 
 quality_client_class_name = "tests.unit.api.quality.test_v0.DummyQualityClient"

--- a/frontend/tests/unit/api/quality/test_v0.py
+++ b/frontend/tests/unit/api/quality/test_v0.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from abc import abstractmethod
 from amundsen_application.base.base_quality_client import BaseQualityClient
 from amundsen_application.api.quality import v0
 from amundsen_application import create_app
@@ -17,9 +18,11 @@ class DummyQualityClient(BaseQualityClient):
     Dummy concrete class that can be instantiated.
     """
 
+    @abstractmethod
     def get_table_quality_checks_summary(self, *, table_key: str) -> Response:
         pass
 
+    @abstractmethod
     def get_table_quality_checks(self, *, table_key: str) -> bytes:
         pass
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -11,7 +11,7 @@ Amundsen Metadata service serves Restful API and is responsible for providing an
 For information about Amundsen and our other services, refer to this [README.md](./../README.md). Please also see our instructions for a [quick start](./../docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](./../docs/architecture.md#architecture).
 
 ## Requirements
-- Python >= 3.7
+- Python >= 3.8
 
 ## Doc
 - https://www.amundsen.io/amundsen/

--- a/metadata/setup.cfg
+++ b/metadata/setup.cfg
@@ -32,7 +32,7 @@ exclude_lines =
     import *
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.12.3'
+__version__ = '3.13.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.13.0'
+__version__ = '4.0.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:
@@ -49,8 +49,10 @@ setup(
         'rds': rds,
         'gremlin': gremlin
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -11,7 +11,7 @@ boto3==1.17.23
 click==8.1.7
 flasgger==0.9.5
 Flask==2.2.5
-Flask-RESTful>=0.3.6
+Flask-RESTful>=0.3.9
 flask-cors==3.0.10
 itsdangerous==2.1.2
 Jinja2==3.1.2

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -4,17 +4,17 @@
 # Common dependencies (common, frontend, metadata, search) -------------------------------------------------------------
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
-# on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
+# on all repositories relying on this file and any issues that arise from common upgrade might be missed.
 amundsen-common>=0.27.0
 attrs>=19.1.0
 boto3==1.17.23
-click==7.0
+click==8.1.7
 flasgger==0.9.5
-Flask==1.0.2
+Flask==2.2.5
 Flask-RESTful>=0.3.6
 flask-cors==3.0.10
-itsdangerous<=2.0.1
-Jinja2>=2.10.1,<3.1
+itsdangerous==2.1.2
+Jinja2==3.1.2
 jsonschema>=3.0.1,<4.0
 marshmallow>=3.0,<=3.6
 marshmallow3-annotations>=1.1.0
@@ -23,5 +23,5 @@ requests>=2.25.0
 requests-aws4auth==1.1.0
 statsd==3.2.1
 typing==3.6.4
-werkzeug==2.0.3
+werkzeug==3.0.1
 wheel==0.38.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,10 +7,9 @@ flake8>=3.9.2
 flake8-tidy-imports>=4.3.0
 isort[colors]~=5.8.0
 mock>=4.0.3
-mypy>=0.812,<0.900
+mypy>=1.5.1
 pytest>=6.2.4
 pytest-cov>=2.12.0
 pytest-env>=0.6.2
 pytest-mock>=3.6.1
-typed-ast>=1.4.3
 pyspark==3.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,9 @@ pytest-cov>=2.12.0
 pytest-env>=0.6.2
 pytest-mock>=3.6.1
 pyspark==3.0.1
+types-mock>=5.1.0.3
+types-protobuf>=4.24.0.4
+types-python-dateutil>=2.8.19.14
+types-pytz>=2023.3.1.1
+types-requests<2.31.0.7
+types-setuptools>=69.0.0.0

--- a/search/README.md
+++ b/search/README.md
@@ -19,7 +19,7 @@ For information about Amundsen and our other services, refer to this [README.md]
 
 ## Requirements
 
-- Python >= 3.7
+- Python >= 3.8
 - Elasticsearch, supported versions:
     - 7.x
     - 8.0.0

--- a/search/search_service/config.py
+++ b/search/search_service/config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from typing import Any, Optional
 
 STATS_FEATURE_KEY = 'STATS'
 
@@ -51,7 +52,7 @@ class LocalConfig(Config):
                                         PORT=PROXY_PORT)
                                     )
     ES_PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('ES_PROXY_CLIENT', 'ELASTICSEARCH_V2_1')]
-    ELASTICSEARCH_CLIENT = os.environ.get('ELASTICSEARCH_CLIENT')   # type: Optional[Any]
+    ELASTICSEARCH_CLIENT: Optional[Any] = os.environ.get('ELASTICSEARCH_CLIENT')
     PROXY_USER = os.environ.get('CREDENTIALS_PROXY_USER', 'elastic')
     PROXY_PASSWORD = os.environ.get('CREDENTIALS_PROXY_PASSWORD', 'elastic')
 

--- a/search/search_service/config.py
+++ b/search/search_service/config.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any, Optional
 
 STATS_FEATURE_KEY = 'STATS'
 

--- a/search/search_service/proxy/base.py
+++ b/search/search_service/proxy/base.py
@@ -3,7 +3,7 @@
 
 from abc import ABCMeta, abstractmethod
 from typing import (
-    Any, Dict, List, Union,
+    Any, Dict, List, Optional, Union,
 )
 
 from amundsen_common.models.api.health_check import HealthCheck
@@ -91,7 +91,7 @@ class BaseProxy(metaclass=ABCMeta):
                                resource_key: str,
                                resource_type: Resource,
                                field: str,
-                               value: str = None,
+                               value: Optional[str] = None,
                                operation: str = 'add') -> str:
         pass
 
@@ -100,7 +100,7 @@ class BaseProxy(metaclass=ABCMeta):
                                resource_key: str,
                                resource_type: Resource,
                                field: str,
-                               value: str = None) -> str:
+                               value: Optional[str] = None) -> str:
         pass
 
     @abstractmethod

--- a/search/search_service/proxy/elasticsearch.py
+++ b/search/search_service/proxy/elasticsearch.py
@@ -4,7 +4,7 @@
 import logging
 import uuid
 from typing import (
-    Any, Dict, List, Union,
+    Any, Dict, List, Optional, Union,
 )
 
 from amundsen_common.models.api import health_check
@@ -96,10 +96,10 @@ class ElasticsearchProxy(BaseProxy):
     ESCAPE_CHARS = str.maketrans({':': r'\:', '/': r'\/'})
 
     def __init__(self, *,
-                 host: str = None,
+                 host: Optional[str] = None,
                  user: str = '',
                  password: str = '',
-                 client: Elasticsearch = None,
+                 client: Optional[Elasticsearch] = None,
                  page_size: int = 10
                  ) -> None:
         """
@@ -827,7 +827,7 @@ class ElasticsearchProxy(BaseProxy):
                                resource_key: str,
                                resource_type: Resource,
                                field: str,
-                               value: str = None,
+                               value: Optional[str] = None,
                                operation: str = 'add') -> str:
         LOGGING.warn(DEPRECATION_MSG)
         return ''
@@ -836,6 +836,6 @@ class ElasticsearchProxy(BaseProxy):
                                resource_key: str,
                                resource_type: Resource,
                                field: str,
-                               value: str = None) -> str:
+                               value: Optional[str] = None) -> str:
         LOGGING.warn(DEPRECATION_MSG)
         return ''

--- a/search/search_service/proxy/es_proxy_v2.py
+++ b/search/search_service/proxy/es_proxy_v2.py
@@ -4,7 +4,7 @@
 import json
 import logging
 from typing import (
-    Any, Dict, List, Union,
+    Any, Dict, List, Optional, Union,
 )
 
 from amundsen_common.models.api import health_check
@@ -127,10 +127,10 @@ class ElasticsearchProxyV2():
                         'email^3']
 
     def __init__(self, *,
-                 host: str = None,
+                 host: Optional[str] = None,
                  user: str = '',
                  password: str = '',
-                 client: Elasticsearch = None,
+                 client: Optional[Elasticsearch] = None,
                  page_size: int = 10) -> None:
         if client:
             self.elasticsearch = client
@@ -348,7 +348,7 @@ class ElasticsearchProxyV2():
                                resource_key: str,
                                resource_type: Resource,
                                field: str,
-                               value: str = None,
+                               value: Optional[str] = None,
                                operation: str = 'add') -> str:
 
         mapped_field = self.RESOURCE_TO_MAPPING[resource_type].get(field)
@@ -398,7 +398,7 @@ class ElasticsearchProxyV2():
                                resource_key: str,
                                resource_type: Resource,
                                field: str,
-                               value: str = None) -> str:
+                               value: Optional[str] = None) -> str:
         mapped_field = self.RESOURCE_TO_MAPPING[resource_type].get(field)
         if not mapped_field:
             mapped_field = field

--- a/search/setup.cfg
+++ b/search/setup.cfg
@@ -32,7 +32,7 @@ exclude_lines =
     import *
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '4.2.0'
+__version__ = '5.0.0'
 
 oidc = ['flaskoidc>=1.0.0']
 
@@ -40,5 +40,10 @@ setup(
         'dev': requirements_dev,
         'oidc': oidc
     },
-    python_requires=">=3.7"
+    python_requires=">=3.8",
+    classifiers=[
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
 )

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '4.1.4'
+__version__ = '4.2.0'
 
 oidc = ['flaskoidc>=1.0.0']
 

--- a/search/tests/unit/api/dashboard/test_search_dashboard_api.py
+++ b/search/tests/unit/api/dashboard/test_search_dashboard_api.py
@@ -28,7 +28,7 @@ class TestSearchDashboardAPI(TestCase):
         result = mock_proxy_results()
         self.mock_proxy.fetch_dashboard_search_results.return_value = SearchResult(total_results=1, results=[result])
 
-        response = self.app.test_client().get('/search_dashboard?query_term=searchterm')
+        response = self.app.test_client().get('/search_dashboard?query_term=searchterm', json={})
         expected_response = {
             "total_results": 1,
             "results": [mock_json_response()]
@@ -43,7 +43,7 @@ class TestSearchDashboardAPI(TestCase):
         self.mock_proxy.fetch_dashboard_search_results.return_value = \
             SearchResult(total_results=0, results=[])
 
-        response = self.app.test_client().get('/search_dashboard?query_term=searchterm')
+        response = self.app.test_client().get('/search_dashboard?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 0,
@@ -52,13 +52,13 @@ class TestSearchDashboardAPI(TestCase):
         self.assertEqual(response.json, expected_response)
 
     def test_should_fail_without_query_term(self) -> None:
-        response = self.app.test_client().get('/search_dashboard')
+        response = self.app.test_client().get('/search_dashboard', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_should_fail_when_proxy_fails(self) -> None:
         self.mock_proxy.fetch_dashboard_search_results.side_effect = RuntimeError('search failed')
 
-        response = self.app.test_client().get('/search_dashboard?query_term=searchterm')
+        response = self.app.test_client().get('/search_dashboard?query_term=searchterm', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/search/tests/unit/api/feature/test_search_feature_api.py
+++ b/search/tests/unit/api/feature/test_search_feature_api.py
@@ -31,7 +31,7 @@ class TestSearchFeatureAPI(TestCase):
         self.mock_proxy.fetch_feature_search_results.return_value = \
             SearchFeatureResult(total_results=1, results=[result])
 
-        response = self.app.test_client().get('/search_feature?query_term=searchterm')
+        response = self.app.test_client().get('/search_feature?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 1,
@@ -47,7 +47,7 @@ class TestSearchFeatureAPI(TestCase):
         self.mock_proxy.fetch_feature_search_results.return_value = \
             SearchFeatureResult(total_results=0, results=[])
 
-        response = self.app.test_client().get('/search_feature?query_term=searchterm')
+        response = self.app.test_client().get('/search_feature?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 0,
@@ -56,11 +56,11 @@ class TestSearchFeatureAPI(TestCase):
         self.assertEqual(response.json, expected_response)
 
     def test_should_fail_without_query_term(self) -> None:
-        response = self.app.test_client().get('/search_feature')
+        response = self.app.test_client().get('/search_feature', json={})
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_should_fail_when_proxy_fails(self) -> None:
         self.mock_proxy.fetch_feature_search_results.side_effect = RuntimeError('search failed')
 
-        response = self.app.test_client().get('/search_feature?query_term=searchterm')
+        response = self.app.test_client().get('/search_feature?query_term=searchterm', json={})
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/search/tests/unit/api/table/test_search_table_api.py
+++ b/search/tests/unit/api/table/test_search_table_api.py
@@ -31,7 +31,7 @@ class TestSearchTableAPI(TestCase):
         result = mock_proxy_results()
         self.mock_proxy.fetch_table_search_results.return_value = SearchTableResult(total_results=1, results=[result])
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 1,
@@ -47,7 +47,7 @@ class TestSearchTableAPI(TestCase):
         self.mock_proxy.fetch_table_search_results.return_value = \
             SearchTableResult(total_results=0, results=[])
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 0,
@@ -60,7 +60,7 @@ class TestSearchTableAPI(TestCase):
             SearchTableResult(total_results=1,
                               results=[mock_default_proxy_results()])
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 1,
@@ -70,13 +70,13 @@ class TestSearchTableAPI(TestCase):
         self.assertEqual(response.json, expected_response)
 
     def test_should_fail_without_query_term(self) -> None:
-        response = self.app.test_client().get('/search')
+        response = self.app.test_client().get('/search', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_should_fail_when_proxy_fails(self) -> None:
         self.mock_proxy.fetch_table_search_results.side_effect = RuntimeError('search failed')
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/search/tests/unit/proxy/test_elasticsearch.py
+++ b/search/tests/unit/proxy/test_elasticsearch.py
@@ -5,7 +5,6 @@ import unittest
 from typing import (  # noqa: F401
     Any, Iterable, List,
 )
-from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from amundsen_common.models.api import health_check


### PR DESCRIPTION
## Description
This change upgrades flask to version 2.2.5 and upgrades its related dependencies. The newer version of werkzeug was not compatible with python 3.7, so also removing support for that here since it is no longer widely supported anyway.
- Upgrading flask to 2.2.5
- werkzeug was subsequently upgraded to 3.0.1, which is not compatible with py37 so removing py37 support
- With removal of py37, needed to upgrade mypy, leading to various mypy fixes

## Motivation and Context
We are going to be upgrading our services to py3.10 soon, and we ran into some issues with the older version of flask. This change will also help resolve some security vulnerabilities for the project and remove outdated support.

## How Has This Been Tested?
I installed the requirements files locally and ran our 3 services (frontend, search, and metadata) to make sure the build worked and to test them manually.

### Documentation
N/A

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
