### PR TITLE
chore: explicitly declare license with classifier

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -21,6 +21,7 @@ setup(
     url='https://github.com/amundsen-io/amundsen/tree/main/common',
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
+    license="Apache 2.0",
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         # Packages in here should rarely be pinned. This is because these
@@ -49,6 +50,7 @@ setup(
     python_requires=">=3.8",
     package_data={'amundsen_common': ['py.typed']},
     classifiers=[
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/databuilder/setup.py
+++ b/databuilder/setup.py
@@ -110,6 +110,7 @@ setup(
     url='https://www.github.com/amundsen-io/amundsen/tree/main/databuilder',
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
+    license="Apache 2.0",
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     dependency_links=[],
@@ -139,6 +140,7 @@ setup(
         'schema_registry': schema_registry,
     },
     classifiers=[
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/frontend/setup.py
+++ b/frontend/setup.py
@@ -61,6 +61,7 @@ setup(
     url='https://www.github.com/amundsen-io/amundsen/tree/main/frontend',
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
+    license="Apache 2.0",
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     dependency_links=[],
@@ -81,6 +82,7 @@ setup(
         logging_action_log=amundsen_application.log.action_log_callback:logging_action_log
     """,
     classifiers=[
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/metadata/setup.py
+++ b/metadata/setup.py
@@ -37,6 +37,7 @@ setup(
     url='https://www.github.com/amundsen-io/amundsen/tree/main/metadata',
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
+    license="Apache 2.0",
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     zip_safe=False,
@@ -51,6 +52,7 @@ setup(
     },
     python_requires=">=3.8",
     classifiers=[
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],

--- a/search/setup.py
+++ b/search/setup.py
@@ -30,6 +30,7 @@ setup(
     url='https://github.com/amundsen-io/amundsen/tree/main/search',
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
+    license="Apache 2.0",
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     zip_safe=False,
@@ -42,6 +43,7 @@ setup(
     },
     python_requires=">=3.8",
     classifiers=[
+        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
## Description
Adds [PyPI project classifiers](https://pypi.org/classifiers/) to explicitly declare the software license.
Classifiers are used to add information to the classifiers panel in PyPI. Example from [NumPy](https://pypi.org/project/numpy/):
![image](https://github.com/user-attachments/assets/6323ac1c-d8ca-4ba2-b52e-ef4e2a97afda)

## Motivation and Context
The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source.

Because these libraries do not declare their license via classifiers, automated tools cannot properly determine the license and may treat them as high-risk packages.
![image](https://github.com/user-attachments/assets/934c4543-59eb-4022-b115-f4b227c267ab)


## How Has This Been Tested?
I have made nearly identical changes to other Open Source projects:
Examples:
https://github.com/trubrics/streamlit-feedback/pull/12
https://github.com/bashtage/linearmodels/pull/545
https://github.com/matthewwardrop/formulaic/pull/144


### CheckList
* [ ] PR title addresses the issue accurately and concisely
* [ ] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)
