### PR TITLE
[AMD-2382] Fix empty timestamp for dashboard

### DIFF
--- a/common/amundsen_common/models/dashboard.py
+++ b/common/amundsen_common/models/dashboard.py
@@ -10,7 +10,7 @@ from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 class SafeFloat(fields.Field):
     def _serialize(self, value, attr, obj, **kwargs):
-        if value == '':
+        if value is None or value == '':
             return None
         try:
             return float(value)
@@ -18,12 +18,13 @@ class SafeFloat(fields.Field):
             self.fail('invalid', input=value)
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value == '':
+        if value is None or value == '':
             return None
         try:
             return float(value)
         except ValueError:
             self.fail('invalid', input=value)
+
 
 @attr.s(auto_attribs=True, kw_only=True)
 class DashboardSummary:

--- a/common/amundsen_common/models/dashboard.py
+++ b/common/amundsen_common/models/dashboard.py
@@ -4,8 +4,26 @@
 from typing import List, Optional
 
 import attr
+from marshmallow import fields
 from marshmallow3_annotations.ext.attrs import AttrsSchema
 
+
+class SafeFloat(fields.Field):
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value == '':
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            self.fail('invalid', input=value)
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value == '':
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            self.fail('invalid', input=value)
 
 @attr.s(auto_attribs=True, kw_only=True)
 class DashboardSummary:
@@ -25,3 +43,5 @@ class DashboardSummarySchema(AttrsSchema):
     class Meta:
         target = DashboardSummary
         register_as_scheme = True
+
+    last_successful_run_timestamp = SafeFloat()

--- a/common/setup.py
+++ b/common/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '0.32.0'
+__version__ = '0.33.0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements-dev.txt')


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

## Description
<!--- Describe your changes in detail -->
If the response for retrieving the user own results has an empty field for last_successful_run_timestamp, there is an exception when it tries to convert it to a float type since it is an empty string rather than a non existent field. Need to fix the handling for this case so it will no longer throw an exception.

UserOwnAPI GET Failed

File "/code/amundsenmetadata-private/upstream/metadata/metadata_service/api/user.py", line 224, in get result[dashboard_key] = DashboardSummarySchema().dump(resources[dashboard_key], many=True) File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/schema.py", line 556, in dump result = self._serialize(processed_obj, many=many) File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/schema.py", line 514, in _serialize return [ File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/schema.py", line 515, in <listcomp> self._serialize(d, many=False) File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/schema.py", line 520, in _serialize value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute) File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/fields.py", line 311, in serialize return self._serialize(value, attr, obj, **kwargs) File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/fields.py", line 894, in _serialize ret = self._format_num(value) # type: _T File "/code/venvs/venv/lib/python3.8/site-packages/marshmallow/fields.py", line 869, in _format_num return self.num_type(value) ValueError: could not convert string to float: ''

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Documentation
<!-- What documentation did you add or modify and why? Add any relevant links then remove this line -->

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
