### PR TITLE
chore: Upgrade flask to 2.2.5 and its related dependencies

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.31.0'
+__version__ = '0.32.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')
@@ -38,7 +38,7 @@ setup(
         # This will allow for any consuming projects to use this library as
         # long as they have a version of pyfoobar equal to or greater than 1.x
         # and less than 2.x installed.
-        'Flask>=1.0.2',
+        'Flask>=2.2.5',
         'attrs>=19.0.0',
         'marshmallow>=3.0',
         'marshmallow3-annotations>=1.1.0'

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.5.0'
+__version__ = '7.4.6'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.4.6'
+__version__ = '7.5.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -45,14 +45,14 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements_dev = requirements_file.readlines()
 
-__version__ = '4.2.1'
+__version__ = '4.3.0'
 
 jira = ['jira==3.0.1']
 asana = ['asana==0.10.3']
 oidc = ['flaskoidc>=1.0.0']
-pyarrrow = ['pyarrow==3.0.0']
+pyarrow = ['pyarrow==3.0.0']
 bigquery_preview = ['google-cloud-bigquery>=2.13.1,<3.0.0', 'flatten-dict==0.3.0']
-all_deps = requirements + requirements_common + requirements_dev + oidc + pyarrrow + bigquery_preview + jira + asana
+all_deps = requirements + requirements_common + requirements_dev + oidc + pyarrow + bigquery_preview + jira + asana
 
 setup(
     name='amundsen-frontend',
@@ -69,7 +69,7 @@ setup(
     extras_require={
         'oidc': oidc,
         'dev': requirements_dev,
-        'pyarrow': pyarrrow,
+        'pyarrow': pyarrow,
         'bigquery_preview': bigquery_preview,
         'jira': jira,
         'asana': asana,

--- a/frontend/tests/unit/api/issue/test_issue.py
+++ b/frontend/tests/unit/api/issue/test_issue.py
@@ -106,7 +106,7 @@ class IssueTest(unittest.TestCase):
         """
         local_app.config['ISSUE_TRACKER_CLIENT_ENABLED'] = False
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -127,7 +127,7 @@ class IssueTest(unittest.TestCase):
         mock_issue_tracker_client.side_effect = IssueConfigurationException
         local_app.config['ISSUE_TRACKER_URL'] = None
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -145,7 +145,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
@@ -162,7 +162,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -179,7 +179,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -196,7 +196,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -213,7 +213,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -230,7 +230,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
@@ -247,7 +247,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'priority_level': 'P2',
@@ -264,7 +264,7 @@ class IssueTest(unittest.TestCase):
          :return:
          """
         with local_app.test_client() as test:
-            response = test.post('/api/issue/issue', data={
+            response = test.post('/api/issue/issue', json={
                 'description': 'test description',
                 'owner_ids': ['user1@email.com', 'user2@email.com'],
                 'frequent_user_ids': ['user1@email.com', 'user2@email.com'],
@@ -285,8 +285,7 @@ class IssueTest(unittest.TestCase):
 
         with local_app.test_client() as test:
             response = test.post('/api/issue/issue',
-                                 content_type='multipart/form-data',
-                                 data={
+                                 json={
                                      'description': 'test description',
                                      'owner_ids': ['user1@email.com', 'user2@email.com'],
                                      'frequent_user_ids': ['user1@email.com', 'user2@email.com'],

--- a/frontend/tests/unit/api/preview/test_v0.py
+++ b/frontend/tests/unit/api/preview/test_v0.py
@@ -32,7 +32,7 @@ class PreviewTest(unittest.TestCase):
 
         local_app.config['PREVIEW_CLIENT'] = None
         with local_app.test_client() as test:
-            response = test.post('/api/preview/v0/', content_type='application/json')
+            response = test.post('/api/preview/v0/', json={})
             self.assertEqual(response.status_code, HTTPStatus.NOT_IMPLEMENTED)
 
     @unittest.mock.patch(PREVIEW_CLIENT_CLASS + '.get_preview_data')
@@ -51,7 +51,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/', content_type='application/json')
+            post_response = test.post('/api/preview/v0/', json={})
             self.assertEqual(post_response.status_code, HTTPStatus.OK)
             self.assertEqual(post_response.json, expected_response_json)
 
@@ -69,7 +69,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/', content_type='application/json')
+            post_response = test.post('/api/preview/v0/', json={})
             self.assertEqual(post_response.status_code,
                              HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertEqual(post_response.json, expected_response_json)
@@ -90,7 +90,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/feature_preview', content_type='application/json')
+            post_response = test.post('/api/preview/v0/feature_preview', json={})
             self.assertEqual(post_response.status_code, HTTPStatus.OK)
             self.assertEqual(post_response.json, expected_response_json)
 
@@ -108,7 +108,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/feature_preview', content_type='application/json')
+            post_response = test.post('/api/preview/v0/feature_preview', json={})
             self.assertEqual(post_response.status_code,
                              HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertEqual(post_response.json, expected_response_json)

--- a/frontend/tests/unit/api/preview/test_v0.py
+++ b/frontend/tests/unit/api/preview/test_v0.py
@@ -32,7 +32,7 @@ class PreviewTest(unittest.TestCase):
 
         local_app.config['PREVIEW_CLIENT'] = None
         with local_app.test_client() as test:
-            response = test.post('/api/preview/v0/')
+            response = test.post('/api/preview/v0/', content_type='application/json')
             self.assertEqual(response.status_code, HTTPStatus.NOT_IMPLEMENTED)
 
     @unittest.mock.patch(PREVIEW_CLIENT_CLASS + '.get_preview_data')
@@ -51,7 +51,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/')
+            post_response = test.post('/api/preview/v0/', content_type='application/json')
             self.assertEqual(post_response.status_code, HTTPStatus.OK)
             self.assertEqual(post_response.json, expected_response_json)
 
@@ -69,7 +69,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/')
+            post_response = test.post('/api/preview/v0/', content_type='application/json')
             self.assertEqual(post_response.status_code,
                              HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertEqual(post_response.json, expected_response_json)
@@ -90,7 +90,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/feature_preview')
+            post_response = test.post('/api/preview/v0/feature_preview', content_type='application/json')
             self.assertEqual(post_response.status_code, HTTPStatus.OK)
             self.assertEqual(post_response.json, expected_response_json)
 
@@ -108,7 +108,7 @@ class PreviewTest(unittest.TestCase):
         mock_get_preview_data.return_value = Response(response=response,
                                                       status=HTTPStatus.OK)
         with local_app.test_client() as test:
-            post_response = test.post('/api/preview/v0/feature_preview')
+            post_response = test.post('/api/preview/v0/feature_preview', content_type='application/json')
             self.assertEqual(post_response.status_code,
                              HTTPStatus.INTERNAL_SERVER_ERROR)
             self.assertEqual(post_response.json, expected_response_json)

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '3.12.3'
+__version__ = '3.13.0'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/metadata/tests/unit/api/column/test_column_badge_api.py
+++ b/metadata/tests/unit/api/column/test_column_badge_api.py
@@ -28,7 +28,8 @@ class TestColumnBadgeAPI(BasicTestCase):
     def test_block_bad_badge_name(self) -> None:
         self.app.config['WHITELIST_BADGES'] = []
         response = self.app.test_client().put(f'/table/{TABLE_NAME}/column/{COLUMN_NAME}'
-                                              f'/badge/{BADGE_NAME}?category=table_status')
+                                              f'/badge/{BADGE_NAME}?category=table_status',
+                                              json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
@@ -36,7 +37,8 @@ class TestColumnBadgeAPI(BasicTestCase):
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='alpha',
                                                      category='table_status')]
         response = self.app.test_client().put(f'/table/{TABLE_NAME}/column/{COLUMN_NAME}'
-                                              f'/badge/{BADGE_NAME}')
+                                              f'/badge/{BADGE_NAME}',
+                                              json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
@@ -44,7 +46,8 @@ class TestColumnBadgeAPI(BasicTestCase):
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='alpha',
                                                      category='table_status')]
         response = self.app.test_client().put(f'/table/{TABLE_NAME}/column/{COLUMN_NAME}'
-                                              f'/badge/{BADGE_NAME}?category=table_status')
+                                              f'/badge/{BADGE_NAME}?category=table_status',
+                                              json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
 

--- a/metadata/tests/unit/api/dashboard/test_dashboard_badge_api.py
+++ b/metadata/tests/unit/api/dashboard/test_dashboard_badge_api.py
@@ -26,21 +26,24 @@ class TestDashboardBadgeAPI(BasicTestCase):
 
     def test_block_bad_badge_name(self) -> None:
         self.app.config['WHITELIST_BADGES'] = []
-        response = self.app.test_client().put(f'/dashboard/{DASHBOARD_NAME}/badge/{BADGE_NAME}?category=table_status')
+        response = self.app.test_client().put(f'/dashboard/{DASHBOARD_NAME}/badge/{BADGE_NAME}?category=table_status',
+                                              json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_block_badge_missing_category(self) -> None:
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='alpha',
                                                      category='table_status')]
-        response = self.app.test_client().put(f'/dashboard/{DASHBOARD_NAME}/badge/{BADGE_NAME}')
+        response = self.app.test_client().put(f'/dashboard/{DASHBOARD_NAME}/badge/{BADGE_NAME}',
+                                              json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_badge_with_category(self) -> None:
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='alpha',
                                                      category='table_status')]
-        response = self.app.test_client().put(f'/dashboard/{DASHBOARD_NAME}/badge/{BADGE_NAME}?category=table_status')
+        response = self.app.test_client().put(f'/dashboard/{DASHBOARD_NAME}/badge/{BADGE_NAME}?category=table_status',
+                                              json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
 

--- a/metadata/tests/unit/api/dashboard/test_dashboard_tag_api.py
+++ b/metadata/tests/unit/api/dashboard/test_dashboard_tag_api.py
@@ -15,7 +15,7 @@ TAG = 'underage_wizards'
 class TestDashboardTagAPI(DashboardTestCase):
 
     def test_should_update_tag(self) -> None:
-        response = self.app.test_client().put(f'/dashboard/{ID}/tag/{TAG}')
+        response = self.app.test_client().put(f'/dashboard/{ID}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.add_tag.assert_called_with(id=ID,
@@ -26,12 +26,12 @@ class TestDashboardTagAPI(DashboardTestCase):
     def test_should_fail_to_update_tag_when_table_not_found(self) -> None:
         self.mock_proxy.add_tag.side_effect = NotFoundException(message='foo')
 
-        response = self.app.test_client().put(f'/dashboard/{ID}/tag/{TAG}')
+        response = self.app.test_client().put(f'/dashboard/{ID}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_should_delete_tag(self) -> None:
-        response = self.app.test_client().delete(f'/dashboard/{ID}/tag/{TAG}')
+        response = self.app.test_client().delete(f'/dashboard/{ID}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.delete_tag.assert_called_with(id=ID,
@@ -42,6 +42,6 @@ class TestDashboardTagAPI(DashboardTestCase):
     def test_should_fail_to_delete_tag_when_table_not_found(self) -> None:
         self.mock_proxy.delete_tag.side_effect = NotFoundException(message='foo')
 
-        response = self.app.test_client().delete(f'/dashboard/{ID}/tag/{TAG}')
+        response = self.app.test_client().delete(f'/dashboard/{ID}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/metadata/tests/unit/api/feature/test_feature_badge_api.py
+++ b/metadata/tests/unit/api/feature/test_feature_badge_api.py
@@ -26,21 +26,21 @@ class TestFeatureBadgeAPI(BasicTestCase):
 
     def test_block_bad_badge_name(self) -> None:
         self.app.config['WHITELIST_BADGES'] = []
-        response = self.app.test_client().put(f'/feature/{FEATURE_NAME}/badge/{BADGE_NAME}?category=data')
+        response = self.app.test_client().put(f'/feature/{FEATURE_NAME}/badge/{BADGE_NAME}?category=data', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_block_badge_missing_category(self) -> None:
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='pii',
                                                      category='data')]
-        response = self.app.test_client().put(f'/feature/{FEATURE_NAME}/badge/{BADGE_NAME}')
+        response = self.app.test_client().put(f'/feature/{FEATURE_NAME}/badge/{BADGE_NAME}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_badge_with_category(self) -> None:
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='pii',
                                                      category='data')]
-        response = self.app.test_client().put(f'/feature/{FEATURE_NAME}/badge/{BADGE_NAME}?category=data')
+        response = self.app.test_client().put(f'/feature/{FEATURE_NAME}/badge/{BADGE_NAME}?category=data', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
 

--- a/metadata/tests/unit/api/feature/test_feature_lineage_api.py
+++ b/metadata/tests/unit/api/feature/test_feature_lineage_api.py
@@ -52,7 +52,7 @@ class TestFeatureLineageAPI(FeatureTestCase):
 
     def test_should_return_response(self) -> None:
         self.mock_proxy.get_lineage.return_value = LINEAGE_RESPONSE
-        response = self.app.test_client().get(f'/feature/{FEATURE_URI}/lineage')
+        response = self.app.test_client().get(f'/feature/{FEATURE_URI}/lineage', json={})
 
         self.mock_proxy.get_lineage.assert_called_with(id=FEATURE_URI,
                                                        resource_type=ResourceType.Feature,
@@ -64,6 +64,6 @@ class TestFeatureLineageAPI(FeatureTestCase):
     def test_should_fail_when_feature_doesnt_exist(self) -> None:
         self.mock_proxy.get_lineage.side_effect = NotFoundException(message='feature not found')
 
-        response = self.app.test_client().get(f'/feature/{FEATURE_URI}/lineage')
+        response = self.app.test_client().get(f'/feature/{FEATURE_URI}/lineage', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/metadata/tests/unit/api/feature/test_feature_tag_api.py
+++ b/metadata/tests/unit/api/feature/test_feature_tag_api.py
@@ -15,7 +15,7 @@ TAG = 'underage_wizards'
 class TestFeatureTagAPI(FeatureTestCase):
 
     def test_should_update_tag(self) -> None:
-        response = self.app.test_client().put(f'/feature/{FEATURE_URI}/tag/{TAG}')
+        response = self.app.test_client().put(f'/feature/{FEATURE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.add_tag.assert_called_with(id=FEATURE_URI,
@@ -26,12 +26,12 @@ class TestFeatureTagAPI(FeatureTestCase):
     def test_should_fail_to_update_tag_when_feature_not_found(self) -> None:
         self.mock_proxy.add_tag.side_effect = NotFoundException(message='cannot find feature')
 
-        response = self.app.test_client().put(f'/feature/{FEATURE_URI}/tag/{TAG}')
+        response = self.app.test_client().put(f'/feature/{FEATURE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_should_delete_tag(self) -> None:
-        response = self.app.test_client().delete(f'/feature/{FEATURE_URI}/tag/{TAG}')
+        response = self.app.test_client().delete(f'/feature/{FEATURE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.delete_tag.assert_called_with(id=FEATURE_URI,
@@ -42,6 +42,6 @@ class TestFeatureTagAPI(FeatureTestCase):
     def test_should_fail_to_delete_tag_when_feature_not_found(self) -> None:
         self.mock_proxy.delete_tag.side_effect = NotFoundException(message='cannot find feature')
 
-        response = self.app.test_client().delete(f'/feature/{FEATURE_URI}/tag/{TAG}')
+        response = self.app.test_client().delete(f'/feature/{FEATURE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/metadata/tests/unit/api/table/test_table_badge_api.py
+++ b/metadata/tests/unit/api/table/test_table_badge_api.py
@@ -26,21 +26,21 @@ class TestTableBadgeAPI(BasicTestCase):
 
     def test_block_bad_badge_name(self) -> None:
         self.app.config['WHITELIST_BADGES'] = []
-        response = self.app.test_client().put(f'/table/{TABLE_NAME}/badge/{BADGE_NAME}?category=table_status')
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/badge/{BADGE_NAME}?category=table_status', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_block_badge_missing_category(self) -> None:
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='alpha',
                                                      category='table_status')]
-        response = self.app.test_client().put(f'/table/{TABLE_NAME}/badge/{BADGE_NAME}')
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/badge/{BADGE_NAME}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_badge_with_category(self) -> None:
         self.app.config['WHITELIST_BADGES'] = [Badge(badge_name='alpha',
                                                      category='table_status')]
-        response = self.app.test_client().put(f'/table/{TABLE_NAME}/badge/{BADGE_NAME}?category=table_status')
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/badge/{BADGE_NAME}?category=table_status', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
 

--- a/metadata/tests/unit/api/table/test_table_lineage_api.py
+++ b/metadata/tests/unit/api/table/test_table_lineage_api.py
@@ -74,7 +74,7 @@ class TestTableLineageAPI(TableTestCase):
 
     def test_should_return_response(self) -> None:
         self.mock_proxy.get_lineage.return_value = LINEAGE_RESPONSE
-        response = self.app.test_client().get(f'/table/{TABLE_URI}/lineage')
+        response = self.app.test_client().get(f'/table/{TABLE_URI}/lineage', json={})
         self.assertEqual(response.json, API_RESPONSE)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.get_lineage.assert_called_with(id=TABLE_URI,
@@ -85,6 +85,6 @@ class TestTableLineageAPI(TableTestCase):
     def test_should_fail_when_table_doesnt_exist(self) -> None:
         self.mock_proxy.get_lineage.side_effect = NotFoundException(message='table not found')
 
-        response = self.app.test_client().get(f'/table/{TABLE_URI}/lineage')
+        response = self.app.test_client().get(f'/table/{TABLE_URI}/lineage', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/metadata/tests/unit/api/table/test_table_tag_api.py
+++ b/metadata/tests/unit/api/table/test_table_tag_api.py
@@ -15,7 +15,7 @@ TAG = 'underage_wizards'
 class TestTableTagAPI(TableTestCase):
 
     def test_should_update_tag(self) -> None:
-        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag/{TAG}')
+        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.add_tag.assert_called_with(id=TABLE_URI,
@@ -26,12 +26,12 @@ class TestTableTagAPI(TableTestCase):
     def test_should_fail_to_update_tag_when_table_not_found(self) -> None:
         self.mock_proxy.add_tag.side_effect = NotFoundException(message='cannot find table')
 
-        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag/{TAG}')
+        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_should_delete_tag(self) -> None:
-        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag/{TAG}')
+        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.mock_proxy.delete_tag.assert_called_with(id=TABLE_URI,
@@ -42,6 +42,6 @@ class TestTableTagAPI(TableTestCase):
     def test_should_fail_to_delete_tag_when_table_not_found(self) -> None:
         self.mock_proxy.delete_tag.side_effect = NotFoundException(message='cannot find table')
 
-        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag/{TAG}')
+        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag/{TAG}', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -4,17 +4,17 @@
 # Common dependencies (common, frontend, metadata, search) -------------------------------------------------------------
 
 # It is recommended to always pin the exact version (not range) - otherwise common upgrade won't trigger unit tests
-# on all repositories reyling on this file and any issues that arise from common upgrade might be missed.
+# on all repositories relying on this file and any issues that arise from common upgrade might be missed.
 amundsen-common>=0.27.0
 attrs>=19.1.0
 boto3==1.17.23
-click==7.0
+click==8.1.7
 flasgger==0.9.5
-Flask==1.0.2
-Flask-RESTful>=0.3.6
+Flask==2.2.5
+Flask-RESTful>=0.3.9
 flask-cors==3.0.10
-itsdangerous<=2.0.1
-Jinja2>=2.10.1,<3.1
+itsdangerous==2.1.2
+Jinja2==3.1.2
 jsonschema>=3.0.1,<4.0
 marshmallow>=3.0,<=3.6
 marshmallow3-annotations>=1.1.0
@@ -23,5 +23,5 @@ requests>=2.25.0
 requests-aws4auth==1.1.0
 statsd==3.2.1
 typing==3.6.4
-werkzeug==2.0.3
+werkzeug==3.0.1
 wheel==0.38.1

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '4.1.4'
+__version__ = '4.2.0'
 
 oidc = ['flaskoidc>=1.0.0']
 

--- a/search/tests/unit/api/dashboard/test_search_dashboard_api.py
+++ b/search/tests/unit/api/dashboard/test_search_dashboard_api.py
@@ -28,7 +28,7 @@ class TestSearchDashboardAPI(TestCase):
         result = mock_proxy_results()
         self.mock_proxy.fetch_dashboard_search_results.return_value = SearchResult(total_results=1, results=[result])
 
-        response = self.app.test_client().get('/search_dashboard?query_term=searchterm')
+        response = self.app.test_client().get('/search_dashboard?query_term=searchterm', json={})
         expected_response = {
             "total_results": 1,
             "results": [mock_json_response()]
@@ -43,7 +43,7 @@ class TestSearchDashboardAPI(TestCase):
         self.mock_proxy.fetch_dashboard_search_results.return_value = \
             SearchResult(total_results=0, results=[])
 
-        response = self.app.test_client().get('/search_dashboard?query_term=searchterm')
+        response = self.app.test_client().get('/search_dashboard?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 0,
@@ -52,13 +52,13 @@ class TestSearchDashboardAPI(TestCase):
         self.assertEqual(response.json, expected_response)
 
     def test_should_fail_without_query_term(self) -> None:
-        response = self.app.test_client().get('/search_dashboard')
+        response = self.app.test_client().get('/search_dashboard', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_should_fail_when_proxy_fails(self) -> None:
         self.mock_proxy.fetch_dashboard_search_results.side_effect = RuntimeError('search failed')
 
-        response = self.app.test_client().get('/search_dashboard?query_term=searchterm')
+        response = self.app.test_client().get('/search_dashboard?query_term=searchterm', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/search/tests/unit/api/feature/test_search_feature_api.py
+++ b/search/tests/unit/api/feature/test_search_feature_api.py
@@ -31,7 +31,7 @@ class TestSearchFeatureAPI(TestCase):
         self.mock_proxy.fetch_feature_search_results.return_value = \
             SearchFeatureResult(total_results=1, results=[result])
 
-        response = self.app.test_client().get('/search_feature?query_term=searchterm')
+        response = self.app.test_client().get('/search_feature?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 1,
@@ -47,7 +47,7 @@ class TestSearchFeatureAPI(TestCase):
         self.mock_proxy.fetch_feature_search_results.return_value = \
             SearchFeatureResult(total_results=0, results=[])
 
-        response = self.app.test_client().get('/search_feature?query_term=searchterm')
+        response = self.app.test_client().get('/search_feature?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 0,
@@ -56,11 +56,11 @@ class TestSearchFeatureAPI(TestCase):
         self.assertEqual(response.json, expected_response)
 
     def test_should_fail_without_query_term(self) -> None:
-        response = self.app.test_client().get('/search_feature')
+        response = self.app.test_client().get('/search_feature', json={})
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_should_fail_when_proxy_fails(self) -> None:
         self.mock_proxy.fetch_feature_search_results.side_effect = RuntimeError('search failed')
 
-        response = self.app.test_client().get('/search_feature?query_term=searchterm')
+        response = self.app.test_client().get('/search_feature?query_term=searchterm', json={})
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/search/tests/unit/api/table/test_search_table_api.py
+++ b/search/tests/unit/api/table/test_search_table_api.py
@@ -31,7 +31,7 @@ class TestSearchTableAPI(TestCase):
         result = mock_proxy_results()
         self.mock_proxy.fetch_table_search_results.return_value = SearchTableResult(total_results=1, results=[result])
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 1,
@@ -47,7 +47,7 @@ class TestSearchTableAPI(TestCase):
         self.mock_proxy.fetch_table_search_results.return_value = \
             SearchTableResult(total_results=0, results=[])
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 0,
@@ -60,7 +60,7 @@ class TestSearchTableAPI(TestCase):
             SearchTableResult(total_results=1,
                               results=[mock_default_proxy_results()])
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         expected_response = {
             "total_results": 1,
@@ -70,13 +70,13 @@ class TestSearchTableAPI(TestCase):
         self.assertEqual(response.json, expected_response)
 
     def test_should_fail_without_query_term(self) -> None:
-        response = self.app.test_client().get('/search')
+        response = self.app.test_client().get('/search', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_should_fail_when_proxy_fails(self) -> None:
         self.mock_proxy.fetch_table_search_results.side_effect = RuntimeError('search failed')
 
-        response = self.app.test_client().get('/search?query_term=searchterm')
+        response = self.app.test_client().get('/search?query_term=searchterm', json={})
 
         self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Description
- Upgrading flask version to 2.2.5, along with some related dependencies.
- With the later version of werkzeug, I had to update tests that used API calls to pass `json` instead of `data` (or instead of nothing) as a param to indicate the expected content type. See [release notes](https://github.com/pallets/werkzeug/blob/817aac4d2c71b83752e451d23f96ac26cfd7bbcd/CHANGES.rst#L146) from version 2.3.0.

## Motivation and Context
We need to upgrade flask due to py3.10 version requirements. This change will also resolve some security dependencies in the project.

## How Has This Been Tested?
Ran our frontend, metadata, and search services locally to ensure there were no issues.

### Documentation
N/A

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
