### PR TITLE
Fix -- handle empty string dashboard run timestamps

### DIFF
--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -624,7 +624,8 @@ class Neo4jProxy(BaseProxy):
                                             param_dict={'key': uri})
 
         result = get_single_record(result)
-        return Description(description=result['description'] if result else None)
+
+        return Description(description=result['description'] if result else None)  # type: ignore
 
     @timer_with_counter
     def get_table_description(self, *,

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -1594,6 +1594,10 @@ class Neo4jProxy(BaseProxy):
 
         results = []
         for record in records:
+            last_successful_run_timestamp = record['last_successful_run_timestamp']
+            if record['last_successful_run_timestamp'] == '':
+                last_successful_run_timestamp = None
+
             results.append(DashboardSummary(
                 uri=record['uri'],
                 cluster=record['cluster_name'],
@@ -1603,7 +1607,7 @@ class Neo4jProxy(BaseProxy):
                 name=record['name'],
                 url=record['url'],
                 description=record['description'],
-                last_successful_run_timestamp=record['last_successful_run_timestamp'] if record['last_successful_run_timestamp'] != '' else None,
+                last_successful_run_timestamp=last_successful_run_timestamp,
             ))
 
         return {ResourceType.Dashboard.name.lower(): results}

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -1603,7 +1603,7 @@ class Neo4jProxy(BaseProxy):
                 name=record['name'],
                 url=record['url'],
                 description=record['description'],
-                last_successful_run_timestamp=record['last_successful_run_timestamp'],
+                last_successful_run_timestamp=record['last_successful_run_timestamp'] if record['last_successful_run_timestamp'] != '' else None,
             ))
 
         return {ResourceType.Dashboard.name.lower(): results}

--- a/metadata/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata/metadata_service/proxy/neo4j_proxy.py
@@ -624,7 +624,6 @@ class Neo4jProxy(BaseProxy):
                                             param_dict={'key': uri})
 
         result = get_single_record(result)
-
         return Description(description=result['description'] if result else None)  # type: ignore
 
     @timer_with_counter

--- a/metadata/tests/unit/proxy/test_neo4j_proxy.py
+++ b/metadata/tests/unit/proxy/test_neo4j_proxy.py
@@ -1182,6 +1182,42 @@ class TestNeo4jProxy(unittest.TestCase):
             self.assertEqual(len(result['dashboard']), 1)
             self.assertEqual(expected, result['dashboard'][0])
 
+    def test_get_dashboard_by_user_relation_empty_string_last_successful_run_timestamp(self) -> None:
+        """
+        Expect last_successful_run_timestamp to be None if value in DB is empty string.
+        """
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
+            mock_execute.return_value = [
+                {
+                    'uri': 'dashboard_uri',
+                    'cluster_name': 'cluster',
+                    'dg_name': 'dashboard_group',
+                    'dg_url': 'http://foo.bar/group',
+                    'product': 'foobar',
+                    'name': 'dashboard',
+                    'url': 'http://foo.bar/dashboard',
+                    'description': 'description',
+                    'last_successful_run_timestamp': ''
+                }
+            ]
+
+            neo4j_proxy = Neo4jProxy(host='neo4j://example.com', port=0000)
+            result = neo4j_proxy.get_dashboard_by_user_relation(user_email='test_user',
+                                                                relation_type=UserResourceRel.follow)
+
+            expected = DashboardSummary(uri='dashboard_uri',
+                                        cluster='cluster',
+                                        group_name='dashboard_group',
+                                        group_url='http://foo.bar/group',
+                                        product='foobar',
+                                        name='dashboard',
+                                        url='http://foo.bar/dashboard',
+                                        description='description',
+                                        last_successful_run_timestamp=None)
+
+            self.assertEqual(len(result['dashboard']), 1)
+            self.assertEqual(expected, result['dashboard'][0])
+
     def test_add_resource_relation_by_user(self) -> None:
         with patch.object(GraphDatabase, 'driver') as mock_driver:
             mock_session = MagicMock()


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR

Example: docs: Improves the documentation on...
-->

## Description
Updated neo4j proxy to return None instead of the empty string when a dashboard's last run timestamp is the empty string.

## Motivation and Context
Case can arise where empty string for the timestamp causes serialization errors.

## How Has This Been Tested?
Added additional unit test.



### CheckList
* [x] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [x] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
