### PR TITLE
fix: Adjusting Tag display to handle long tag names

### DIFF
--- a/frontend/amundsen_application/static/.betterer.results
+++ b/frontend/amundsen_application/static/.betterer.results
@@ -13,8 +13,8 @@ exports[`eslint`] = {
       [83, 6, 13, "Do not use setState in componentDidUpdate", "57229240"],
       [101, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
-    "js/components/OwnerEditor/index.tsx:2385247435": [
-      [85, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
+    "js/components/OwnerEditor/index.tsx:2842129076": [
+      [88, 6, 13, "Do not use setState in componentDidUpdate", "57229240"]
     ],
     "js/components/Preloader/index.tsx:958787996": [
       [22, 4, 26, "Must use destructuring props assignment", "1492876559"],
@@ -76,14 +76,13 @@ exports[`eslint`] = {
     "js/features/SearchBar/index.tsx:2560837631": [
       [84, 2, 51, "refToSelf should be placed before constructor", "3412474606"]
     ],
-    "js/features/Tags/TagInput/index.tsx:914140200": [
+    "js/features/Tags/TagInput/index.tsx:896029978": [
       [107, 19, 2, "Array.prototype.map() expects a return value from arrow function.", "5859494"],
       [172, 2, 801, "onChange should be placed before noOptionsMessage", "331725852"],
       [186, 8, 21, "Must use destructuring props assignment", "2890513821"],
       [190, 6, 21, "Must use destructuring props assignment", "2890513821"],
       [238, 8, 118, "Visible, non-interactive elements with click handlers must have at least one keyboard listener.", "3772713652"],
-      [238, 8, 118, "Static HTML elements with event handlers require a role.", "3772713652"],
-      [310, 10, 203, "Missing an explicit type attribute for button", "893477908"]
+      [238, 8, 118, "Static HTML elements with event handlers require a role.", "3772713652"]
     ],
     "js/pages/DashboardPage/ChartList/index.tsx:305174342": [
       [11, 0, 446, "Component should be written as a pure function", "2708651446"]

--- a/frontend/amundsen_application/static/css/_layouts.scss
+++ b/frontend/amundsen_application/static/css/_layouts.scss
@@ -241,11 +241,13 @@ $close-btn-size: 24px;
       flex-basis: $inner-column-size;
       flex-direction: column;
       margin-right: 12px;
+      min-width: 0;
     }
 
     > .right-column {
       flex-basis: $inner-column-size;
       margin-left: 12px;
+      min-width: 0;
     }
   }
 

--- a/frontend/amundsen_application/static/js/features/Tags/TagInfo/index.tsx
+++ b/frontend/amundsen_application/static/js/features/Tags/TagInfo/index.tsx
@@ -49,6 +49,7 @@ export class TagInfo extends React.Component<TagInfoProps> {
         className={'btn tag-button' + (compact ? ' compact' : '')}
         type="button"
         onClick={this.onClick}
+        title={name}
       >
         <span className="tag-name">{name}</span>
         {!compact && <span className="tag-count">{data.tag_count}</span>}

--- a/frontend/amundsen_application/static/js/features/Tags/TagInfo/styles.scss
+++ b/frontend/amundsen_application/static/js/features/Tags/TagInfo/styles.scss
@@ -13,6 +13,7 @@
   padding: 8px;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: 100%;
 
   &.compact {
     height: 30px;

--- a/frontend/amundsen_application/static/js/features/Tags/TagInput/index.tsx
+++ b/frontend/amundsen_application/static/js/features/Tags/TagInput/index.tsx
@@ -311,6 +311,7 @@ export class TagInput extends React.Component<TagInputProps, TagInputState> {
           <button
             className="btn btn-default muted add-btn"
             onClick={this.startEditing}
+            title="New"
           >
             <img className="icon icon-plus" alt="" />
             New

--- a/frontend/amundsen_application/static/js/features/Tags/TagInput/index.tsx
+++ b/frontend/amundsen_application/static/js/features/Tags/TagInput/index.tsx
@@ -312,6 +312,7 @@ export class TagInput extends React.Component<TagInputProps, TagInputState> {
             className="btn btn-default muted add-btn"
             onClick={this.startEditing}
             title="New"
+            type="button"
           >
             <img className="icon icon-plus" alt="" />
             New


### PR DESCRIPTION
## Description
We found that there were some visual inconsistencies when dealing with long tag names. Handled the overflow with the layout and set `max-width` for the button to utilize the default overflow handling. Added titles to allow for accessibility.

## Motivation and Context
To provide a better user experience.

## How Has This Been Tested?
Locally with mock data to force long tag names

### Screenshots

#### Before
![before](https://github.com/user-attachments/assets/5a789313-8caa-4ff3-a75b-1b179c9641c7)

#### After
![after](https://github.com/user-attachments/assets/3523db94-5a19-42d5-97fb-1bf1557e7950)

#### After (w/Title)
![after_title](https://github.com/user-attachments/assets/f6a8b35d-e625-47cc-b204-29cd640ab695)

### CheckList
* [x] PR title addresses the issue accurately and concisely
