### PR TITLE
chore: Upgrade sqlalchemy in frontend to latest 1.x.x version

### DIFF
--- a/frontend/amundsen_application/base/examples/example_announcement_client.py
+++ b/frontend/amundsen_application/base/examples/example_announcement_client.py
@@ -10,6 +10,7 @@ from amundsen_application.base.base_announcement_client import BaseAnnouncementC
 try:
     from sqlalchemy import Column, Integer, String, DateTime, create_engine
     from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.inspection import inspect
     from sqlalchemy.orm import sessionmaker
 except ModuleNotFoundError:
     pass
@@ -37,7 +38,7 @@ class SQLAlchemyAnnouncementClient(BaseAnnouncementClient):
         session = sessionmaker(bind=self.engine)()
 
         # add dummy announcements to preview
-        if not self.engine.dialect.has_table(self.engine, DBAnnouncement.__tablename__):
+        if not inspect(self.engine).has_table(DBAnnouncement.__tablename__):
             Base.metadata.create_all(self.engine)
 
             announcements = []

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 responses==0.12.1
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.52
 retrying>=1.3.3,<2.0
 
 # Backport of PEP 557, Data Classes for Python 3.6.


### PR DESCRIPTION
## Description
Upgrading sqlalchemy in frontend service to latest 1.x.x version

## Motivation and Context
Match version of the package we use internally

## How Has This Been Tested?
Ran the tests and ran frontend service locally

### Documentation
<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
* [X] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
