### PR TITLE
chore: Remove py37 support, and unify compatibility matrix from 3.8-3.9

### DIFF
--- a/.github/workflows/common_pull_request.yml
+++ b/.github/workflows/common_pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/common_pull_request.yml
+++ b/.github/workflows/common_pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.8.x', '3.9.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/databuilder_pull_request.yml
+++ b/.github/workflows/databuilder_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/databuilder_pull_request.yml
+++ b/.github/workflows/databuilder_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.8.x', '3.9.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup python 3.7
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/.github/workflows/frontend_pull_request.yml
+++ b/.github/workflows/frontend_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x", "3.8.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/frontend_pull_request.yml
+++ b/.github/workflows/frontend_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.8.x', '3.9.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/metadata_pull_request.yml
+++ b/.github/workflows/metadata_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/metadata_pull_request.yml
+++ b/.github/workflows/metadata_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.8.x', '3.9.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Checkout master
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/noop_pull_request.yml
+++ b/.github/workflows/noop_pull_request.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6.x", "3.7.x", "3.8.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Do nothing
         run: exit 0

--- a/.github/workflows/noop_pull_request.yml
+++ b/.github/workflows/noop_pull_request.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.8.x', '3.9.x']
     steps:
       - name: Do nothing
         run: exit 0

--- a/.github/workflows/search_pull_request.yml
+++ b/.github/workflows/search_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7.x"]
+        python-version: ['3.8.x', '3.9.x', '3.10.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/search_pull_request.yml
+++ b/.github/workflows/search_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.8.x', '3.9.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/Dockerfile.frontend.local
+++ b/Dockerfile.frontend.local
@@ -14,7 +14,7 @@ RUN npm run dev-build
 
 COPY ./frontend /app
 
-FROM python:3.7-slim
+FROM python:3.8-slim
 WORKDIR /app
 
 COPY ./frontend /app

--- a/Dockerfile.frontend.public
+++ b/Dockerfile.frontend.public
@@ -8,7 +8,7 @@ RUN npm install
 COPY ./frontend/amundsen_application/static /app/amundsen_application/static
 RUN npm run build
 
-FROM python:3.7-slim as base
+FROM python:3.8-slim as base
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/Dockerfile.metadata.public
+++ b/Dockerfile.metadata.public
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.8-slim as base
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/Dockerfile.search.public
+++ b/Dockerfile.search.public
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 WORKDIR /app
 RUN pip3 install gunicorn
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We want your input about what is important, for that, add your votes using the ð
 * [Top Questions](https://github.com/amundsen-io/amundsen/issues?q=is%3Aissue+is%3Aclosed+sort%3Areactions-%2B1-desc+label%3Atype%3Aquestion+label%3Astatus%3Aneeds_votes)
 
 ## Requirements
-- Python 3.7
+- Python >= 3.8
 - Node v12
 
 ## User Interface

--- a/common/README.md
+++ b/common/README.md
@@ -8,7 +8,7 @@ Amundsen Common library holds common codes among micro services in Amundsen.
 For information about Amundsen and our other services, visit the [main repository](https://github.com/amundsen-io/amundsen). Please also see our instructions for a [quick start](https://github.com/amundsen-io/amundsen/blob/master/docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](https://github.com/amundsen-io/amundsen/blob/master/docs/architecture.md#architecture).
 
 ## Requirements
-- Python >= 3.6
+- Python >= 3.8
 
 ## Doc
 - https://www.amundsen.io/amundsen/

--- a/common/amundsen_common/log/action_log_callback.py
+++ b/common/amundsen_common/log/action_log_callback.py
@@ -16,8 +16,8 @@ from amundsen_common.log.action_log_model import ActionLogParams
 
 LOGGER = logging.getLogger(__name__)
 
-__pre_exec_callbacks = []  # type: List[Callable[..., Any]]
-__post_exec_callbacks = []  # type: List[Callable[..., Any]]
+__pre_exec_callbacks: List[Callable[..., Any]] = []
+__post_exec_callbacks: List[Callable[..., Any]] = []
 
 
 def register_pre_exec_callback(action_log_callback: Callable[..., Any]) -> None:

--- a/common/setup.py
+++ b/common/setup.py
@@ -51,6 +51,5 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/common/setup.py
+++ b/common/setup.py
@@ -46,6 +46,11 @@ setup(
     extras_require={
         'all': requirements_dev
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     package_data={'amundsen_common': ['py.typed']},
+    classifiers=[
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
 )

--- a/databuilder/README.md
+++ b/databuilder/README.md
@@ -11,7 +11,7 @@ Amundsen Databuilder is a data ingestion library, which is inspired by [Apache G
 For information about Amundsen and our other services, visit the [main repository](https://github.com/amundsen-io/amundsen#amundsen) `README.md` . Please also see our instructions for a [quick start](https://github.com/amundsen-io/amundsen/blob/master/docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](https://github.com/amundsen-io/amundsen/blob/master/docs/architecture.md#architecture).
 
 ## Requirements
-- Python >= 3.6.x
+- Python >= 3.8.x
 - elasticsearch 7.x
 
 ## Doc

--- a/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
+++ b/databuilder/databuilder/extractor/delta_lake_metadata_extractor.py
@@ -503,8 +503,8 @@ class DeltaLakeMetadataExtractor(Extractor):
             _table_columns = table.columns
         else:
             _table_columns = []
-        columns_with_valid_type = list(map(lambda l: l.name,
-                                           filter(lambda l: str(l.data_type).lower() in valid_types, _table_columns)
+        columns_with_valid_type = list(map(lambda n: n.name,
+                                           filter(lambda d: str(d.data_type).lower() in valid_types, _table_columns)
                                            )
                                        )
 

--- a/databuilder/setup.cfg
+++ b/databuilder/setup.cfg
@@ -40,7 +40,7 @@ output = build/coverage.xml
 directory = build/coverage_html
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 exclude = example

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -17,7 +17,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 with open(requirements_path, 'r') as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-kafka = ['confluent-kafka==1.0.0']
+kafka = ['confluent-kafka==1.5.0']
 
 cassandra = ['cassandra-driver==3.20.1']
 
@@ -141,6 +141,5 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -69,7 +69,7 @@ neptune = [
 ]
 
 feast = [
-    'feast==0.17.0',
+    'feast==0.34.1',
     'fastapi!=0.76.*'
 ]
 

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -17,7 +17,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 with open(requirements_path, 'r') as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-kafka = ['confluent-kafka==1.5.0']
+kafka = ['confluent-kafka==2.3.0']
 
 cassandra = ['cassandra-driver==3.20.1']
 

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -69,8 +69,9 @@ neptune = [
 ]
 
 feast = [
-    'feast==0.34.1',
-    'fastapi!=0.76.*'
+    'feast==0.17.0',
+    'fastapi!=0.76.*',
+    'protobuf<=3.20.1'
 ]
 
 atlas = [

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -114,7 +114,7 @@ setup(
     include_package_data=True,
     dependency_links=[],
     install_requires=requirements,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     extras_require={
         'all': all_deps,
         'dev': requirements_dev,
@@ -139,6 +139,8 @@ setup(
         'schema_registry': schema_registry,
     },
     classifiers=[
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ The frontend service leverages a separate [search service](./../search) for allo
 For information about Amundsen and our other services, refer to this [README.md](https://github.com/amundsen-io/amundsen). Please also see our instructions for a [quick start](https://www.amundsen.io/amundsen/installation/) setup  of Amundsen with dummy data, and an [overview of the architecture](https://www.amundsen.io/amundsen/architecture/).
 
 ## Requirements
-- Python >= 3.6
+- Python >= 3.8
 - Node = v12
 - npm >= 6.x.x
 

--- a/frontend/setup.cfg
+++ b/frontend/setup.cfg
@@ -21,7 +21,7 @@ output = build/coverage.xml
 directory = build/coverage_html
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -75,12 +75,14 @@ setup(
         'asana': asana,
         'all': all_deps,
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points="""
         [action_log.post_exec.plugin]
         logging_action_log=amundsen_application.log.action_log_callback:logging_action_log
     """,
     classifiers=[
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -83,6 +83,5 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -11,7 +11,7 @@ Amundsen Metadata service serves Restful API and is responsible for providing an
 For information about Amundsen and our other services, refer to this [README.md](./../README.md). Please also see our instructions for a [quick start](./../docs/installation.md#bootstrap-a-default-version-of-amundsen-using-docker) setup  of Amundsen with dummy data, and an [overview of the architecture](./../docs/architecture.md#architecture).
 
 ## Requirements
-- Python >= 3.7
+- Python >= 3.8
 
 ## Doc
 - https://www.amundsen.io/amundsen/

--- a/metadata/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata/metadata_service/proxy/gremlin_proxy.py
@@ -281,7 +281,7 @@ def _safe_get_list(root, *keys, transform: Optional[Callable] = None):
         raise RuntimeError(f'{values} is not a List!  root={root} keys={keys}')
     elif transform is None:
         return sorted(values)
-    elif len(values) > 0 and type(values[0]) == datetime and transform == int:
+    elif len(values) > 0 and type(values[0]) is datetime and transform == int:
         # need to do something special for datetimes we are transforming into int's
         return sorted([transform(value.timestamp()) for value in values])
     else:

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -436,7 +436,7 @@ class Neo4jProxy(BaseProxy):
 
         resource_reports = self._extract_resource_reports_from_query(table_records.get('resource_reports', []))
 
-        return wmk_results, table_writer, table_apps, timestamp_value,\
+        return wmk_results, table_writer, table_apps, timestamp_value, \
             tags, src, badges, prog_descriptions, resource_reports
 
     @timer_with_counter

--- a/metadata/setup.cfg
+++ b/metadata/setup.cfg
@@ -32,7 +32,7 @@ exclude_lines =
     import *
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -53,6 +53,5 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -49,8 +49,10 @@ setup(
         'rds': rds,
         'gremlin': gremlin
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -1524,7 +1524,7 @@ class TestNeo4jProxy(unittest.TestCase):
             key = "alpha"
             mock_execute.return_value = [{
                 "upstream_entities": [
-                    {"key": "beta", "source": "gold", "level": 1, "badges": [], "usage":100, "parent": None},
+                    {"key": "beta", "source": "gold", "level": 1, "badges": [], "usage": 100, "parent": None},
                     {"key": "gamma", "source": "dyno", "level": 1,
                      "badges":
                         [
@@ -1541,7 +1541,7 @@ class TestNeo4jProxy(unittest.TestCase):
             expected = Lineage(
                 key=key,
                 upstream_entities=[
-                    LineageItem(**{"key": "beta", "source": "gold", "level": 1, "badges": [], "usage":100}),
+                    LineageItem(**{"key": "beta", "source": "gold", "level": 1, "badges": [], "usage": 100}),
                     LineageItem(**{"key": "gamma", "source": "dyno", "level": 1,
                                    "badges":
                                        [

--- a/search/README.md
+++ b/search/README.md
@@ -19,7 +19,7 @@ For information about Amundsen and our other services, refer to this [README.md]
 
 ## Requirements
 
-- Python >= 3.7
+- Python >= 3.8
 - Elasticsearch, supported versions:
     - 7.x
     - 8.0.0

--- a/search/search_service/config.py
+++ b/search/search_service/config.py
@@ -52,7 +52,7 @@ class LocalConfig(Config):
                                         PORT=PROXY_PORT)
                                     )
     ES_PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('ES_PROXY_CLIENT', 'ELASTICSEARCH_V2_1')]
-    ELASTICSEARCH_CLIENT = os.environ.get('ELASTICSEARCH_CLIENT')   # type: Optional[Any]
+    ELASTICSEARCH_CLIENT: Optional[Any] = os.environ.get('ELASTICSEARCH_CLIENT')
     PROXY_USER = os.environ.get('CREDENTIALS_PROXY_USER', 'elastic')
     PROXY_PASSWORD = os.environ.get('CREDENTIALS_PROXY_PASSWORD', 'elastic')
 

--- a/search/setup.cfg
+++ b/search/setup.cfg
@@ -32,7 +32,7 @@ exclude_lines =
     import *
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 disallow_untyped_defs = True
 ignore_missing_imports = True
 strict_optional = True

--- a/search/setup.py
+++ b/search/setup.py
@@ -44,6 +44,5 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/search/setup.py
+++ b/search/setup.py
@@ -40,5 +40,10 @@ setup(
         'dev': requirements_dev,
         'oidc': oidc
     },
-    python_requires=">=3.7"
+    python_requires=">=3.8",
+    classifiers=[
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
 )


### PR DESCRIPTION
## Description
Remove python 3.7 support since it has reached its EOL, and unify the compatibility matrix across services to include 3.8 and 3.9

## Motivation and Context
We are going to be upgrading our services to py3.10 soon, so this is getting the project set up for that. py3.10 won't be added in this PR yet because it appears to require other package upgrades, so keeping the focus on removing py3.7 here. We will need to upgrade flask and werkzeug with our py3.10 upgrade, and werkzeug 3.0.1 does not support py3.7 so that is the main motivation.

## How Has This Been Tested?

### Documentation
Updated all relevant docs that show version requirements

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [X] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
