### PR TITLE
feat: Aggregating Alerts Feature

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -9,9 +9,9 @@ exports[`eslint`] = {
       [71, 6, 118, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3051403928"],
       [71, 6, 118, "Static HTML elements with event handlers require a role.", "3051403928"]
     ],
-    "js/components/EditableText/index.tsx:175217081": [
-      [82, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
-      [100, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/components/EditableText/index.tsx:2590685581": [
+      [83, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
+      [101, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/components/OwnerEditor/index.tsx:2385247435": [
       [85, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
@@ -35,11 +35,7 @@ exports[`eslint`] = {
       [79, 19, 21, "Must use destructuring state assignment", "3239125001"]
     ],
     "js/ducks/dashboard/api/v0.ts:1572663041": [
-      [20, 2, 4, "Assignment to property of function parameter \'data\'.", "2087377941"],
       [43, 28, 104, "Do not nest ternary expressions.", "1163212497"]
-    ],
-    "js/ducks/issue/api/v0.ts:638633038": [
-      [45, 8, 19, "Assignment to property of function parameter \'notificationPayload\'.", "3904454342"]
     ],
     "js/ducks/issue/reducer.ts:891877399": [
       [141, 6, 56, "Unexpected lexical declaration in case block.", "2031834906"]
@@ -56,19 +52,13 @@ exports[`eslint`] = {
       [417, 6, 61, "Unexpected lexical declaration in case block.", "2053236172"]
     ],
     "js/ducks/search/utils.ts:923002554": [
-      [19, 2, 8, "Assignment to function parameter \'resource\'.", "2131237679"],
       [20, 2, 248, "Expected a default case.", "1034339850"]
     ],
     "js/ducks/tableMetadata/api/v0.ts:3333048528": [
-      [92, 6, 9, "Assignment to property of function parameter \'tableData\'.", "1466754955"],
       [141, 23, 2, "Expected to return a value at the end of arrow function.", "5859494"]
     ],
     "js/ducks/tableMetadata/reducer.ts:3935312006": [
       [482, 6, 84, "Unexpected lexical declaration in case block.", "114266473"]
-    ],
-    "js/ducks/utilMethods.ts:1762524729": [
-      [21, 6, 3, "Assignment to property of function parameter \'obj\'.", "193420290"],
-      [34, 6, 3, "Assignment to property of function parameter \'obj\'.", "193420290"]
     ],
     "js/features/Breadcrumb/index.tsx:1046428150": [
       [69, 6, 141, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "1742605206"],
@@ -78,16 +68,6 @@ exports[`eslint`] = {
       [36, 2, 93, "constructor should be placed after nestedType", "2074701101"],
       [116, 6, 36, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3801508926"],
       [116, 6, 36, "Static HTML elements with event handlers require a role.", "3801508926"]
-    ],
-    "js/features/ColumnList/ColumnType/parser.ts:2297011907": [
-      [59, 6, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [60, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [84, 10, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [86, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [131, 8, 10, "Assignment to function parameter \'startIndex\'.", "3807744539"],
-      [132, 8, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [135, 6, 12, "Assignment to function parameter \'currentIndex\'.", "2078922066"],
-      [178, 4, 10, "Assignment to function parameter \'columnType\'.", "460876587"]
     ],
     "js/features/Footer/index.tsx:3658564998": [
       [45, 8, 22, "Must use destructuring props assignment", "1925601400"],
@@ -141,14 +121,8 @@ exports[`eslint`] = {
       [13, 0, 455, "Component should be written as a pure function", "2334877134"],
       [15, 35, 20, "Must use destructuring props assignment", "2510284131"]
     ],
-    "js/pages/TableDetailPage/ReportTableIssue/index.tsx:1210646415": [
-      [170, 15, 20, "Script URL is a form of eval.", "3959800777"]
-    ],
-    "js/pages/TableDetailPage/TableOwnerEditor/index.tsx:2069554136": [
-      [30, 4, 3, "Assignment to property of function parameter \'obj\'.", "193420290"]
-    ],
-    "js/utils/owner.ts:2186084439": [
-      [10, 4, 9, "Assignment to property of function parameter \'resultObj\'.", "1686251499"]
+    "js/pages/TableDetailPage/ReportTableIssue/index.tsx:2299677182": [
+      [168, 15, 20, "Script URL is a form of eval.", "3959800777"]
     ]
   }`
 };

--- a/frontend/amundsen_application/static/.betterer.ts
+++ b/frontend/amundsen_application/static/.betterer.ts
@@ -15,7 +15,7 @@ export default {
       'no-extra-boolean-cast': 'error',
       'no-multi-str': 'error',
       'no-nested-ternary': 'error',
-      'no-param-reassign': 'error',
+      'no-param-reassign': 'off',
       'no-restricted-globals': 'error',
       'no-script-url': 'error',
       'no-unneeded-ternary': 'error',

--- a/frontend/amundsen_application/static/js/components/Alert/Alert.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/Alert.tsx
@@ -82,6 +82,9 @@ export const Alert: React.FC<AlertProps> = ({
         onClick={handleSeeDetails}
       >
         {OPEN_PAYLOAD_CTA}
+        {(payload?.descriptions || []).length > 1
+          ? ` (${(payload.descriptions || []).length})`
+          : ''}
       </button>
     );
   }

--- a/frontend/amundsen_application/static/js/components/Alert/AlertList.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/AlertList.tsx
@@ -10,19 +10,46 @@ export interface AlertListProps {
   notices: NoticeType[];
 }
 
+export interface AggregatedAlertListProps {
+  notices: {
+    [key: string]: NoticeType;
+  };
+}
+
+const aggregateNotices = (notices) =>
+  notices.reduce((accum, notice: any) => {
+    if (notice) {
+      const { messageHtml, severity, payload } = notice;
+
+      if (payload) {
+        accum[messageHtml] ??= {
+          severity,
+          payload: { descriptions: [] },
+        };
+        accum[messageHtml].payload.descriptions.push(payload);
+      } else {
+        accum[messageHtml] = { ...notice };
+      }
+    }
+
+    return accum;
+  }, {});
+
 export const AlertList: React.FC<AlertListProps> = ({ notices }) => {
   if (!notices.length) {
     return null;
   }
 
+  const aggregated = aggregateNotices(notices);
+
   return (
     <div className="alert-list">
-      {notices.map((notice, idx) => (
+      {Object.keys(aggregated).map((notice, idx) => (
         <Alert
           key={idx}
-          message={notice.messageHtml}
-          severity={notice.severity}
-          payload={notice.payload}
+          message={notice}
+          severity={aggregated[notice].severity}
+          payload={aggregated[notice].payload}
         />
       ))}
     </div>

--- a/frontend/amundsen_application/static/js/components/Alert/AlertList.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/AlertList.tsx
@@ -21,6 +21,7 @@ const aggregateNotices = (notices) =>
     if (notice) {
       const { messageHtml, severity, payload } = notice;
 
+      /* eslint-disable no-param-reassign */
       if (payload) {
         accum[messageHtml] ??= {
           severity,
@@ -30,6 +31,7 @@ const aggregateNotices = (notices) =>
       } else {
         accum[messageHtml] = { ...notice };
       }
+      /* eslint-enable no-param-reassign */
     }
 
     return accum;

--- a/frontend/amundsen_application/static/js/components/Alert/alert.story.tsx
+++ b/frontend/amundsen_application/static/js/components/Alert/alert.story.tsx
@@ -138,6 +138,22 @@ const list = [
     messageHtml: 'Second alert of the stack',
   },
   { severity: NoticeSeverity.ALERT, messageHtml: 'Third alert of the stack' },
+  {
+    severity: NoticeSeverity.ALERT,
+    messageHtml: 'Aggregated alert of the stack',
+    payload: {
+      term: 'Test term 1',
+      description: 'Test description 1',
+    },
+  },
+  {
+    severity: NoticeSeverity.ALERT,
+    messageHtml: 'Aggregated alert of the stack',
+    payload: {
+      term: 'Test term 2',
+      description: 'Test description 2',
+    },
+  },
 ];
 
 export const AlertListStory = (): React.ReactNode => (

--- a/frontend/amundsen_application/static/js/components/Alert/styles.scss
+++ b/frontend/amundsen_application/static/js/components/Alert/styles.scss
@@ -51,6 +51,11 @@ $alert-alert-background: #ffe4dd;
     margin-right: $spacer-1;
   }
 
+  .info-svg-icon {
+    margin-right: $spacer-half;
+    margin-left: -$spacer-half;
+  }
+
   .alert-action {
     margin: auto 0 auto auto;
   }

--- a/frontend/amundsen_application/static/js/components/DefinitionList/definitionList.story.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/definitionList.story.tsx
@@ -34,12 +34,12 @@ export const DefinitionListStory = (): React.ReactNode => (
           {
             term: 'Verity checks',
             description:
-              '1 out of 4 checks failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+              '1 out of 4 checks failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Owner</a>)',
           },
           {
             term: 'Failed DAGs',
             description:
-              '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+              '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Owner</a>)',
           },
         ]}
       />
@@ -55,7 +55,46 @@ export const DefinitionListStory = (): React.ReactNode => (
           {
             term: 'Failed DAGs',
             description:
-              '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Ownser</a>)',
+              '1 out of 4 DAGs failed (<a href="http://lyft.com">Link</a> | <a href="http://lyft.com">Owner</a>)',
+          },
+        ]}
+      />
+    </StorySection>
+    <StorySection title="DefinitionList with aggregated descriptions">
+      <DefinitionList
+        definitions={[
+          {
+            term: 'Table name',
+            description: [
+              {
+                'Failed Check': 'coco.fact_rides',
+                Owner: '<a href="http://lyft.com">Owner</a>',
+              },
+              {
+                'Failed Check 2': 'coco.fact_rides',
+                Owner: 'Just a normal string',
+              },
+            ],
+          },
+        ]}
+      />
+    </StorySection>
+    <StorySection title="DefinitionList with aggregated descriptions and fixed term width">
+      <DefinitionList
+        termWidth={200}
+        definitions={[
+          {
+            term: 'Table name',
+            description: [
+              {
+                'Failed Check': 'coco.fact_rides',
+                Owner: '<a href="http://lyft.com">Owner</a>',
+              },
+              {
+                'Failed Check 2': 'coco.fact_rides',
+                Owner: 'Just a normal string',
+              },
+            ],
           },
         ]}
       />

--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.spec.tsx
@@ -149,5 +149,32 @@ describe('DefinitionList', () => {
         expect(actual).toEqual(expected);
       });
     });
+
+    describe('when passing aggregated descriptions', () => {
+      it('should render them', () => {
+        const { wrapper } = setup({
+          definitions: [
+            {
+              term: 'Table name',
+              description: [
+                {
+                  'Failed Check': 'coco.fact_rides',
+                  Owner: '<a href="http://lyft.com">Owner</a>',
+                },
+                {
+                  'Failed Check 2': 'coco.fact_rides',
+                  Owner: 'Just a normal string',
+                },
+              ],
+            },
+          ],
+        });
+
+        const itemGroup = wrapper.find('.definition-list-items-group');
+
+        expect(itemGroup.length).toEqual(2);
+        expect(itemGroup.find('.definition-list-term').length).toEqual(4);
+      });
+    });
   });
 });

--- a/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/index.tsx
@@ -23,26 +23,69 @@ export interface DefinitionListProps {
 export const DefinitionList: React.FC<DefinitionListProps> = ({
   definitions,
   termWidth,
-}) => (
-  <dl className="definition-list">
-    {definitions.map(({ term, description }) => (
-      <div className="definition-list-container" key={term}>
-        <dt
-          className="definition-list-term"
-          style={{ minWidth: termWidth ? `${termWidth}px` : 'auto' }}
-        >
-          {term}
-        </dt>
-        <dd className="definition-list-definition">
-          {typeof description === 'string' ? (
-            <SanitizedHTML html={description} className="definition-text" />
+}) => {
+  const parseDescription = (description) => {
+    switch (typeof description) {
+      case 'object':
+        return (
+          <>
+            {Array.isArray(description)
+              ? description.map((item) => {
+                  const items = Object.keys(item).map((key) => (
+                    <div key={key}>
+                      <div
+                        className="definition-list-term"
+                        style={{
+                          minWidth: termWidth ? `${termWidth}px` : 'auto',
+                        }}
+                      >
+                        {key}:
+                      </div>
+                      <div className="definition-list-definition">
+                        {parseDescription(item[key])}
+                      </div>
+                    </div>
+                  ));
+
+                  return (
+                    <div className="definition-list-items-group">{items}</div>
+                  );
+                })
+              : description}
+          </>
+        );
+      case 'string':
+        return <SanitizedHTML html={description} className="definition-text" />;
+      default:
+        return description;
+    }
+  };
+
+  return (
+    <dl className="definition-list">
+      {definitions.map(({ term, description }) => (
+        <div className="definition-list-container" key={term}>
+          {Array.isArray(description) ? (
+            <div className="definition-list-inner-container">
+              {parseDescription(description)}
+            </div>
           ) : (
-            description
+            <>
+              <dt
+                className="definition-list-term"
+                style={{ minWidth: termWidth ? `${termWidth}px` : 'auto' }}
+              >
+                {term}
+              </dt>
+              <dd className="definition-list-definition">
+                {parseDescription(description)}
+              </dd>
+            </>
           )}
-        </dd>
-      </div>
-    ))}
-  </dl>
-);
+        </div>
+      ))}
+    </dl>
+  );
+};
 
 export default DefinitionList;

--- a/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
+++ b/frontend/amundsen_application/static/js/components/DefinitionList/styles.scss
@@ -10,6 +10,7 @@
 .definition-list-container {
   display: flex;
   padding-bottom: $spacer-2;
+  width: 100%;
 
   &:last-child {
     padding-bottom: 0;
@@ -30,11 +31,33 @@
 
   margin-left: 0;
   margin-bottom: 0;
-  overflow: hidden;
 }
 
-.definition-text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.definition-list-inner-container {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+
+  > *:not(:last-child) {
+    border-bottom: 1px solid $gray20;
+  }
+}
+
+.definition-list-items-group {
+  padding: $spacer-1 0;
+
+  > * {
+    display: flex;
+
+    :not(:last-child) {
+      margin-bottom: $spacer-half;
+    }
+    > .definition-list-term {
+      flex: 0;
+      flex-basis: 25%;
+    }
+    > .definition-list-definition {
+      flex: 1;
+    }
+  }
 }

--- a/frontend/amundsen_application/static/package.json
+++ b/frontend/amundsen_application/static/package.json
@@ -414,7 +414,7 @@
       "no-multi-str": "warn",
       "no-nested-ternary": "warn",
       "no-new-wrappers": "error",
-      "no-param-reassign": "warn",
+      "no-param-reassign": "off",
       "no-plusplus": "off",
       "no-prototype-builtins": "off",
       "no-restricted-globals": "warn",


### PR DESCRIPTION
## Description
Aggregates alert notices that are passed into the AlertList component and then parses them in the DefinitionList.

## Motivation and Context
The UI is cluttered when there are numerous alerts taking up space, especially when many of them have the same title. Aggregating them into one modal alleviates this and reduces the visual strain on the user.

### Screenshots (Before)

#### Notices
![Screenshot 2024-02-09 at 3 20 46 PM](https://github.com/amundsen-io/amundsen/assets/8338893/55c8f162-1b64-4f22-859f-7316395c4396)

#### Modal
![Screenshot 2024-02-09 at 3 20 51 PM](https://github.com/amundsen-io/amundsen/assets/8338893/570ee70a-f8e0-4ded-bdfd-e2e88d24c091)

#### Info SVG Icon Alignment
![Screenshot 2024-02-23 at 12 51 57 PM](https://github.com/amundsen-io/amundsen/assets/8338893/74fb5066-d172-4f6a-af1d-2015c4d8e114)

### Screenshots (After)

#### Notices
![Screenshot 2024-02-23 at 12 56 24 PM](https://github.com/amundsen-io/amundsen/assets/8338893/6a3cd477-b0c9-4db7-9821-f24bfd387487)

#### Modal
![Screenshot 2024-02-09 at 3 18 18 PM](https://github.com/amundsen-io/amundsen/assets/8338893/0ade51b0-0abd-40a0-9320-82e194afdac1)

#### Storybook
![Screenshot 2024-02-09 at 3 41 36 PM](https://github.com/amundsen-io/amundsen/assets/8338893/04239306-5945-40d6-80fd-3d330c360cc6)

#### Info SVG Icon Alignment
![Screenshot 2024-02-23 at 12 56 24 PM](https://github.com/amundsen-io/amundsen/assets/8338893/6a645e3c-3840-423c-ab00-ea37b1fb0d43)

## How Has This Been Tested?
- Utilizing mock data to recreate the notices that can be aggregated as well as without aggregation.
- Unit testing through already existing tests in place
- Verification and updates to storybook and related components

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [x] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
