### PR TITLE
docs: Documents boto3 endpoint variables for the S3 preview client

### DIFF
--- a/frontend/docs/examples/s3_preview_client.md
+++ b/frontend/docs/examples/s3_preview_client.md
@@ -18,3 +18,8 @@ To use a preview client set these environment variables in your deployment.
 - `PREVIEW_CLIENT_ENABLED`: `true`
 - `PREVIEW_CLIENT`: `{python path to preview client class}` (ex: `amundsen_application.base.examples.example_s3_json_preview_client.S3JSONPreviewClient` if you are using the JSON example client)
 - `PREVIEW_CLIENT_S3_BUCKET`: `{S3 bucket where the preview data is stored}`
+
+The example client builds its client with `boto3.client("s3")`, so boto3 resolves credentials, region and endpoint from the standard AWS environment, which defaults to Amazon S3. If your preview data is stored in another S3-compatible object store (for example Backblaze B2, Cloudflare R2, or MinIO), also set boto3's own variables.
+
+- `AWS_ENDPOINT_URL_S3`: `{S3 API endpoint of the object store}` (ex: `https://s3.example-region.example.com`)
+- `AWS_DEFAULT_REGION`: `{region the bucket is in}`


### PR DESCRIPTION
## Description

The S3 preview client guide currently only describes Amazon S3. The example client creates its client with `boto3.client("s3")` in `frontend/amundsen_application/base/examples/example_s3_json_preview_client.py`, so boto3 already resolves credentials, region and endpoint from the standard AWS environment, and no code change is needed to read preview data from another S3-compatible object store. This adds a short note and two environment-variable bullets to the Usage section, next to the existing `PREVIEW_CLIENT_*` variables.

## Motivation and Context

Deployments that keep precomputed preview data outside Amazon S3 have to either dig through botocore's configuration docs or assume the shipped example client is Amazon-only and write their own `base_s3_preview_client` implementation. Documenting the variables boto3 already honors keeps the existing example client usable as is.

## How Has This Been Tested?

Ran `mkdocs build` with the docs requirements from `requirements.txt`, both with and without this change. The page renders correctly and the build log is identical apart from the output directory and the build time, with the same 13 pre-existing warnings and none originating from this file.

Also checked the behavior against the pinned `boto3==1.34.83` from `frontend/requirements-common.txt`: with `AWS_ENDPOINT_URL_S3` set, `boto3.client("s3").meta.endpoint_url` reflects that endpoint, so the documented variables work with the version the frontend already installs.

### Documentation

`frontend/docs/examples/s3_preview_client.md` gains one paragraph and two bullets under Usage. Docs only, no code changes.

### CheckList
* [x] PR title addresses the issue accurately and concisely
* [x] Updates Documentation and Docstrings
* [ ] Adds tests
* [ ] Adds instrumentation (logs, or UI events)