### PR TITLE
fix: Change databuilder search data extractors to publish `name` in user document.

### DIFF
--- a/databuilder/databuilder/extractor/atlas_search_data_extractor.py
+++ b/databuilder/databuilder/extractor/atlas_search_data_extractor.py
@@ -204,6 +204,7 @@ class AtlasSearchDataExtractor(Extractor):
              lambda x: AtlasSearchDataExtractorHelpers.get_badges_from_classifications(x), [])
         ],
         'User': [
+            ('name', 'attributes.full_name', None, ''),
             ('email', 'attributes.qualifiedName', None, ''),
             ('first_name', 'attributes.first_name', None, ''),
             ('last_name', 'attributes.last_name', None, ''),

--- a/databuilder/databuilder/extractor/mysql_search_data_extractor.py
+++ b/databuilder/databuilder/extractor/mysql_search_data_extractor.py
@@ -426,6 +426,7 @@ def _user_search(session: Session, published_tag: str, limit: int) -> List[Dict]
 
             manager_email = user.manager.email if user.manager else ''
             user_result = dict(email=user.email,
+                               name=user.full_name,
                                first_name=user.first_name,
                                last_name=user.last_name,
                                full_name=user.full_name,

--- a/databuilder/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/databuilder/extractor/neo4j_search_data_extractor.py
@@ -73,7 +73,7 @@ class Neo4jSearchDataExtractor(Extractor):
         where user.full_name is not null
         return user.email as email, user.first_name as first_name, user.last_name as last_name,
         user.full_name as full_name, user.github_username as github_username, user.team_name as team_name,
-        user.employee_type as employee_type, manager.email as manager_email,
+        user.employee_type as employee_type, manager.email as manager_email, user.full_name as name,
         user.slack_id as slack_id, user.is_active as is_active, user.role_name as role_name,
         REDUCE(sum_r = 0, r in COLLECT(DISTINCT read)| sum_r + r.read_count) AS total_read,
         count(distinct b) as total_own,

--- a/databuilder/databuilder/extractor/neptune_search_data_extractor.py
+++ b/databuilder/databuilder/extractor/neptune_search_data_extractor.py
@@ -121,6 +121,7 @@ def _user_search_query(graph: GraphTraversalSource, tag_filter: str) -> List[Dic
         'total_own',
         'total_follow'
     )
+    traversal = traversal.by('full_name')  # name
     traversal = traversal.by('email')  # email
     traversal = traversal.by('first_name')  # first_name
     traversal = traversal.by('last_name')  # last_name

--- a/databuilder/databuilder/models/user_elasticsearch_document.py
+++ b/databuilder/databuilder/models/user_elasticsearch_document.py
@@ -10,6 +10,7 @@ class UserESDocument(ElasticsearchDocument):
     """
 
     def __init__(self,
+                 name: str,
                  email: str,
                  first_name: str,
                  last_name: str,
@@ -25,6 +26,7 @@ class UserESDocument(ElasticsearchDocument):
                  total_own: int,
                  total_follow: int,
                  ) -> None:
+        self.name = name
         self.email = email
         self.first_name = first_name
         self.last_name = last_name

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -5,7 +5,7 @@ import os
 
 from setuptools import find_packages, setup
 
-__version__ = '7.5.1'
+__version__ = '7.5.2'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'requirements.txt')

--- a/databuilder/tests/unit/extractor/test_mysql_search_data_extractor.py
+++ b/databuilder/tests/unit/extractor/test_mysql_search_data_extractor.py
@@ -137,7 +137,7 @@ class MyTestCase(unittest.TestCase):
         manager = User(rk='test_manager_key', email='test_manager@email.com')
         user.manager = manager
 
-        expected_dict = dict(name='test_first_name test_last_name',
+        expected_dict = dict(name='test_full_name',
                              email='test_user@email.com',
                              first_name='test_first_name',
                              last_name='test_last_name',

--- a/databuilder/tests/unit/extractor/test_mysql_search_data_extractor.py
+++ b/databuilder/tests/unit/extractor/test_mysql_search_data_extractor.py
@@ -137,7 +137,8 @@ class MyTestCase(unittest.TestCase):
         manager = User(rk='test_manager_key', email='test_manager@email.com')
         user.manager = manager
 
-        expected_dict = dict(email='test_user@email.com',
+        expected_dict = dict(name='test_first_name test_last_name',
+                             email='test_user@email.com',
                              first_name='test_first_name',
                              last_name='test_last_name',
                              full_name='test_full_name',

--- a/databuilder/tests/unit/models/test_user_elasticsearch_document.py
+++ b/databuilder/tests/unit/models/test_user_elasticsearch_document.py
@@ -29,7 +29,8 @@ class TestUserElasticsearchDocument(unittest.TestCase):
                                   total_own=3,
                                   total_follow=1)
 
-        expected_document_dict = {"first_name": "test_firstname",
+        expected_document_dict = {"name": "test_firstname test_lastname",
+                                  "first_name": "test_firstname",
                                   "last_name": "test_lastname",
                                   "full_name": "full_name",
                                   "team_name": "team",

--- a/databuilder/tests/unit/models/test_user_elasticsearch_document.py
+++ b/databuilder/tests/unit/models/test_user_elasticsearch_document.py
@@ -13,7 +13,8 @@ class TestUserElasticsearchDocument(unittest.TestCase):
         """
         Test string generated from to_json method
         """
-        test_obj = UserESDocument(email='test@email.com',
+        test_obj = UserESDocument(name='test_firstname test_lastname',
+                                  email='test@email.com',
                                   first_name='test_firstname',
                                   last_name='test_lastname',
                                   full_name='full_name',


### PR DESCRIPTION
## Description
Changes the search data databuilder extractors to extract a `name` field, for publishing to elasticsearch.

Currently, the user document schema in elasticsearch expects a `name` keyword, which is the primary field for searching users. (Expected from [Databuilder publish](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/task/search/document_mappings.py#L262), and expected from [search service](https://github.com/amundsen-io/amundsen/blob/main/search/search_service/proxy/es_proxy_v2_1.py#L82))

## Motivation and Context
The change is required because currently the elasticsearch query does not use the `name` field to create better matches for search results, and instead is likely just using first/last and key of the user. This is fine when searching for just first or last, but when searching both the search results currently aren't great for this reason.

This is actually fixed in the [example query](https://github.com/amundsen-io/amundsen/blob/main/databuilder/databuilder/task/search/search_data_queries.py#L127) ([PR](https://github.com/amundsen-io/amundsen/pull/1717)) for posting from neo4j to elasticsearch, but this query is never used.

## How Has This Been Tested?
This has only been tested with the neo4j_search_data_extractor, and not the other extractors. Testing was done by:
1. Loading from databuilder via the search_data_extractor script
2. Navigating to the index on `localhost:9200` and inspecting document values
3. Attempting a search in the frontend and comparing results

### Documentation
No change in documentation

### CheckList
* [X] PR title addresses the issue accurately and concisely

Believe this fix has no need for:
* [X] N/A: ~Updates Documentation and Docstrings~
* [X] N/A: ~Adds tests~
* [X] N/A: ~Adds instrumentation (logs, or UI events)~
